### PR TITLE
テーブルの動的カラム管理機能を実装

### DIFF
--- a/app/(protected)/[itemId]/page.tsx
+++ b/app/(protected)/[itemId]/page.tsx
@@ -4,52 +4,50 @@ import { notFound } from 'next/navigation';
 
 export const dynamic = 'force-dynamic';
 
-type WorkspacePageProps = {
-  params: Promise<{ workspaceId: string }>;
+type ItemPageProps = {
+  params: Promise<{ itemId: string }>;
 };
 
-export default async function WorkspacePage({ params }: WorkspacePageProps) {
-  const { workspaceId } = await params;
+export default async function ItemPage({ params }: ItemPageProps) {
+  const { itemId } = await params;
 
-  const workspace = await getItemById(workspaceId);
+  const item = await getItemById(itemId);
 
-  if (!workspace) {
+  if (!item) {
     notFound();
   }
 
   return (
     <div className="container mx-auto p-6">
       <div className="mb-6 flex items-center justify-between">
-        <h1 className="text-2xl font-bold">{workspace.name}</h1>
+        <h1 className="text-2xl font-bold">{item.name}</h1>
       </div>
 
       <div className="grid gap-4">
         <div className="rounded-lg border p-4">
-          <h2 className="text-lg font-semibold mb-4">フォルダ情報</h2>
+          <h2 className="text-lg font-semibold mb-4">
+            {item.type === 'FOLDER' ? 'フォルダ情報' : 'テーブル情報'}
+          </h2>
           <dl className="grid grid-cols-1 gap-4 sm:grid-cols-2">
             <div>
-              <dt className="text-sm font-medium text-muted-foreground">
-                フォルダID
-              </dt>
-              <dd className="mt-1 text-sm">{workspace.id}</dd>
+              <dt className="text-sm font-medium text-muted-foreground">ID</dt>
+              <dd className="mt-1 text-sm">{item.id}</dd>
             </div>
             <p className="text-sm text-muted-foreground mt-1">
-              作成者: {workspace.createdBy.name || workspace.createdBy.email}
+              作成者: {item.createdBy.name || item.createdBy.email}
             </p>
             <div>
               <dt className="text-sm font-medium text-muted-foreground">
-                子フォルダ数
+                {item.type === 'FOLDER' ? '子フォルダ数' : '子アイテム数'}
               </dt>
-              <dd className="mt-1 text-sm">
-                {workspace._count?.children || 0}
-              </dd>
+              <dd className="mt-1 text-sm">{item._count?.children || 0}</dd>
             </div>
             <div>
               <dt className="text-sm font-medium text-muted-foreground">
                 作成日時
               </dt>
               <dd className="mt-1 text-sm">
-                {new Date(workspace.createdAt).toLocaleString('ja-JP')}
+                {new Date(item.createdAt).toLocaleString('ja-JP')}
               </dd>
             </div>
             <div>
@@ -57,17 +55,19 @@ export default async function WorkspacePage({ params }: WorkspacePageProps) {
                 更新日時
               </dt>
               <dd className="mt-1 text-sm">
-                {new Date(workspace.updatedAt).toLocaleString('ja-JP')}
+                {new Date(item.updatedAt).toLocaleString('ja-JP')}
               </dd>
             </div>
           </dl>
         </div>
 
-        {workspace.children && workspace.children.length > 0 && (
+        {item.children && item.children.length > 0 && (
           <div className="rounded-lg border p-4">
-            <h2 className="text-lg font-semibold mb-4">子フォルダ</h2>
+            <h2 className="text-lg font-semibold mb-4">
+              {item.type === 'FOLDER' ? '子フォルダ' : '子アイテム'}
+            </h2>
             <div className="grid gap-2">
-              {workspace.children.map((child: Item) => (
+              {item.children.map((child: Item) => (
                 <div
                   key={child.id}
                   className="flex items-center gap-2 rounded-md border p-3"
@@ -84,10 +84,12 @@ export default async function WorkspacePage({ params }: WorkspacePageProps) {
           </div>
         )}
 
-        {(!workspace.children || workspace.children.length === 0) && (
+        {(!item.children || item.children.length === 0) && (
           <div className="rounded-lg border p-8 text-center">
             <p className="text-muted-foreground">
-              このワークスペースには子フォルダがありません
+              {item.type === 'FOLDER'
+                ? 'このフォルダには子アイテムがありません'
+                : 'このテーブルには子アイテムがありません'}
             </p>
           </div>
         )}

--- a/app/(protected)/[itemId]/page.tsx
+++ b/app/(protected)/[itemId]/page.tsx
@@ -1,5 +1,7 @@
 import { getItemById } from '@/features/item/api';
 import type { Item } from '@/features/item/types';
+import { getColumnSchema } from '@/features/column/types/schema';
+import { ColumnList } from '@/features/column/components/column-list';
 import { notFound } from 'next/navigation';
 
 export const dynamic = 'force-dynamic';
@@ -16,6 +18,11 @@ export default async function ItemPage({ params }: ItemPageProps) {
   if (!item) {
     notFound();
   }
+
+  // TABLE型の場合、カラムスキーマを取得
+  const columnSchema =
+    item.type === 'TABLE' ? getColumnSchema(item.meta) : null;
+  const columns = columnSchema?.columns || [];
 
   return (
     <div className="container mx-auto p-6">
@@ -60,6 +67,14 @@ export default async function ItemPage({ params }: ItemPageProps) {
             </div>
           </dl>
         </div>
+
+        {/* TABLE型の場合、カラム管理UIを表示 */}
+        {item.type === 'TABLE' && (
+          <div className="rounded-lg border p-4">
+            <h2 className="text-lg font-semibold mb-4">カラム管理</h2>
+            <ColumnList itemId={itemId} columns={columns} />
+          </div>
+        )}
 
         {item.children && item.children.length > 0 && (
           <div className="rounded-lg border p-4">

--- a/features/column/api/__tests__/add-column.test.ts
+++ b/features/column/api/__tests__/add-column.test.ts
@@ -1,0 +1,300 @@
+import { addColumn } from '../add-column';
+
+// revalidatePathをモック化
+jest.mock('next/cache', () => ({
+  revalidatePath: jest.fn(),
+}));
+
+// Supabaseクライアントをモック化
+jest.mock('@/lib/supabase/server', () => ({
+  createClient: jest.fn(),
+}));
+
+// Prismaクライアントをモック化
+jest.mock('@/lib/prisma', () => ({
+  prisma: {
+    user: {
+      findUnique: jest.fn(),
+    },
+    item: {
+      findUnique: jest.fn(),
+      update: jest.fn(),
+    },
+  },
+}));
+
+import { createClient } from '@/lib/supabase/server';
+import { prisma } from '@/lib/prisma';
+
+describe('addColumn', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const mockUser = {
+    auth: {
+      getUser: jest.fn().mockResolvedValue({
+        data: { user: { email: 'test@example.com' } },
+      }),
+    },
+  };
+
+  const mockDbUser = {
+    id: 'user-1',
+    role: 'MEMBER',
+  };
+
+  const mockItem = {
+    id: 'item-1',
+    type: 'TABLE',
+    createdById: 'user-1',
+    meta: {
+      schema: {
+        columns: [],
+      },
+      version: 1,
+    },
+  };
+
+  it('カラムを追加できる', async () => {
+    (createClient as jest.Mock).mockResolvedValue(mockUser);
+    (prisma.user.findUnique as jest.Mock).mockResolvedValue(mockDbUser);
+    (prisma.item.findUnique as jest.Mock).mockResolvedValue(mockItem);
+    (prisma.item.update as jest.Mock).mockResolvedValue({
+      ...mockItem,
+      meta: {
+        schema: {
+          columns: [
+            {
+              id: 'col-1',
+              name: '顧客名',
+              type: 'TEXT',
+              order: 0,
+            },
+          ],
+        },
+        version: 1,
+      },
+    });
+
+    const result = await addColumn('item-1', {
+      name: '顧客名',
+      type: 'TEXT',
+      order: 0,
+    });
+
+    expect(result).toEqual({ success: true });
+    expect(prisma.item.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: 'item-1' },
+        data: {
+          meta: expect.objectContaining({
+            schema: expect.objectContaining({
+              columns: expect.arrayContaining([
+                expect.objectContaining({
+                  name: '顧客名',
+                  type: 'TEXT',
+                }),
+              ]),
+            }),
+          }),
+        },
+      })
+    );
+  });
+
+  it('スキーマが存在しない場合は新規作成してカラムを追加できる', async () => {
+    (createClient as jest.Mock).mockResolvedValue(mockUser);
+    (prisma.user.findUnique as jest.Mock).mockResolvedValue(mockDbUser);
+    (prisma.item.findUnique as jest.Mock).mockResolvedValue({
+      ...mockItem,
+      meta: null,
+    });
+    (prisma.item.update as jest.Mock).mockResolvedValue({
+      ...mockItem,
+      meta: {
+        schema: {
+          columns: [
+            {
+              id: 'col-1',
+              name: '顧客名',
+              type: 'TEXT',
+              order: 0,
+            },
+          ],
+        },
+        version: 1,
+      },
+    });
+
+    const result = await addColumn('item-1', {
+      name: '顧客名',
+      type: 'TEXT',
+      order: 0,
+    });
+
+    expect(result).toEqual({ success: true });
+    expect(prisma.item.update).toHaveBeenCalled();
+  });
+
+  it('認証されていない場合はエラーを返す', async () => {
+    (createClient as jest.Mock).mockResolvedValue({
+      auth: {
+        getUser: jest.fn().mockResolvedValue({
+          data: { user: null },
+        }),
+      },
+    });
+
+    const result = await addColumn('item-1', {
+      name: '顧客名',
+      type: 'TEXT',
+      order: 0,
+    });
+
+    expect(result).toEqual({ error: '認証が必要です' });
+    expect(prisma.item.update).not.toHaveBeenCalled();
+  });
+
+  it('カラム名が空の場合はエラーを返す', async () => {
+    (createClient as jest.Mock).mockResolvedValue(mockUser);
+    (prisma.user.findUnique as jest.Mock).mockResolvedValue(mockDbUser);
+
+    const result = await addColumn('item-1', {
+      name: '',
+      type: 'TEXT',
+      order: 0,
+    });
+
+    expect(result).toEqual({
+      error: 'カラム名を入力してください',
+    });
+    expect(prisma.item.findUnique).not.toHaveBeenCalled();
+  });
+
+  it('テーブルが見つからない場合はエラーを返す', async () => {
+    (createClient as jest.Mock).mockResolvedValue(mockUser);
+    (prisma.user.findUnique as jest.Mock).mockResolvedValue(mockDbUser);
+    (prisma.item.findUnique as jest.Mock).mockResolvedValue(null);
+
+    const result = await addColumn('item-1', {
+      name: '顧客名',
+      type: 'TEXT',
+      order: 0,
+    });
+
+    expect(result).toEqual({ error: 'テーブルが見つかりません' });
+    expect(prisma.item.update).not.toHaveBeenCalled();
+  });
+
+  it('テーブルではない場合はエラーを返す', async () => {
+    (createClient as jest.Mock).mockResolvedValue(mockUser);
+    (prisma.user.findUnique as jest.Mock).mockResolvedValue(mockDbUser);
+    (prisma.item.findUnique as jest.Mock).mockResolvedValue({
+      ...mockItem,
+      type: 'FOLDER',
+    });
+
+    const result = await addColumn('item-1', {
+      name: '顧客名',
+      type: 'TEXT',
+      order: 0,
+    });
+
+    expect(result).toEqual({ error: 'テーブルではありません' });
+    expect(prisma.item.update).not.toHaveBeenCalled();
+  });
+
+  it('権限がない場合はエラーを返す', async () => {
+    (createClient as jest.Mock).mockResolvedValue(mockUser);
+    (prisma.user.findUnique as jest.Mock).mockResolvedValue(mockDbUser);
+    (prisma.item.findUnique as jest.Mock).mockResolvedValue({
+      ...mockItem,
+      createdById: 'other-user',
+    });
+
+    const result = await addColumn('item-1', {
+      name: '顧客名',
+      type: 'TEXT',
+      order: 0,
+    });
+
+    expect(result).toEqual({
+      error: 'カラムを追加する権限がありません',
+    });
+    expect(prisma.item.update).not.toHaveBeenCalled();
+  });
+
+  it('ADMIN権限の場合は他人のテーブルにもカラムを追加できる', async () => {
+    (createClient as jest.Mock).mockResolvedValue(mockUser);
+    (prisma.user.findUnique as jest.Mock).mockResolvedValue({
+      ...mockDbUser,
+      role: 'ADMIN',
+    });
+    (prisma.item.findUnique as jest.Mock).mockResolvedValue({
+      ...mockItem,
+      createdById: 'other-user',
+    });
+    (prisma.item.update as jest.Mock).mockResolvedValue(mockItem);
+
+    const result = await addColumn('item-1', {
+      name: '顧客名',
+      type: 'TEXT',
+      order: 0,
+    });
+
+    expect(result).toEqual({ success: true });
+    expect(prisma.item.update).toHaveBeenCalled();
+  });
+
+  it('同じ名前のカラムが既に存在する場合はエラーを返す', async () => {
+    (createClient as jest.Mock).mockResolvedValue(mockUser);
+    (prisma.user.findUnique as jest.Mock).mockResolvedValue(mockDbUser);
+    (prisma.item.findUnique as jest.Mock).mockResolvedValue({
+      ...mockItem,
+      meta: {
+        schema: {
+          columns: [
+            {
+              id: 'col-1',
+              name: '顧客名',
+              type: 'TEXT',
+              order: 0,
+            },
+          ],
+        },
+        version: 1,
+      },
+    });
+
+    const result = await addColumn('item-1', {
+      name: '顧客名',
+      type: 'TEXT',
+      order: 1,
+    });
+
+    expect(result).toEqual({
+      error: '同じ名前のカラムが既に存在します',
+    });
+    expect(prisma.item.update).not.toHaveBeenCalled();
+  });
+
+  it('データベースエラーが発生した場合はエラーを返す', async () => {
+    (createClient as jest.Mock).mockResolvedValue(mockUser);
+    (prisma.user.findUnique as jest.Mock).mockResolvedValue(mockDbUser);
+    (prisma.item.findUnique as jest.Mock).mockResolvedValue(mockItem);
+    (prisma.item.update as jest.Mock).mockRejectedValue(
+      new Error('Database error')
+    );
+
+    const result = await addColumn('item-1', {
+      name: '顧客名',
+      type: 'TEXT',
+      order: 0,
+    });
+
+    expect(result).toEqual({
+      error: 'カラムの追加に失敗しました',
+    });
+  });
+});

--- a/features/column/api/__tests__/remove-column.test.ts
+++ b/features/column/api/__tests__/remove-column.test.ts
@@ -1,0 +1,209 @@
+import { removeColumn } from '../remove-column';
+
+// revalidatePathをモック化
+jest.mock('next/cache', () => ({
+  revalidatePath: jest.fn(),
+}));
+
+// Supabaseクライアントをモック化
+jest.mock('@/lib/supabase/server', () => ({
+  createClient: jest.fn(),
+}));
+
+// Prismaクライアントをモック化
+jest.mock('@/lib/prisma', () => ({
+  prisma: {
+    user: {
+      findUnique: jest.fn(),
+    },
+    item: {
+      findUnique: jest.fn(),
+      update: jest.fn(),
+    },
+  },
+}));
+
+import { createClient } from '@/lib/supabase/server';
+import { prisma } from '@/lib/prisma';
+
+describe('removeColumn', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const mockUser = {
+    auth: {
+      getUser: jest.fn().mockResolvedValue({
+        data: { user: { email: 'test@example.com' } },
+      }),
+    },
+  };
+
+  const mockDbUser = {
+    id: 'user-1',
+    role: 'MEMBER',
+  };
+
+  const mockItem = {
+    id: 'item-1',
+    type: 'TABLE',
+    createdById: 'user-1',
+    meta: {
+      schema: {
+        columns: [
+          {
+            id: 'col-1',
+            name: '顧客名',
+            type: 'TEXT',
+            order: 0,
+          },
+          {
+            id: 'col-2',
+            name: '会社名',
+            type: 'TEXT',
+            order: 1,
+          },
+        ],
+      },
+      version: 1,
+    },
+  };
+
+  it('カラムを削除できる', async () => {
+    (createClient as jest.Mock).mockResolvedValue(mockUser);
+    (prisma.user.findUnique as jest.Mock).mockResolvedValue(mockDbUser);
+    (prisma.item.findUnique as jest.Mock).mockResolvedValue(mockItem);
+    (prisma.item.update as jest.Mock).mockResolvedValue({
+      ...mockItem,
+      meta: {
+        schema: {
+          columns: [
+            {
+              id: 'col-2',
+              name: '会社名',
+              type: 'TEXT',
+              order: 1,
+            },
+          ],
+        },
+        version: 1,
+      },
+    });
+
+    const result = await removeColumn('item-1', 'col-1');
+
+    expect(result).toEqual({ success: true });
+    expect(prisma.item.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: 'item-1' },
+        data: {
+          meta: expect.objectContaining({
+            schema: expect.objectContaining({
+              columns: expect.not.arrayContaining([
+                expect.objectContaining({
+                  id: 'col-1',
+                }),
+              ]),
+            }),
+          }),
+        },
+      })
+    );
+  });
+
+  it('認証されていない場合はエラーを返す', async () => {
+    (createClient as jest.Mock).mockResolvedValue({
+      auth: {
+        getUser: jest.fn().mockResolvedValue({
+          data: { user: null },
+        }),
+      },
+    });
+
+    const result = await removeColumn('item-1', 'col-1');
+
+    expect(result).toEqual({ error: '認証が必要です' });
+    expect(prisma.item.update).not.toHaveBeenCalled();
+  });
+
+  it('テーブルが見つからない場合はエラーを返す', async () => {
+    (createClient as jest.Mock).mockResolvedValue(mockUser);
+    (prisma.user.findUnique as jest.Mock).mockResolvedValue(mockDbUser);
+    (prisma.item.findUnique as jest.Mock).mockResolvedValue(null);
+
+    const result = await removeColumn('item-1', 'col-1');
+
+    expect(result).toEqual({ error: 'テーブルが見つかりません' });
+    expect(prisma.item.update).not.toHaveBeenCalled();
+  });
+
+  it('テーブルではない場合はエラーを返す', async () => {
+    (createClient as jest.Mock).mockResolvedValue(mockUser);
+    (prisma.user.findUnique as jest.Mock).mockResolvedValue(mockDbUser);
+    (prisma.item.findUnique as jest.Mock).mockResolvedValue({
+      ...mockItem,
+      type: 'FOLDER',
+    });
+
+    const result = await removeColumn('item-1', 'col-1');
+
+    expect(result).toEqual({ error: 'テーブルではありません' });
+    expect(prisma.item.update).not.toHaveBeenCalled();
+  });
+
+  it('権限がない場合はエラーを返す', async () => {
+    (createClient as jest.Mock).mockResolvedValue(mockUser);
+    (prisma.user.findUnique as jest.Mock).mockResolvedValue(mockDbUser);
+    (prisma.item.findUnique as jest.Mock).mockResolvedValue({
+      ...mockItem,
+      createdById: 'other-user',
+    });
+
+    const result = await removeColumn('item-1', 'col-1');
+
+    expect(result).toEqual({
+      error: 'カラムを削除する権限がありません',
+    });
+    expect(prisma.item.update).not.toHaveBeenCalled();
+  });
+
+  it('スキーマが存在しない場合はエラーを返す', async () => {
+    (createClient as jest.Mock).mockResolvedValue(mockUser);
+    (prisma.user.findUnique as jest.Mock).mockResolvedValue(mockDbUser);
+    (prisma.item.findUnique as jest.Mock).mockResolvedValue({
+      ...mockItem,
+      meta: null,
+    });
+
+    const result = await removeColumn('item-1', 'col-1');
+
+    expect(result).toEqual({ error: 'スキーマが見つかりません' });
+    expect(prisma.item.update).not.toHaveBeenCalled();
+  });
+
+  it('カラムが見つからない場合はエラーを返す', async () => {
+    (createClient as jest.Mock).mockResolvedValue(mockUser);
+    (prisma.user.findUnique as jest.Mock).mockResolvedValue(mockDbUser);
+    (prisma.item.findUnique as jest.Mock).mockResolvedValue(mockItem);
+
+    const result = await removeColumn('item-1', 'col-999');
+
+    expect(result).toEqual({ error: 'カラムが見つかりません' });
+    expect(prisma.item.update).not.toHaveBeenCalled();
+  });
+
+  it('データベースエラーが発生した場合はエラーを返す', async () => {
+    (createClient as jest.Mock).mockResolvedValue(mockUser);
+    (prisma.user.findUnique as jest.Mock).mockResolvedValue(mockDbUser);
+    (prisma.item.findUnique as jest.Mock).mockResolvedValue(mockItem);
+    (prisma.item.update as jest.Mock).mockRejectedValue(
+      new Error('Database error')
+    );
+
+    const result = await removeColumn('item-1', 'col-1');
+
+    expect(result).toEqual({
+      error: 'カラムの削除に失敗しました',
+    });
+  });
+});

--- a/features/column/api/__tests__/reorder-column.test.ts
+++ b/features/column/api/__tests__/reorder-column.test.ts
@@ -1,0 +1,264 @@
+import { reorderColumn } from '../reorder-column';
+
+// revalidatePathをモック化
+jest.mock('next/cache', () => ({
+  revalidatePath: jest.fn(),
+}));
+
+// Supabaseクライアントをモック化
+jest.mock('@/lib/supabase/server', () => ({
+  createClient: jest.fn(),
+}));
+
+// Prismaクライアントをモック化
+jest.mock('@/lib/prisma', () => ({
+  prisma: {
+    user: {
+      findUnique: jest.fn(),
+    },
+    item: {
+      findUnique: jest.fn(),
+      update: jest.fn(),
+    },
+  },
+}));
+
+import { createClient } from '@/lib/supabase/server';
+import { prisma } from '@/lib/prisma';
+
+describe('reorderColumn', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const mockUser = {
+    auth: {
+      getUser: jest.fn().mockResolvedValue({
+        data: { user: { email: 'test@example.com' } },
+      }),
+    },
+  };
+
+  const mockDbUser = {
+    id: 'user-1',
+    role: 'MEMBER',
+  };
+
+  const mockItem = {
+    id: 'item-1',
+    type: 'TABLE',
+    createdById: 'user-1',
+    meta: {
+      schema: {
+        columns: [
+          {
+            id: 'col-1',
+            name: '顧客名',
+            type: 'TEXT',
+            order: 0,
+          },
+          {
+            id: 'col-2',
+            name: '会社名',
+            type: 'TEXT',
+            order: 1,
+          },
+          {
+            id: 'col-3',
+            name: '電話番号',
+            type: 'TEXT',
+            order: 2,
+          },
+        ],
+      },
+      version: 1,
+    },
+  };
+
+  it('カラムを並び替えられる', async () => {
+    (createClient as jest.Mock).mockResolvedValue(mockUser);
+    (prisma.user.findUnique as jest.Mock).mockResolvedValue(mockDbUser);
+    (prisma.item.findUnique as jest.Mock).mockResolvedValue(mockItem);
+    (prisma.item.update as jest.Mock).mockResolvedValue(mockItem);
+
+    const result = await reorderColumn('item-1', 'col-1', 2);
+
+    expect(result).toEqual({ success: true });
+    expect(prisma.item.update).toHaveBeenCalled();
+  });
+
+  it('認証されていない場合はエラーを返す', async () => {
+    (createClient as jest.Mock).mockResolvedValue({
+      auth: {
+        getUser: jest.fn().mockResolvedValue({
+          data: { user: null },
+        }),
+      },
+    });
+
+    const result = await reorderColumn('item-1', 'col-1', 2);
+
+    expect(result).toEqual({ error: '認証が必要です' });
+    expect(prisma.item.update).not.toHaveBeenCalled();
+  });
+
+  it('並び順が負の値の場合はエラーを返す', async () => {
+    (createClient as jest.Mock).mockResolvedValue(mockUser);
+    (prisma.user.findUnique as jest.Mock).mockResolvedValue(mockDbUser);
+
+    const result = await reorderColumn('item-1', 'col-1', -1);
+
+    expect(result).toEqual({
+      error: '並び順は0以上である必要があります',
+    });
+    expect(prisma.item.findUnique).not.toHaveBeenCalled();
+  });
+
+  it('テーブルが見つからない場合はエラーを返す', async () => {
+    (createClient as jest.Mock).mockResolvedValue(mockUser);
+    (prisma.user.findUnique as jest.Mock).mockResolvedValue(mockDbUser);
+    (prisma.item.findUnique as jest.Mock).mockResolvedValue(null);
+
+    const result = await reorderColumn('item-1', 'col-1', 2);
+
+    expect(result).toEqual({ error: 'テーブルが見つかりません' });
+    expect(prisma.item.update).not.toHaveBeenCalled();
+  });
+
+  it('テーブルではない場合はエラーを返す', async () => {
+    (createClient as jest.Mock).mockResolvedValue(mockUser);
+    (prisma.user.findUnique as jest.Mock).mockResolvedValue(mockDbUser);
+    (prisma.item.findUnique as jest.Mock).mockResolvedValue({
+      ...mockItem,
+      type: 'FOLDER',
+    });
+
+    const result = await reorderColumn('item-1', 'col-1', 2);
+
+    expect(result).toEqual({ error: 'テーブルではありません' });
+    expect(prisma.item.update).not.toHaveBeenCalled();
+  });
+
+  it('権限がない場合はエラーを返す', async () => {
+    (createClient as jest.Mock).mockResolvedValue(mockUser);
+    (prisma.user.findUnique as jest.Mock).mockResolvedValue(mockDbUser);
+    (prisma.item.findUnique as jest.Mock).mockResolvedValue({
+      ...mockItem,
+      createdById: 'other-user',
+    });
+
+    const result = await reorderColumn('item-1', 'col-1', 2);
+
+    expect(result).toEqual({
+      error: 'カラムを並び替える権限がありません',
+    });
+    expect(prisma.item.update).not.toHaveBeenCalled();
+  });
+
+  it('スキーマが存在しない場合はエラーを返す', async () => {
+    (createClient as jest.Mock).mockResolvedValue(mockUser);
+    (prisma.user.findUnique as jest.Mock).mockResolvedValue(mockDbUser);
+    (prisma.item.findUnique as jest.Mock).mockResolvedValue({
+      ...mockItem,
+      meta: null,
+    });
+
+    const result = await reorderColumn('item-1', 'col-1', 2);
+
+    expect(result).toEqual({ error: 'スキーマが見つかりません' });
+    expect(prisma.item.update).not.toHaveBeenCalled();
+  });
+
+  it('カラムが見つからない場合はエラーを返す', async () => {
+    (createClient as jest.Mock).mockResolvedValue(mockUser);
+    (prisma.user.findUnique as jest.Mock).mockResolvedValue(mockDbUser);
+    (prisma.item.findUnique as jest.Mock).mockResolvedValue(mockItem);
+
+    const result = await reorderColumn('item-1', 'col-999', 2);
+
+    expect(result).toEqual({ error: 'カラムが見つかりません' });
+    expect(prisma.item.update).not.toHaveBeenCalled();
+  });
+
+  it('無効な並び順の場合はエラーを返す', async () => {
+    (createClient as jest.Mock).mockResolvedValue(mockUser);
+    (prisma.user.findUnique as jest.Mock).mockResolvedValue(mockDbUser);
+    // 新しいオブジェクトを返すようにする（mutationを避ける）
+    (prisma.item.findUnique as jest.Mock).mockResolvedValue({
+      ...mockItem,
+      meta: {
+        schema: {
+          columns: [
+            {
+              id: 'col-1',
+              name: '顧客名',
+              type: 'TEXT',
+              order: 0,
+            },
+            {
+              id: 'col-2',
+              name: '会社名',
+              type: 'TEXT',
+              order: 1,
+            },
+            {
+              id: 'col-3',
+              name: '電話番号',
+              type: 'TEXT',
+              order: 2,
+            },
+          ],
+        },
+        version: 1,
+      },
+    });
+
+    const result = await reorderColumn('item-1', 'col-1', 999);
+
+    expect(result).toEqual({ error: '無効な並び順です' });
+    expect(prisma.item.update).not.toHaveBeenCalled();
+  });
+
+  it('データベースエラーが発生した場合はエラーを返す', async () => {
+    (createClient as jest.Mock).mockResolvedValue(mockUser);
+    (prisma.user.findUnique as jest.Mock).mockResolvedValue(mockDbUser);
+    // 新しいオブジェクトを返すようにする（mutationを避ける）
+    (prisma.item.findUnique as jest.Mock).mockResolvedValue({
+      ...mockItem,
+      meta: {
+        schema: {
+          columns: [
+            {
+              id: 'col-1',
+              name: '顧客名',
+              type: 'TEXT',
+              order: 0,
+            },
+            {
+              id: 'col-2',
+              name: '会社名',
+              type: 'TEXT',
+              order: 1,
+            },
+            {
+              id: 'col-3',
+              name: '電話番号',
+              type: 'TEXT',
+              order: 2,
+            },
+          ],
+        },
+        version: 1,
+      },
+    });
+    (prisma.item.update as jest.Mock).mockRejectedValue(
+      new Error('Database error')
+    );
+
+    const result = await reorderColumn('item-1', 'col-1', 2);
+
+    expect(result).toEqual({
+      error: 'カラムの並び替えに失敗しました',
+    });
+  });
+});

--- a/features/column/api/__tests__/update-column.test.ts
+++ b/features/column/api/__tests__/update-column.test.ts
@@ -1,0 +1,255 @@
+import { updateColumn } from '../update-column';
+
+// revalidatePathをモック化
+jest.mock('next/cache', () => ({
+  revalidatePath: jest.fn(),
+}));
+
+// Supabaseクライアントをモック化
+jest.mock('@/lib/supabase/server', () => ({
+  createClient: jest.fn(),
+}));
+
+// Prismaクライアントをモック化
+jest.mock('@/lib/prisma', () => ({
+  prisma: {
+    user: {
+      findUnique: jest.fn(),
+    },
+    item: {
+      findUnique: jest.fn(),
+      update: jest.fn(),
+    },
+  },
+}));
+
+import { createClient } from '@/lib/supabase/server';
+import { prisma } from '@/lib/prisma';
+
+describe('updateColumn', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const mockUser = {
+    auth: {
+      getUser: jest.fn().mockResolvedValue({
+        data: { user: { email: 'test@example.com' } },
+      }),
+    },
+  };
+
+  const mockDbUser = {
+    id: 'user-1',
+    role: 'MEMBER',
+  };
+
+  const mockItem = {
+    id: 'item-1',
+    type: 'TABLE',
+    createdById: 'user-1',
+    meta: {
+      schema: {
+        columns: [
+          {
+            id: 'col-1',
+            name: '顧客名',
+            type: 'TEXT',
+            order: 0,
+          },
+        ],
+      },
+      version: 1,
+    },
+  };
+
+  it('カラムを更新できる', async () => {
+    (createClient as jest.Mock).mockResolvedValue(mockUser);
+    (prisma.user.findUnique as jest.Mock).mockResolvedValue(mockDbUser);
+    (prisma.item.findUnique as jest.Mock).mockResolvedValue(mockItem);
+    (prisma.item.update as jest.Mock).mockResolvedValue(mockItem);
+
+    const result = await updateColumn('item-1', 'col-1', {
+      name: '顧客名（更新）',
+    });
+
+    expect(result).toEqual({ success: true });
+    expect(prisma.item.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: 'item-1' },
+        data: {
+          meta: expect.objectContaining({
+            schema: expect.objectContaining({
+              columns: expect.arrayContaining([
+                expect.objectContaining({
+                  id: 'col-1',
+                  name: '顧客名（更新）',
+                }),
+              ]),
+            }),
+          }),
+        },
+      })
+    );
+  });
+
+  it('認証されていない場合はエラーを返す', async () => {
+    (createClient as jest.Mock).mockResolvedValue({
+      auth: {
+        getUser: jest.fn().mockResolvedValue({
+          data: { user: null },
+        }),
+      },
+    });
+
+    const result = await updateColumn('item-1', 'col-1', {
+      name: '顧客名（更新）',
+    });
+
+    expect(result).toEqual({ error: '認証が必要です' });
+    expect(prisma.item.update).not.toHaveBeenCalled();
+  });
+
+  it('カラム名が空の場合はエラーを返す', async () => {
+    (createClient as jest.Mock).mockResolvedValue(mockUser);
+    (prisma.user.findUnique as jest.Mock).mockResolvedValue(mockDbUser);
+
+    const result = await updateColumn('item-1', 'col-1', {
+      name: '',
+    });
+
+    expect(result).toEqual({
+      error: 'カラム名を入力してください',
+    });
+    expect(prisma.item.findUnique).not.toHaveBeenCalled();
+  });
+
+  it('テーブルが見つからない場合はエラーを返す', async () => {
+    (createClient as jest.Mock).mockResolvedValue(mockUser);
+    (prisma.user.findUnique as jest.Mock).mockResolvedValue(mockDbUser);
+    (prisma.item.findUnique as jest.Mock).mockResolvedValue(null);
+
+    const result = await updateColumn('item-1', 'col-1', {
+      name: '顧客名（更新）',
+    });
+
+    expect(result).toEqual({ error: 'テーブルが見つかりません' });
+    expect(prisma.item.update).not.toHaveBeenCalled();
+  });
+
+  it('テーブルではない場合はエラーを返す', async () => {
+    (createClient as jest.Mock).mockResolvedValue(mockUser);
+    (prisma.user.findUnique as jest.Mock).mockResolvedValue(mockDbUser);
+    (prisma.item.findUnique as jest.Mock).mockResolvedValue({
+      ...mockItem,
+      type: 'FOLDER',
+    });
+
+    const result = await updateColumn('item-1', 'col-1', {
+      name: '顧客名（更新）',
+    });
+
+    expect(result).toEqual({ error: 'テーブルではありません' });
+    expect(prisma.item.update).not.toHaveBeenCalled();
+  });
+
+  it('権限がない場合はエラーを返す', async () => {
+    (createClient as jest.Mock).mockResolvedValue(mockUser);
+    (prisma.user.findUnique as jest.Mock).mockResolvedValue(mockDbUser);
+    (prisma.item.findUnique as jest.Mock).mockResolvedValue({
+      ...mockItem,
+      createdById: 'other-user',
+    });
+
+    const result = await updateColumn('item-1', 'col-1', {
+      name: '顧客名（更新）',
+    });
+
+    expect(result).toEqual({
+      error: 'カラムを更新する権限がありません',
+    });
+    expect(prisma.item.update).not.toHaveBeenCalled();
+  });
+
+  it('スキーマが存在しない場合はエラーを返す', async () => {
+    (createClient as jest.Mock).mockResolvedValue(mockUser);
+    (prisma.user.findUnique as jest.Mock).mockResolvedValue(mockDbUser);
+    (prisma.item.findUnique as jest.Mock).mockResolvedValue({
+      ...mockItem,
+      meta: null,
+    });
+
+    const result = await updateColumn('item-1', 'col-1', {
+      name: '顧客名（更新）',
+    });
+
+    expect(result).toEqual({ error: 'スキーマが見つかりません' });
+    expect(prisma.item.update).not.toHaveBeenCalled();
+  });
+
+  it('同じ名前のカラムが既に存在する場合はエラーを返す', async () => {
+    (createClient as jest.Mock).mockResolvedValue(mockUser);
+    (prisma.user.findUnique as jest.Mock).mockResolvedValue(mockDbUser);
+    (prisma.item.findUnique as jest.Mock).mockResolvedValue({
+      ...mockItem,
+      meta: {
+        schema: {
+          columns: [
+            {
+              id: 'col-1',
+              name: '顧客名',
+              type: 'TEXT',
+              order: 0,
+            },
+            {
+              id: 'col-2',
+              name: '会社名',
+              type: 'TEXT',
+              order: 1,
+            },
+          ],
+        },
+        version: 1,
+      },
+    });
+
+    const result = await updateColumn('item-1', 'col-1', {
+      name: '会社名',
+    });
+
+    expect(result).toEqual({
+      error: '同じ名前のカラムが既に存在します',
+    });
+    expect(prisma.item.update).not.toHaveBeenCalled();
+  });
+
+  it('カラムが見つからない場合はエラーを返す', async () => {
+    (createClient as jest.Mock).mockResolvedValue(mockUser);
+    (prisma.user.findUnique as jest.Mock).mockResolvedValue(mockDbUser);
+    (prisma.item.findUnique as jest.Mock).mockResolvedValue(mockItem);
+
+    const result = await updateColumn('item-1', 'col-999', {
+      name: '顧客名（更新）',
+    });
+
+    expect(result).toEqual({ error: 'カラムが見つかりません' });
+    expect(prisma.item.update).not.toHaveBeenCalled();
+  });
+
+  it('データベースエラーが発生した場合はエラーを返す', async () => {
+    (createClient as jest.Mock).mockResolvedValue(mockUser);
+    (prisma.user.findUnique as jest.Mock).mockResolvedValue(mockDbUser);
+    (prisma.item.findUnique as jest.Mock).mockResolvedValue(mockItem);
+    (prisma.item.update as jest.Mock).mockRejectedValue(
+      new Error('Database error')
+    );
+
+    const result = await updateColumn('item-1', 'col-1', {
+      name: '顧客名（更新）',
+    });
+
+    expect(result).toEqual({
+      error: 'カラムの更新に失敗しました',
+    });
+  });
+});

--- a/features/column/api/add-column.ts
+++ b/features/column/api/add-column.ts
@@ -1,0 +1,107 @@
+'use server';
+
+import { revalidatePath } from 'next/cache';
+import { createClient } from '@/lib/supabase/server';
+import { prisma } from '@/lib/prisma';
+import type { CreateColumnInput } from '../types/column';
+import { createTableMeta, getColumnSchema } from '../types/schema';
+import {
+  addColumnToSchema,
+  hasColumnWithName,
+} from '../utils/schema-operations';
+
+type FormState = {
+  error?: string;
+  success?: boolean;
+};
+
+/**
+ * カラムを追加するServer Action
+ */
+export async function addColumn(
+  itemId: string,
+  input: CreateColumnInput
+): Promise<FormState> {
+  // セッションからユーザー情報を取得
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return { error: '認証が必要です' };
+  }
+
+  // DB からユーザー ID を取得
+  const dbUser = await prisma.user.findUnique({
+    where: { email: user.email! },
+    select: { id: true, role: true },
+  });
+
+  if (!dbUser) {
+    return { error: 'ユーザー情報が取得できませんでした' };
+  }
+
+  // バリデーション
+  if (!input.name || input.name.trim() === '') {
+    return { error: 'カラム名を入力してください' };
+  }
+
+  try {
+    // Itemを取得
+    const item = await prisma.item.findUnique({
+      where: { id: itemId },
+    });
+
+    if (!item) {
+      return { error: 'テーブルが見つかりません' };
+    }
+
+    if (item.type !== 'TABLE') {
+      return { error: 'テーブルではありません' };
+    }
+
+    // TODO: 権限チェック（将来実装）
+    // 現在は作成者のみ編集可能とする簡易実装
+    if (item.createdById !== dbUser.id && dbUser.role !== 'ADMIN') {
+      return { error: 'カラムを追加する権限がありません' };
+    }
+
+    // 現在のスキーマを取得
+    let schema = getColumnSchema(item.meta);
+
+    // スキーマが存在しない場合は新規作成
+    if (!schema) {
+      const tableMeta = createTableMeta();
+      schema = tableMeta.schema;
+    }
+
+    // カラム名の重複チェック
+    if (hasColumnWithName(schema, input.name.trim())) {
+      return { error: '同じ名前のカラムが既に存在します' };
+    }
+
+    // カラムを追加
+    const newSchema = addColumnToSchema(schema, {
+      ...input,
+      name: input.name.trim(),
+    });
+
+    // TableMetaを更新
+    const newTableMeta = createTableMeta(newSchema);
+
+    // DBを更新
+    await prisma.item.update({
+      where: { id: itemId },
+      data: {
+        meta: newTableMeta as never,
+      },
+    });
+
+    revalidatePath(`/tables/${itemId}`);
+    return { success: true };
+  } catch (error) {
+    console.error('カラム追加エラー:', error);
+    return { error: 'カラムの追加に失敗しました' };
+  }
+}

--- a/features/column/api/index.ts
+++ b/features/column/api/index.ts
@@ -1,0 +1,4 @@
+export * from './add-column';
+export * from './update-column';
+export * from './remove-column';
+export * from './reorder-column';

--- a/features/column/api/remove-column.ts
+++ b/features/column/api/remove-column.ts
@@ -1,0 +1,93 @@
+'use server';
+
+import { revalidatePath } from 'next/cache';
+import { createClient } from '@/lib/supabase/server';
+import { prisma } from '@/lib/prisma';
+import { getColumnSchema, createTableMeta } from '../types/schema';
+import { removeColumnFromSchema } from '../utils/schema-operations';
+
+type FormState = {
+  error?: string;
+  success?: boolean;
+};
+
+/**
+ * カラムを削除するServer Action
+ */
+export async function removeColumn(
+  itemId: string,
+  columnId: string
+): Promise<FormState> {
+  // セッションからユーザー情報を取得
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return { error: '認証が必要です' };
+  }
+
+  // DB からユーザー ID を取得
+  const dbUser = await prisma.user.findUnique({
+    where: { email: user.email! },
+    select: { id: true, role: true },
+  });
+
+  if (!dbUser) {
+    return { error: 'ユーザー情報が取得できませんでした' };
+  }
+
+  try {
+    // Itemを取得
+    const item = await prisma.item.findUnique({
+      where: { id: itemId },
+    });
+
+    if (!item) {
+      return { error: 'テーブルが見つかりません' };
+    }
+
+    if (item.type !== 'TABLE') {
+      return { error: 'テーブルではありません' };
+    }
+
+    // TODO: 権限チェック（将来実装）
+    if (item.createdById !== dbUser.id && dbUser.role !== 'ADMIN') {
+      return { error: 'カラムを削除する権限がありません' };
+    }
+
+    // 現在のスキーマを取得
+    const schema = getColumnSchema(item.meta);
+
+    if (!schema) {
+      return { error: 'スキーマが見つかりません' };
+    }
+
+    // カラムを削除
+    const newSchema = removeColumnFromSchema(schema, columnId);
+
+    // TableMetaを更新
+    const newTableMeta = createTableMeta(newSchema);
+
+    // DBを更新
+    await prisma.item.update({
+      where: { id: itemId },
+      data: {
+        meta: newTableMeta as never,
+      },
+    });
+
+    revalidatePath(`/tables/${itemId}`);
+    return { success: true };
+  } catch (error) {
+    console.error('カラム削除エラー:', error);
+
+    // カラムが見つからない場合
+    if (error instanceof Error && error.message.includes('not found')) {
+      return { error: 'カラムが見つかりません' };
+    }
+
+    return { error: 'カラムの削除に失敗しました' };
+  }
+}

--- a/features/column/api/reorder-column.ts
+++ b/features/column/api/reorder-column.ts
@@ -1,0 +1,104 @@
+'use server';
+
+import { revalidatePath } from 'next/cache';
+import { createClient } from '@/lib/supabase/server';
+import { prisma } from '@/lib/prisma';
+import { getColumnSchema, createTableMeta } from '../types/schema';
+import { reorderColumnInSchema } from '../utils/schema-operations';
+
+type FormState = {
+  error?: string;
+  success?: boolean;
+};
+
+/**
+ * カラムを並び替えるServer Action
+ */
+export async function reorderColumn(
+  itemId: string,
+  columnId: string,
+  newOrder: number
+): Promise<FormState> {
+  // セッションからユーザー情報を取得
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return { error: '認証が必要です' };
+  }
+
+  // DB からユーザー ID を取得
+  const dbUser = await prisma.user.findUnique({
+    where: { email: user.email! },
+    select: { id: true, role: true },
+  });
+
+  if (!dbUser) {
+    return { error: 'ユーザー情報が取得できませんでした' };
+  }
+
+  // バリデーション
+  if (newOrder < 0) {
+    return { error: '並び順は0以上である必要があります' };
+  }
+
+  try {
+    // Itemを取得
+    const item = await prisma.item.findUnique({
+      where: { id: itemId },
+    });
+
+    if (!item) {
+      return { error: 'テーブルが見つかりません' };
+    }
+
+    if (item.type !== 'TABLE') {
+      return { error: 'テーブルではありません' };
+    }
+
+    // TODO: 権限チェック（将来実装）
+    if (item.createdById !== dbUser.id && dbUser.role !== 'ADMIN') {
+      return { error: 'カラムを並び替える権限がありません' };
+    }
+
+    // 現在のスキーマを取得
+    const schema = getColumnSchema(item.meta);
+
+    if (!schema) {
+      return { error: 'スキーマが見つかりません' };
+    }
+
+    // カラムを並び替え
+    const newSchema = reorderColumnInSchema(schema, columnId, newOrder);
+
+    // TableMetaを更新
+    const newTableMeta = createTableMeta(newSchema);
+
+    // DBを更新
+    await prisma.item.update({
+      where: { id: itemId },
+      data: {
+        meta: newTableMeta as never,
+      },
+    });
+
+    revalidatePath(`/tables/${itemId}`);
+    return { success: true };
+  } catch (error) {
+    console.error('カラム並び替えエラー:', error);
+
+    // エラーメッセージを解析
+    if (error instanceof Error) {
+      if (error.message.includes('not found')) {
+        return { error: 'カラムが見つかりません' };
+      }
+      if (error.message.includes('Invalid order')) {
+        return { error: '無効な並び順です' };
+      }
+    }
+
+    return { error: 'カラムの並び替えに失敗しました' };
+  }
+}

--- a/features/column/api/update-column.ts
+++ b/features/column/api/update-column.ts
@@ -1,0 +1,115 @@
+'use server';
+
+import { revalidatePath } from 'next/cache';
+import { createClient } from '@/lib/supabase/server';
+import { prisma } from '@/lib/prisma';
+import type { UpdateColumnInput } from '../types/column';
+import { getColumnSchema, createTableMeta } from '../types/schema';
+import {
+  updateColumnInSchema,
+  hasColumnWithName,
+} from '../utils/schema-operations';
+
+type FormState = {
+  error?: string;
+  success?: boolean;
+};
+
+/**
+ * カラムを更新するServer Action
+ */
+export async function updateColumn(
+  itemId: string,
+  columnId: string,
+  input: UpdateColumnInput
+): Promise<FormState> {
+  // セッションからユーザー情報を取得
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return { error: '認証が必要です' };
+  }
+
+  // DB からユーザー ID を取得
+  const dbUser = await prisma.user.findUnique({
+    where: { email: user.email! },
+    select: { id: true, role: true },
+  });
+
+  if (!dbUser) {
+    return { error: 'ユーザー情報が取得できませんでした' };
+  }
+
+  // バリデーション
+  if (input.name !== undefined && input.name.trim() === '') {
+    return { error: 'カラム名を入力してください' };
+  }
+
+  try {
+    // Itemを取得
+    const item = await prisma.item.findUnique({
+      where: { id: itemId },
+    });
+
+    if (!item) {
+      return { error: 'テーブルが見つかりません' };
+    }
+
+    if (item.type !== 'TABLE') {
+      return { error: 'テーブルではありません' };
+    }
+
+    // TODO: 権限チェック（将来実装）
+    if (item.createdById !== dbUser.id && dbUser.role !== 'ADMIN') {
+      return { error: 'カラムを更新する権限がありません' };
+    }
+
+    // 現在のスキーマを取得
+    const schema = getColumnSchema(item.meta);
+
+    if (!schema) {
+      return { error: 'スキーマが見つかりません' };
+    }
+
+    // カラム名を変更する場合、重複チェック
+    if (input.name !== undefined) {
+      if (hasColumnWithName(schema, input.name.trim(), columnId)) {
+        return { error: '同じ名前のカラムが既に存在します' };
+      }
+    }
+
+    // カラムを更新
+    const updatedInput = {
+      ...input,
+      ...(input.name !== undefined && { name: input.name.trim() }),
+    };
+
+    const newSchema = updateColumnInSchema(schema, columnId, updatedInput);
+
+    // TableMetaを更新
+    const newTableMeta = createTableMeta(newSchema);
+
+    // DBを更新
+    await prisma.item.update({
+      where: { id: itemId },
+      data: {
+        meta: newTableMeta as never,
+      },
+    });
+
+    revalidatePath(`/tables/${itemId}`);
+    return { success: true };
+  } catch (error) {
+    console.error('カラム更新エラー:', error);
+
+    // カラムが見つからない場合
+    if (error instanceof Error && error.message.includes('not found')) {
+      return { error: 'カラムが見つかりません' };
+    }
+
+    return { error: 'カラムの更新に失敗しました' };
+  }
+}

--- a/features/column/components/add-column-dialog.tsx
+++ b/features/column/components/add-column-dialog.tsx
@@ -71,7 +71,7 @@ export function AddColumnDialog({
         toast.success('カラムを追加しました');
         onOpenChange(false);
       }
-    } catch (error) {
+    } catch {
       toast.error('カラムの追加に失敗しました');
     } finally {
       setIsSubmitting(false);

--- a/features/column/components/add-column-dialog.tsx
+++ b/features/column/components/add-column-dialog.tsx
@@ -1,0 +1,160 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Checkbox } from '@/components/ui/checkbox';
+import { toast } from 'sonner';
+import { addColumn } from '../api/add-column';
+import type { ColumnType } from '../types/column';
+import { COLUMN_TYPE_LIST, COLUMN_CONFIGS } from '../constants';
+
+type AddColumnDialogProps = {
+  itemId: string;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  nextOrder: number;
+};
+
+export function AddColumnDialog({
+  itemId,
+  open,
+  onOpenChange,
+  nextOrder,
+}: AddColumnDialogProps) {
+  const [columnType, setColumnType] = useState<ColumnType>('TEXT');
+  const [columnName, setColumnName] = useState('');
+  const [isRequired, setIsRequired] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  // ダイアログが閉じられたときに状態をリセット
+  useEffect(() => {
+    if (!open) {
+      setColumnType('TEXT');
+      setColumnName('');
+      setIsRequired(false);
+    }
+  }, [open]);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setIsSubmitting(true);
+
+    try {
+      const result = await addColumn(itemId, {
+        name: columnName,
+        type: columnType,
+        order: nextOrder,
+        validation: isRequired ? { required: true } : undefined,
+      });
+
+      if (result.error) {
+        toast.error('カラムの追加に失敗しました', {
+          description: result.error,
+        });
+      } else if (result.success) {
+        toast.success('カラムを追加しました');
+        onOpenChange(false);
+      }
+    } catch (error) {
+      toast.error('カラムの追加に失敗しました');
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-[425px]">
+        <DialogHeader>
+          <DialogTitle>カラムを追加</DialogTitle>
+        </DialogHeader>
+        <form onSubmit={handleSubmit}>
+          <div className="grid gap-4 py-4">
+            <div className="grid gap-2">
+              <Label htmlFor="name">カラム名</Label>
+              <Input
+                id="name"
+                value={columnName}
+                onChange={(e) => setColumnName(e.target.value)}
+                placeholder="顧客名"
+                required
+              />
+            </div>
+
+            <div className="grid gap-2">
+              <Label htmlFor="type">タイプ</Label>
+              <Select
+                value={columnType}
+                onValueChange={(value) => setColumnType(value as ColumnType)}
+              >
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {COLUMN_TYPE_LIST.map((type) => {
+                    const config = COLUMN_CONFIGS[type];
+                    const Icon = config.icon;
+                    return (
+                      <SelectItem key={type} value={type}>
+                        <div className="flex items-center gap-2">
+                          <Icon className="h-4 w-4" />
+                          <span>{config.label}</span>
+                        </div>
+                      </SelectItem>
+                    );
+                  })}
+                </SelectContent>
+              </Select>
+              <p className="text-xs text-muted-foreground">
+                {COLUMN_CONFIGS[columnType].description}
+              </p>
+            </div>
+
+            <div className="flex items-center space-x-2">
+              <Checkbox
+                id="required"
+                checked={isRequired}
+                onCheckedChange={(checked) => setIsRequired(checked === true)}
+              />
+              <label
+                htmlFor="required"
+                className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
+              >
+                必須項目にする
+              </label>
+            </div>
+          </div>
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => onOpenChange(false)}
+              disabled={isSubmitting}
+            >
+              キャンセル
+            </Button>
+            <Button type="submit" disabled={isSubmitting}>
+              {isSubmitting ? '追加中...' : '追加'}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/features/column/components/column-list-item.tsx
+++ b/features/column/components/column-list-item.tsx
@@ -1,0 +1,75 @@
+'use client';
+
+import { useState } from 'react';
+import { GripVertical, MoreHorizontal } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import type { Column } from '../types/column';
+import { COLUMN_CONFIGS } from '../constants';
+import { EditColumnItem } from './edit-column-item';
+import { DeleteColumnItem } from './delete-column-item';
+
+type ColumnListItemProps = {
+  itemId: string;
+  column: Column;
+};
+
+/**
+ * カラムリストアイテムコンポーネント
+ */
+export function ColumnListItem({ itemId, column }: ColumnListItemProps) {
+  const [open, setOpen] = useState(false);
+  const config = COLUMN_CONFIGS[column.type];
+  const Icon = config.icon;
+
+  return (
+    <div className="flex items-center gap-2 p-3 border rounded-lg bg-card hover:bg-accent/50 transition-colors">
+      {/* ドラッグハンドル（将来実装） */}
+      <div className="cursor-grab text-muted-foreground">
+        <GripVertical className="h-4 w-4" />
+      </div>
+
+      {/* アイコン */}
+      <div className="flex-shrink-0">
+        <Icon className="h-4 w-4 text-muted-foreground" />
+      </div>
+
+      {/* カラム情報 */}
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center gap-2">
+          <div className="font-medium truncate">{column.name}</div>
+          {column.validation?.required && (
+            <span className="text-xs text-destructive">*</span>
+          )}
+        </div>
+        <div className="text-xs text-muted-foreground">{config.label}</div>
+      </div>
+
+      {/* アクションメニュー */}
+      <DropdownMenu open={open} onOpenChange={setOpen}>
+        <DropdownMenuTrigger asChild>
+          <Button variant="ghost" className="h-8 w-8 p-0">
+            <span className="sr-only">メニューを開く</span>
+            <MoreHorizontal className="h-4 w-4" />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent side="bottom" align="end">
+          <EditColumnItem
+            itemId={itemId}
+            column={column}
+            onOpenChange={setOpen}
+          />
+          <DeleteColumnItem
+            itemId={itemId}
+            column={column}
+            onOpenChange={setOpen}
+          />
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </div>
+  );
+}

--- a/features/column/components/column-list.tsx
+++ b/features/column/components/column-list.tsx
@@ -1,0 +1,55 @@
+'use client';
+
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Plus } from 'lucide-react';
+import type { Column } from '../types/column';
+import { ColumnListItem } from './column-list-item';
+import { AddColumnDialog } from './add-column-dialog';
+import { useState } from 'react';
+
+type ColumnListProps = {
+  itemId: string;
+  columns: Column[];
+};
+
+/**
+ * カラム一覧表示コンポーネント
+ */
+export function ColumnList({ itemId, columns }: ColumnListProps) {
+  const [isAddDialogOpen, setIsAddDialogOpen] = useState(false);
+
+  return (
+    <Card>
+      <CardHeader>
+        <div className="flex items-center justify-between">
+          <CardTitle>カラム</CardTitle>
+          <Button size="sm" onClick={() => setIsAddDialogOpen(true)}>
+            <Plus className="mr-2 h-4 w-4" />
+            カラムを追加
+          </Button>
+        </div>
+      </CardHeader>
+      <CardContent>
+        {columns.length === 0 ? (
+          <div className="text-center py-8 text-muted-foreground">
+            カラムがまだありません
+          </div>
+        ) : (
+          <div className="space-y-2">
+            {columns.map((column) => (
+              <ColumnListItem key={column.id} itemId={itemId} column={column} />
+            ))}
+          </div>
+        )}
+      </CardContent>
+
+      <AddColumnDialog
+        itemId={itemId}
+        open={isAddDialogOpen}
+        onOpenChange={setIsAddDialogOpen}
+        nextOrder={columns.length}
+      />
+    </Card>
+  );
+}

--- a/features/column/components/delete-column-item.tsx
+++ b/features/column/components/delete-column-item.tsx
@@ -1,0 +1,103 @@
+'use client';
+
+import { useState } from 'react';
+import { Trash2, AlertCircle } from 'lucide-react';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from '@/components/ui/alert-dialog';
+import { DropdownMenuItem } from '@/components/ui/dropdown-menu';
+import { toast } from 'sonner';
+import { removeColumn } from '../api/remove-column';
+import type { Column } from '../types/column';
+
+type DeleteColumnItemProps = {
+  itemId: string;
+  column: Column;
+  onOpenChange: (open: boolean) => void;
+};
+
+export function DeleteColumnItem({
+  itemId,
+  column,
+  onOpenChange: onDropdownOpenChange,
+}: DeleteColumnItemProps) {
+  const [open, setOpen] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
+
+  const handleDelete = async () => {
+    setIsDeleting(true);
+
+    const result = await removeColumn(itemId, column.id);
+
+    setOpen(false);
+    setIsDeleting(false);
+
+    if (result.error) {
+      toast.error('削除に失敗しました', {
+        description: result.error,
+      });
+    } else {
+      toast.success('カラムを削除しました', {
+        description: `${column.name}を削除しました`,
+      });
+    }
+  };
+
+  const handleOpenChange = (isOpen: boolean) => {
+    setOpen(isOpen);
+    if (!isOpen) {
+      onDropdownOpenChange(false);
+    }
+  };
+
+  return (
+    <AlertDialog open={open} onOpenChange={handleOpenChange}>
+      <AlertDialogTrigger asChild>
+        <DropdownMenuItem
+          className="text-destructive hover:text-destructive focus:text-destructive"
+          onSelect={(e) => e.preventDefault()}
+        >
+          <Trash2 className="text-destructive" />
+          削除
+        </DropdownMenuItem>
+      </AlertDialogTrigger>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <div className="flex items-center space-x-2">
+            <AlertCircle className="text-destructive" />
+            <AlertDialogTitle className="text-destructive">
+              {column.name}を削除
+            </AlertDialogTitle>
+          </div>
+          <AlertDialogDescription>
+            削除したカラムは復元できません。
+            <br />
+            このカラムに保存されているすべてのデータも削除されます。
+            <br />
+            本当に削除しますか？
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={isDeleting}>
+            キャンセル
+          </AlertDialogCancel>
+          <AlertDialogAction
+            onClick={handleDelete}
+            disabled={isDeleting}
+            className="bg-destructive text-white hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60"
+          >
+            {isDeleting ? '削除中...' : '削除'}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/features/column/components/edit-column-item.tsx
+++ b/features/column/components/edit-column-item.tsx
@@ -63,7 +63,7 @@ export function EditColumnItem({
         setOpen(false);
         onOpenChange(false);
       }
-    } catch (error) {
+    } catch {
       toast.error('カラムの更新に失敗しました');
     } finally {
       setIsSubmitting(false);

--- a/features/column/components/edit-column-item.tsx
+++ b/features/column/components/edit-column-item.tsx
@@ -1,0 +1,130 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { DropdownMenuItem } from '@/components/ui/dropdown-menu';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Pencil } from 'lucide-react';
+import { toast } from 'sonner';
+import { updateColumn } from '../api/update-column';
+import type { Column } from '../types/column';
+
+type EditColumnItemProps = {
+  itemId: string;
+  column: Column;
+  onOpenChange: (open: boolean) => void;
+};
+
+export function EditColumnItem({
+  itemId,
+  column,
+  onOpenChange,
+}: EditColumnItemProps) {
+  const [open, setOpen] = useState(false);
+  const [columnName, setColumnName] = useState(column.name);
+  const [isRequired, setIsRequired] = useState(
+    column.validation?.required || false
+  );
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  // ダイアログが開かれたときに最新の値をセット
+  useEffect(() => {
+    if (open) {
+      setColumnName(column.name);
+      setIsRequired(column.validation?.required || false);
+    }
+  }, [open, column]);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setIsSubmitting(true);
+
+    try {
+      const result = await updateColumn(itemId, column.id, {
+        name: columnName,
+        validation: isRequired ? { required: true } : { required: false },
+      });
+
+      if (result.error) {
+        toast.error('カラムの更新に失敗しました', {
+          description: result.error,
+        });
+      } else if (result.success) {
+        toast.success('カラムを更新しました');
+        setOpen(false);
+        onOpenChange(false);
+      }
+    } catch (error) {
+      toast.error('カラムの更新に失敗しました');
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <>
+      <DropdownMenuItem onClick={() => setOpen(true)}>
+        <Pencil className="mr-2 h-4 w-4" />
+        編集
+      </DropdownMenuItem>
+
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent className="sm:max-w-[425px]">
+          <DialogHeader>
+            <DialogTitle>カラムを編集</DialogTitle>
+          </DialogHeader>
+          <form onSubmit={handleSubmit}>
+            <div className="grid gap-4 py-4">
+              <div className="grid gap-2">
+                <Label htmlFor="edit-name">カラム名</Label>
+                <Input
+                  id="edit-name"
+                  value={columnName}
+                  onChange={(e) => setColumnName(e.target.value)}
+                  placeholder="顧客名"
+                  required
+                />
+              </div>
+
+              <div className="flex items-center space-x-2">
+                <Checkbox
+                  id="edit-required"
+                  checked={isRequired}
+                  onCheckedChange={(checked) => setIsRequired(checked === true)}
+                />
+                <label
+                  htmlFor="edit-required"
+                  className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
+                >
+                  必須項目にする
+                </label>
+              </div>
+            </div>
+            <DialogFooter>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => setOpen(false)}
+                disabled={isSubmitting}
+              >
+                キャンセル
+              </Button>
+              <Button type="submit" disabled={isSubmitting}>
+                {isSubmitting ? '更新中...' : '更新'}
+              </Button>
+            </DialogFooter>
+          </form>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/features/column/components/index.ts
+++ b/features/column/components/index.ts
@@ -1,0 +1,5 @@
+export * from './column-list';
+export * from './column-list-item';
+export * from './add-column-dialog';
+export * from './edit-column-item';
+export * from './delete-column-item';

--- a/features/column/constants/column-config.ts
+++ b/features/column/constants/column-config.ts
@@ -1,0 +1,119 @@
+import {
+  AlignLeft,
+  Calendar,
+  CheckSquare,
+  Hash,
+  List,
+  Text,
+} from 'lucide-react';
+import type { LucideIcon } from 'lucide-react';
+import type { ColumnType } from '../types/column';
+
+/**
+ * カラムタイプごとの設定
+ */
+export type ColumnConfig = {
+  icon: LucideIcon;
+  label: string;
+  description: string;
+  hasConfig: boolean; // 設定項目があるか
+  defaultConfig?: Record<string, unknown>;
+};
+
+/**
+ * カラムタイプの設定（Config-Driven UI）
+ */
+export const COLUMN_CONFIGS: Record<ColumnType, ColumnConfig> = {
+  TEXT: {
+    icon: Text,
+    label: 'テキスト（1行）',
+    description: '短いテキストを入力できます',
+    hasConfig: true,
+    defaultConfig: {
+      maxLength: 255,
+      placeholder: '',
+    },
+  },
+  TEXTAREA: {
+    icon: AlignLeft,
+    label: 'テキスト（複数行）',
+    description: '長いテキストを入力できます',
+    hasConfig: true,
+    defaultConfig: {
+      maxLength: 5000,
+      placeholder: '',
+      rows: 4,
+    },
+  },
+  NUMBER: {
+    icon: Hash,
+    label: '数値',
+    description: '数値を入力できます',
+    hasConfig: true,
+    defaultConfig: {
+      step: 1,
+      placeholder: '',
+    },
+  },
+  DATE: {
+    icon: Calendar,
+    label: '日付',
+    description: '日付を選択できます',
+    hasConfig: true,
+    defaultConfig: {
+      format: 'YYYY-MM-DD',
+    },
+  },
+  SELECT: {
+    icon: List,
+    label: '選択肢',
+    description: 'ドロップダウンから選択できます',
+    hasConfig: true,
+    defaultConfig: {
+      options: [],
+      allowCustom: false,
+    },
+  },
+  CHECKBOX: {
+    icon: CheckSquare,
+    label: 'チェックボックス',
+    description: 'ON/OFFを切り替えられます',
+    hasConfig: true,
+    defaultConfig: {
+      defaultValue: false,
+    },
+  },
+} as const;
+
+/**
+ * カラムタイプの配列（UI表示順）
+ */
+export const COLUMN_TYPE_LIST: ColumnType[] = [
+  'TEXT',
+  'TEXTAREA',
+  'NUMBER',
+  'DATE',
+  'SELECT',
+  'CHECKBOX',
+] as const;
+
+/**
+ * カラムタイプの表示名を取得
+ */
+export function getColumnTypeLabel(type: ColumnType): string {
+  return COLUMN_CONFIGS[type].label;
+}
+
+/**
+ * カラムタイプの説明を取得
+ */
+export function getColumnTypeDescription(type: ColumnType): string {
+  return COLUMN_CONFIGS[type].description;
+}
+
+/**
+ * カラムタイプのアイコンを取得
+ */
+export function getColumnTypeIcon(type: ColumnType): LucideIcon {
+  return COLUMN_CONFIGS[type].icon;
+}

--- a/features/column/constants/index.ts
+++ b/features/column/constants/index.ts
@@ -1,0 +1,1 @@
+export * from './column-config';

--- a/features/column/types/column.ts
+++ b/features/column/types/column.ts
@@ -1,0 +1,166 @@
+/**
+ * カラムタイプの列挙型
+ */
+export const COLUMN_TYPES = {
+  TEXT: 'TEXT',
+  TEXTAREA: 'TEXTAREA',
+  NUMBER: 'NUMBER',
+  DATE: 'DATE',
+  SELECT: 'SELECT',
+  CHECKBOX: 'CHECKBOX',
+} as const;
+
+export type ColumnType = (typeof COLUMN_TYPES)[keyof typeof COLUMN_TYPES];
+
+/**
+ * 選択肢の型（SELECT型で使用）
+ */
+export type SelectOption = {
+  id: string;
+  label: string;
+  color?: string;
+};
+
+/**
+ * 日付フォーマットの型
+ * 将来的に年月のみ、日時、秒数までなど細かい設定に対応可能
+ */
+export type DateFormatType =
+  | 'YYYY-MM-DD' // 日付のみ
+  | 'YYYY/MM/DD' // 日付のみ（スラッシュ区切り）
+  | 'YYYY-MM' // 年月のみ（将来実装）
+  | 'YYYY-MM-DD HH:mm' // 日時（将来実装）
+  | 'YYYY-MM-DD HH:mm:ss'; // 日時秒（将来実装）
+
+/**
+ * 各カラムタイプ固有の設定
+ */
+export type ColumnTypeConfig = {
+  TEXT: {
+    maxLength?: number;
+    placeholder?: string;
+  };
+  TEXTAREA: {
+    maxLength?: number;
+    placeholder?: string;
+    rows?: number;
+  };
+  NUMBER: {
+    min?: number;
+    max?: number;
+    step?: number;
+    placeholder?: string;
+  };
+  DATE: {
+    format?: DateFormatType;
+    min?: string; // ISO 8601形式
+    max?: string; // ISO 8601形式
+  };
+  SELECT: {
+    options: SelectOption[];
+    multiple?: boolean; // 複数選択を許可するか（将来実装）
+    allowCustom?: boolean; // カスタム入力を許可するか
+  };
+  CHECKBOX: {
+    multiple?: boolean; // 複数選択を許可するか（将来実装）
+    options?: SelectOption[]; // multiple=trueの場合に使用（将来実装）
+    defaultValue?: boolean; // 単一選択の場合のデフォルト値
+  };
+};
+
+/**
+ * バリデーションルールの型
+ */
+export type ValidationRule = {
+  required?: boolean;
+  message?: string;
+};
+
+/**
+ * 基本カラム定義
+ */
+type BaseColumn = {
+  id: string;
+  name: string;
+  description?: string;
+  order: number;
+  validation?: ValidationRule;
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+/**
+ * 各カラムタイプの定義（Discriminated Union）
+ */
+export type TextColumn = BaseColumn & {
+  type: 'TEXT';
+  config?: ColumnTypeConfig['TEXT'];
+};
+
+export type TextareaColumn = BaseColumn & {
+  type: 'TEXTAREA';
+  config?: ColumnTypeConfig['TEXTAREA'];
+};
+
+export type NumberColumn = BaseColumn & {
+  type: 'NUMBER';
+  config?: ColumnTypeConfig['NUMBER'];
+};
+
+export type DateColumn = BaseColumn & {
+  type: 'DATE';
+  config?: ColumnTypeConfig['DATE'];
+};
+
+export type SelectColumn = BaseColumn & {
+  type: 'SELECT';
+  config: ColumnTypeConfig['SELECT']; // SELECT型はoptionsが必須
+};
+
+export type CheckboxColumn = BaseColumn & {
+  type: 'CHECKBOX';
+  config?: ColumnTypeConfig['CHECKBOX'];
+};
+
+/**
+ * カラム型の統合型（Discriminated Union）
+ */
+export type Column =
+  | TextColumn
+  | TextareaColumn
+  | NumberColumn
+  | DateColumn
+  | SelectColumn
+  | CheckboxColumn;
+
+/**
+ * カラムスキーマ（テーブルの全カラム定義）
+ */
+export type ColumnSchema = {
+  columns: Column[];
+};
+
+/**
+ * カラム作成用の入力型
+ */
+export type CreateColumnInput<T extends ColumnType = ColumnType> =
+  T extends 'TEXT'
+    ? Omit<TextColumn, 'id' | 'createdAt' | 'updatedAt'>
+    : T extends 'TEXTAREA'
+      ? Omit<TextareaColumn, 'id' | 'createdAt' | 'updatedAt'>
+      : T extends 'NUMBER'
+        ? Omit<NumberColumn, 'id' | 'createdAt' | 'updatedAt'>
+        : T extends 'DATE'
+          ? Omit<DateColumn, 'id' | 'createdAt' | 'updatedAt'>
+          : T extends 'SELECT'
+            ? Omit<SelectColumn, 'id' | 'createdAt' | 'updatedAt'>
+            : T extends 'CHECKBOX'
+              ? Omit<CheckboxColumn, 'id' | 'createdAt' | 'updatedAt'>
+              : never;
+
+/**
+ * カラム更新用の入力型
+ */
+export type UpdateColumnInput = Partial<
+  Omit<Column, 'id' | 'createdAt' | 'updatedAt'>
+>;

--- a/features/column/types/column.ts
+++ b/features/column/types/column.ts
@@ -134,29 +134,9 @@ export type Column =
   | CheckboxColumn;
 
 /**
- * カラムスキーマ（テーブルの全カラム定義）
- */
-export type ColumnSchema = {
-  columns: Column[];
-};
-
-/**
  * カラム作成用の入力型
  */
-export type CreateColumnInput<T extends ColumnType = ColumnType> =
-  T extends 'TEXT'
-    ? Omit<TextColumn, 'id' | 'createdAt' | 'updatedAt'>
-    : T extends 'TEXTAREA'
-      ? Omit<TextareaColumn, 'id' | 'createdAt' | 'updatedAt'>
-      : T extends 'NUMBER'
-        ? Omit<NumberColumn, 'id' | 'createdAt' | 'updatedAt'>
-        : T extends 'DATE'
-          ? Omit<DateColumn, 'id' | 'createdAt' | 'updatedAt'>
-          : T extends 'SELECT'
-            ? Omit<SelectColumn, 'id' | 'createdAt' | 'updatedAt'>
-            : T extends 'CHECKBOX'
-              ? Omit<CheckboxColumn, 'id' | 'createdAt' | 'updatedAt'>
-              : never;
+export type CreateColumnInput = Omit<Column, 'id' | 'createdAt' | 'updatedAt'>;
 
 /**
  * カラム更新用の入力型

--- a/features/column/types/index.ts
+++ b/features/column/types/index.ts
@@ -1,2 +1,3 @@
 export * from './column';
 export * from './validation';
+export * from './schema';

--- a/features/column/types/index.ts
+++ b/features/column/types/index.ts
@@ -1,0 +1,2 @@
+export * from './column';
+export * from './validation';

--- a/features/column/types/schema.ts
+++ b/features/column/types/schema.ts
@@ -1,0 +1,87 @@
+import type { Column } from './column';
+
+/**
+ * Itemモデルのmetaフィールドに保存するスキーマ定義
+ * TABLE型のItemの場合のみ使用
+ */
+export type TableMeta = {
+  schema: ColumnSchema;
+  version?: number; // スキーマバージョン（将来のマイグレーション用）
+};
+
+/**
+ * カラムスキーマ（テーブルの全カラム定義）
+ */
+export type ColumnSchema = {
+  columns: Column[];
+};
+
+/**
+ * FOLDER型のItemのmeta
+ * 現在は特に使用しないが、将来の拡張用に定義
+ */
+export type FolderMeta = {
+  // 将来的にフォルダの設定（アイコン、色など）を追加可能
+  [key: string]: unknown;
+};
+
+/**
+ * Itemのmeta型（type判別用）
+ */
+export type ItemMeta = {
+  FOLDER: FolderMeta | null;
+  TABLE: TableMeta;
+};
+
+/**
+ * 空のスキーマを生成
+ */
+export function createEmptySchema(): ColumnSchema {
+  return {
+    columns: [],
+  };
+}
+
+/**
+ * 新しいTableMetaを生成
+ */
+export function createTableMeta(schema?: ColumnSchema): TableMeta {
+  return {
+    schema: schema || createEmptySchema(),
+    version: 1,
+  };
+}
+
+/**
+ * metaがTableMetaかどうかを判定（型ガード）
+ */
+export function isTableMeta(meta: unknown): meta is TableMeta {
+  if (!meta || typeof meta !== 'object') {
+    return false;
+  }
+
+  const tableMeta = meta as TableMeta;
+  return (
+    typeof tableMeta.schema === 'object' &&
+    tableMeta.schema !== null &&
+    Array.isArray(tableMeta.schema.columns)
+  );
+}
+
+/**
+ * ItemのmetaからTableMetaを安全に取得
+ */
+export function getTableMeta(meta: unknown): TableMeta | null {
+  if (isTableMeta(meta)) {
+    return meta;
+  }
+  return null;
+}
+
+/**
+ * ItemのmetaからColumnSchemaを安全に取得
+ */
+export function getColumnSchema(meta: unknown): ColumnSchema | null {
+  const tableMeta = getTableMeta(meta);
+  return tableMeta?.schema || null;
+}

--- a/features/column/types/validation.ts
+++ b/features/column/types/validation.ts
@@ -1,0 +1,50 @@
+import type { Column, ColumnType } from './column';
+
+/**
+ * バリデーションエラーの型
+ */
+export type ValidationError = {
+  columnId: string;
+  columnName: string;
+  message: string;
+};
+
+/**
+ * バリデーション結果の型
+ */
+export type ValidationResult = {
+  isValid: boolean;
+  errors: ValidationError[];
+};
+
+/**
+ * カラムの値の型（各カラムタイプに対応）
+ */
+export type ColumnValue = {
+  TEXT: string;
+  TEXTAREA: string;
+  NUMBER: number;
+  DATE: string; // ISO 8601形式（将来的に年月のみ、日時秒なども対応）
+  SELECT: string | string[]; // 単一選択: option.id、複数選択: option.id[]（将来実装）
+  CHECKBOX: boolean | string[]; // 単一: boolean、複数選択: option.id[]（将来実装）
+};
+
+/**
+ * レコードデータの型（カラムIDをキーとした値のマップ）
+ */
+export type RecordData = Record<string, unknown>;
+
+/**
+ * バリデーション関数の型
+ */
+export type ValidateColumnFn<T extends ColumnType = ColumnType> = (
+  value: unknown,
+  column: Extract<Column, { type: T }>
+) => ValidationError | null;
+
+/**
+ * バリデータの型定義
+ */
+export type ColumnValidator = {
+  [K in ColumnType]: ValidateColumnFn<K>;
+};

--- a/features/column/utils/index.ts
+++ b/features/column/utils/index.ts
@@ -1,0 +1,2 @@
+export * from './schema-operations';
+export * from './validate-column-value';

--- a/features/column/utils/schema-operations.ts
+++ b/features/column/utils/schema-operations.ts
@@ -1,0 +1,188 @@
+import { nanoid } from 'nanoid';
+import type {
+  Column,
+  ColumnSchema,
+  CreateColumnInput,
+  UpdateColumnInput,
+} from '../types/column';
+
+/**
+ * カラムをスキーマに追加
+ */
+export function addColumnToSchema(
+  schema: ColumnSchema,
+  input: CreateColumnInput
+): ColumnSchema {
+  const newColumn: Column = {
+    ...input,
+    id: nanoid(),
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  } as Column;
+
+  return {
+    ...schema,
+    columns: [...schema.columns, newColumn],
+  };
+}
+
+/**
+ * カラムを更新
+ */
+export function updateColumnInSchema(
+  schema: ColumnSchema,
+  columnId: string,
+  input: UpdateColumnInput
+): ColumnSchema {
+  const columnIndex = schema.columns.findIndex((col) => col.id === columnId);
+
+  if (columnIndex === -1) {
+    throw new Error(`Column with id ${columnId} not found`);
+  }
+
+  const updatedColumn: Column = {
+    ...schema.columns[columnIndex],
+    ...input,
+    updatedAt: new Date(),
+  } as Column;
+
+  const newColumns = [...schema.columns];
+  newColumns[columnIndex] = updatedColumn;
+
+  return {
+    ...schema,
+    columns: newColumns,
+  };
+}
+
+/**
+ * カラムを削除
+ */
+export function removeColumnFromSchema(
+  schema: ColumnSchema,
+  columnId: string
+): ColumnSchema {
+  const columnExists = schema.columns.some((col) => col.id === columnId);
+
+  if (!columnExists) {
+    throw new Error(`Column with id ${columnId} not found`);
+  }
+
+  return {
+    ...schema,
+    columns: schema.columns.filter((col) => col.id !== columnId),
+  };
+}
+
+/**
+ * カラムの並び替え
+ * @param schema 現在のスキーマ
+ * @param columnId 移動するカラムのID
+ * @param newOrder 新しい並び順（0-indexed）
+ */
+export function reorderColumnInSchema(
+  schema: ColumnSchema,
+  columnId: string,
+  newOrder: number
+): ColumnSchema {
+  const columnIndex = schema.columns.findIndex((col) => col.id === columnId);
+
+  if (columnIndex === -1) {
+    throw new Error(`Column with id ${columnId} not found`);
+  }
+
+  if (newOrder < 0 || newOrder >= schema.columns.length) {
+    throw new Error(
+      `Invalid order: ${newOrder}. Must be between 0 and ${schema.columns.length - 1}`
+    );
+  }
+
+  // カラムを配列から取り出す
+  const [movedColumn] = schema.columns.splice(columnIndex, 1);
+
+  // 新しい位置に挿入
+  const newColumns = [...schema.columns];
+  newColumns.splice(newOrder, 0, movedColumn);
+
+  // order値を再計算
+  const reorderedColumns = newColumns.map((col, index) => ({
+    ...col,
+    order: index,
+    updatedAt: new Date(),
+  }));
+
+  return {
+    ...schema,
+    columns: reorderedColumns,
+  };
+}
+
+/**
+ * カラムIDでカラムを取得
+ */
+export function getColumnById(
+  schema: ColumnSchema,
+  columnId: string
+): Column | null {
+  return schema.columns.find((col) => col.id === columnId) || null;
+}
+
+/**
+ * カラム名でカラムを取得
+ */
+export function getColumnByName(
+  schema: ColumnSchema,
+  name: string
+): Column | null {
+  return schema.columns.find((col) => col.name === name) || null;
+}
+
+/**
+ * カラム名の重複チェック
+ */
+export function hasColumnWithName(
+  schema: ColumnSchema,
+  name: string,
+  excludeColumnId?: string
+): boolean {
+  return schema.columns.some(
+    (col) => col.name === name && col.id !== excludeColumnId
+  );
+}
+
+/**
+ * スキーマの整合性チェック
+ * - カラムIDの重複チェック
+ * - カラム名の重複チェック
+ */
+export function validateSchema(schema: ColumnSchema): {
+  isValid: boolean;
+  errors: string[];
+} {
+  const errors: string[] = [];
+
+  // カラムIDの重複チェック
+  const columnIds = schema.columns.map((col) => col.id);
+  const uniqueIds = new Set(columnIds);
+  if (columnIds.length !== uniqueIds.size) {
+    errors.push('Duplicate column IDs found');
+  }
+
+  // カラム名の重複チェック
+  const columnNames = schema.columns.map((col) => col.name);
+  const uniqueNames = new Set(columnNames);
+  if (columnNames.length !== uniqueNames.size) {
+    errors.push('Duplicate column names found');
+  }
+
+  // カラム名が空でないかチェック
+  const emptyNames = schema.columns.filter((col) => !col.name.trim());
+  if (emptyNames.length > 0) {
+    errors.push('Column names cannot be empty');
+  }
+
+  return {
+    isValid: errors.length === 0,
+    errors,
+  };
+}

--- a/features/column/utils/schema-operations.ts
+++ b/features/column/utils/schema-operations.ts
@@ -1,5 +1,9 @@
 import { nanoid } from 'nanoid';
-import type { Column, CreateColumnInput, UpdateColumnInput } from '../types/column';
+import type {
+  Column,
+  CreateColumnInput,
+  UpdateColumnInput,
+} from '../types/column';
 import type { ColumnSchema } from '../types/schema';
 
 /**

--- a/features/column/utils/schema-operations.ts
+++ b/features/column/utils/schema-operations.ts
@@ -1,10 +1,6 @@
 import { nanoid } from 'nanoid';
-import type {
-  Column,
-  ColumnSchema,
-  CreateColumnInput,
-  UpdateColumnInput,
-} from '../types/column';
+import type { Column, CreateColumnInput, UpdateColumnInput } from '../types/column';
+import type { ColumnSchema } from '../types/schema';
 
 /**
  * カラムをスキーマに追加

--- a/features/column/utils/validate-column-value.ts
+++ b/features/column/utils/validate-column-value.ts
@@ -1,0 +1,295 @@
+import type {
+  Column,
+  CheckboxColumn,
+  DateColumn,
+  NumberColumn,
+  SelectColumn,
+  TextColumn,
+  TextareaColumn,
+} from '../types/column';
+import type { ValidationError } from '../types/validation';
+
+/**
+ * カラムの値をバリデーション
+ */
+export function validateColumnValue(
+  value: unknown,
+  column: Column
+): ValidationError | null {
+  // required チェック
+  if (column.validation?.required && isEmptyValue(value)) {
+    return {
+      columnId: column.id,
+      columnName: column.name,
+      message:
+        column.validation.message || `${column.name}は必須項目です`,
+    };
+  }
+
+  // 値が空の場合はそれ以上のチェックをスキップ
+  if (isEmptyValue(value)) {
+    return null;
+  }
+
+  // カラムタイプごとのバリデーション
+  switch (column.type) {
+    case 'TEXT':
+      return validateTextValue(value, column);
+    case 'TEXTAREA':
+      return validateTextareaValue(value, column);
+    case 'NUMBER':
+      return validateNumberValue(value, column);
+    case 'DATE':
+      return validateDateValue(value, column);
+    case 'SELECT':
+      return validateSelectValue(value, column);
+    case 'CHECKBOX':
+      return validateCheckboxValue(value, column);
+    default:
+      return null;
+  }
+}
+
+/**
+ * 値が空かどうかを判定
+ */
+function isEmptyValue(value: unknown): boolean {
+  return (
+    value === null ||
+    value === undefined ||
+    value === '' ||
+    (Array.isArray(value) && value.length === 0)
+  );
+}
+
+/**
+ * TEXT型のバリデーション
+ */
+function validateTextValue(
+  value: unknown,
+  column: TextColumn
+): ValidationError | null {
+  if (typeof value !== 'string') {
+    return {
+      columnId: column.id,
+      columnName: column.name,
+      message: `${column.name}は文字列である必要があります`,
+    };
+  }
+
+  const maxLength = column.config?.maxLength;
+  if (maxLength && value.length > maxLength) {
+    return {
+      columnId: column.id,
+      columnName: column.name,
+      message: `${column.name}は${maxLength}文字以内で入力してください`,
+    };
+  }
+
+  return null;
+}
+
+/**
+ * TEXTAREA型のバリデーション
+ */
+function validateTextareaValue(
+  value: unknown,
+  column: TextareaColumn
+): ValidationError | null {
+  if (typeof value !== 'string') {
+    return {
+      columnId: column.id,
+      columnName: column.name,
+      message: `${column.name}は文字列である必要があります`,
+    };
+  }
+
+  const maxLength = column.config?.maxLength;
+  if (maxLength && value.length > maxLength) {
+    return {
+      columnId: column.id,
+      columnName: column.name,
+      message: `${column.name}は${maxLength}文字以内で入力してください`,
+    };
+  }
+
+  return null;
+}
+
+/**
+ * NUMBER型のバリデーション
+ */
+function validateNumberValue(
+  value: unknown,
+  column: NumberColumn
+): ValidationError | null {
+  const numValue = Number(value);
+
+  if (isNaN(numValue)) {
+    return {
+      columnId: column.id,
+      columnName: column.name,
+      message: `${column.name}は数値である必要があります`,
+    };
+  }
+
+  const min = column.config?.min;
+  if (min !== undefined && numValue < min) {
+    return {
+      columnId: column.id,
+      columnName: column.name,
+      message: `${column.name}は${min}以上である必要があります`,
+    };
+  }
+
+  const max = column.config?.max;
+  if (max !== undefined && numValue > max) {
+    return {
+      columnId: column.id,
+      columnName: column.name,
+      message: `${column.name}は${max}以下である必要があります`,
+    };
+  }
+
+  return null;
+}
+
+/**
+ * DATE型のバリデーション
+ */
+function validateDateValue(
+  value: unknown,
+  column: DateColumn
+): ValidationError | null {
+  if (typeof value !== 'string') {
+    return {
+      columnId: column.id,
+      columnName: column.name,
+      message: `${column.name}は文字列である必要があります`,
+    };
+  }
+
+  // ISO 8601形式かどうかをチェック
+  const date = new Date(value);
+  if (isNaN(date.getTime())) {
+    return {
+      columnId: column.id,
+      columnName: column.name,
+      message: `${column.name}は有効な日付形式である必要があります`,
+    };
+  }
+
+  const min = column.config?.min;
+  if (min && value < min) {
+    return {
+      columnId: column.id,
+      columnName: column.name,
+      message: `${column.name}は${min}以降である必要があります`,
+    };
+  }
+
+  const max = column.config?.max;
+  if (max && value > max) {
+    return {
+      columnId: column.id,
+      columnName: column.name,
+      message: `${column.name}は${max}以前である必要があります`,
+    };
+  }
+
+  return null;
+}
+
+/**
+ * SELECT型のバリデーション
+ */
+function validateSelectValue(
+  value: unknown,
+  column: SelectColumn
+): ValidationError | null {
+  // 単一選択の場合
+  if (typeof value === 'string') {
+    const validOptionIds = column.config.options.map((opt) => opt.id);
+
+    if (!validOptionIds.includes(value)) {
+      return {
+        columnId: column.id,
+        columnName: column.name,
+        message: `${column.name}は有効な選択肢から選んでください`,
+      };
+    }
+
+    return null;
+  }
+
+  // 複数選択の場合（将来実装）
+  if (Array.isArray(value)) {
+    const validOptionIds = column.config.options.map((opt) => opt.id);
+
+    const invalidValues = value.filter(
+      (v) => typeof v !== 'string' || !validOptionIds.includes(v)
+    );
+
+    if (invalidValues.length > 0) {
+      return {
+        columnId: column.id,
+        columnName: column.name,
+        message: `${column.name}は有効な選択肢から選んでください`,
+      };
+    }
+
+    return null;
+  }
+
+  return {
+    columnId: column.id,
+    columnName: column.name,
+    message: `${column.name}は文字列または配列である必要があります`,
+  };
+}
+
+/**
+ * CHECKBOX型のバリデーション
+ */
+function validateCheckboxValue(
+  value: unknown,
+  column: CheckboxColumn
+): ValidationError | null {
+  // 単一選択の場合
+  if (typeof value === 'boolean') {
+    return null;
+  }
+
+  // 複数選択の場合（将来実装）
+  if (Array.isArray(value)) {
+    if (!column.config?.options) {
+      return {
+        columnId: column.id,
+        columnName: column.name,
+        message: `${column.name}の選択肢が定義されていません`,
+      };
+    }
+
+    const validOptionIds = column.config.options.map((opt) => opt.id);
+
+    const invalidValues = value.filter(
+      (v) => typeof v !== 'string' || !validOptionIds.includes(v)
+    );
+
+    if (invalidValues.length > 0) {
+      return {
+        columnId: column.id,
+        columnName: column.name,
+        message: `${column.name}は有効な選択肢から選んでください`,
+      };
+    }
+
+    return null;
+  }
+
+  return {
+    columnId: column.id,
+    columnName: column.name,
+    message: `${column.name}はブール値または配列である必要があります`,
+  };
+}

--- a/features/column/utils/validate-column-value.ts
+++ b/features/column/utils/validate-column-value.ts
@@ -21,8 +21,7 @@ export function validateColumnValue(
     return {
       columnId: column.id,
       columnName: column.name,
-      message:
-        column.validation.message || `${column.name}は必須項目です`,
+      message: column.validation.message || `${column.name}は必須項目です`,
     };
   }
 

--- a/features/layout/components/workspace-menu/create-item-button/create-folder-button.tsx
+++ b/features/layout/components/workspace-menu/create-item-button/create-folder-button.tsx
@@ -18,17 +18,17 @@ import { toast } from 'sonner';
 import { createFolder } from '@/features/item/api/create-folder';
 
 type CreateFolderButtonProps = {
-  workspaceId: string;
+  parentId: string;
   onOpenChange: (open: boolean) => void;
 };
 
 type CreateFolderContentProps = {
-  workspaceId: string;
+  parentId: string;
   onClose: () => void;
 };
 
 function CreateFolderContent({
-  workspaceId,
+  parentId,
   onClose,
 }: CreateFolderContentProps) {
   const [state, formAction] = useActionState(createFolder, {});
@@ -47,7 +47,7 @@ function CreateFolderContent({
 
   return (
     <form action={formAction}>
-      <input type="hidden" name="parentId" value={workspaceId} />
+      <input type="hidden" name="parentId" value={parentId} />
 
       <div className="grid gap-4 py-4">
         <div className="grid gap-2">
@@ -73,7 +73,7 @@ function CreateFolderContent({
 }
 
 export function CreateFolderButton({
-  workspaceId,
+  parentId,
   onOpenChange: onDropdownOpenChange,
 }: CreateFolderButtonProps) {
   const [open, setOpen] = useState(false);
@@ -111,7 +111,7 @@ export function CreateFolderButton({
           </DialogHeader>
           <CreateFolderContent
             key={resetKey}
-            workspaceId={workspaceId}
+            parentId={parentId}
             onClose={handleClose}
           />
         </DialogContent>

--- a/features/layout/components/workspace-menu/create-item-button/create-folder-button.tsx
+++ b/features/layout/components/workspace-menu/create-item-button/create-folder-button.tsx
@@ -27,10 +27,7 @@ type CreateFolderContentProps = {
   onClose: () => void;
 };
 
-function CreateFolderContent({
-  parentId,
-  onClose,
-}: CreateFolderContentProps) {
+function CreateFolderContent({ parentId, onClose }: CreateFolderContentProps) {
   const [state, formAction] = useActionState(createFolder, {});
 
   // 成功・エラー時の処理

--- a/features/layout/components/workspace-menu/create-item-button/create-table-button.tsx
+++ b/features/layout/components/workspace-menu/create-item-button/create-table-button.tsx
@@ -18,16 +18,16 @@ import { toast } from 'sonner';
 import { createTable } from '@/features/item/api/create-table';
 
 type CreateTableButtonProps = {
-  workspaceId: string;
+  parentId: string;
   onOpenChange: (open: boolean) => void;
 };
 
 type CreateTableContentProps = {
-  workspaceId: string;
+  parentId: string;
   onClose: () => void;
 };
 
-function CreateTableContent({ workspaceId, onClose }: CreateTableContentProps) {
+function CreateTableContent({ parentId, onClose }: CreateTableContentProps) {
   const [state, formAction] = useActionState(createTable, {});
 
   // 成功・エラー時の処理
@@ -44,7 +44,7 @@ function CreateTableContent({ workspaceId, onClose }: CreateTableContentProps) {
 
   return (
     <form action={formAction}>
-      <input type="hidden" name="parentId" value={workspaceId} />
+      <input type="hidden" name="parentId" value={parentId} />
 
       <div className="grid gap-4 py-4">
         <div className="grid gap-2">
@@ -70,7 +70,7 @@ function CreateTableContent({ workspaceId, onClose }: CreateTableContentProps) {
 }
 
 export function CreateTableButton({
-  workspaceId,
+  parentId,
   onOpenChange: onDropdownOpenChange,
 }: CreateTableButtonProps) {
   const [open, setOpen] = useState(false);
@@ -108,7 +108,7 @@ export function CreateTableButton({
           </DialogHeader>
           <CreateTableContent
             key={resetKey}
-            workspaceId={workspaceId}
+            parentId={parentId}
             onClose={handleClose}
           />
         </DialogContent>

--- a/features/layout/components/workspace-menu/create-item-button/index.tsx
+++ b/features/layout/components/workspace-menu/create-item-button/index.tsx
@@ -11,10 +11,10 @@ import { CreateFolderButton } from './create-folder-button';
 import { CreateTableButton } from './create-table-button';
 
 type CreateItemButtonProps = {
-  workspaceId: string;
+  parentId: string;
 };
 
-export function CreateItemButton({ workspaceId }: CreateItemButtonProps) {
+export function CreateItemButton({ parentId }: CreateItemButtonProps) {
   const [open, setOpen] = useState(false);
 
   return (
@@ -32,8 +32,8 @@ export function CreateItemButton({ workspaceId }: CreateItemButtonProps) {
         </button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="start" sideOffset={4}>
-        <CreateFolderButton workspaceId={workspaceId} onOpenChange={setOpen} />
-        <CreateTableButton workspaceId={workspaceId} onOpenChange={setOpen} />
+        <CreateFolderButton parentId={parentId} onOpenChange={setOpen} />
+        <CreateTableButton parentId={parentId} onOpenChange={setOpen} />
       </DropdownMenuContent>
     </DropdownMenu>
   );

--- a/features/layout/components/workspace-menu/item.tsx
+++ b/features/layout/components/workspace-menu/item.tsx
@@ -130,7 +130,7 @@ export function Item({
               <span>{item.name}</span>
             </Link>
             <EditItemButton itemId={item.id} itemName={item.name} />
-            {config.showAddButton && <CreateItemButton workspaceId={item.id} />}
+            {config.showAddButton && <CreateItemButton parentId={item.id} />}
           </div>
         </SidebarMenuButton>
 
@@ -214,7 +214,7 @@ export function Item({
             <span>{item.name}</span>
           </Link>
           <EditItemButton itemId={item.id} itemName={item.name} />
-          {config.showAddButton && <CreateItemButton workspaceId={item.id} />}
+          {config.showAddButton && <CreateItemButton parentId={item.id} />}
         </div>
       </SidebarMenuSubButton>
 

--- a/features/layout/components/workspace-menu/items.tsx
+++ b/features/layout/components/workspace-menu/items.tsx
@@ -78,7 +78,7 @@ export function WorkspaceItemsWrapper({ items }: WorkspaceItemsWrapperProps) {
             <Link href="/workspace" className="flex-1">
               <span>ワークスペース</span>
             </Link>
-            <CreateItemButton workspaceId="" />
+            <CreateItemButton parentId="" />
           </div>
         </SidebarGroupLabel>
         <SidebarMenu ref={setWorkspaceMenuRef}>
@@ -110,7 +110,7 @@ export function WorkspaceItemsWrapper({ items }: WorkspaceItemsWrapperProps) {
           <Link href="/workspace" className="flex-1">
             <span>ワークスペース</span>
           </Link>
-          <CreateItemButton workspaceId="" />
+          <CreateItemButton parentId="" />
         </div>
       </SidebarGroupLabel>
       <SidebarMenu ref={setWorkspaceMenuRef} className="min-h-[200px]">


### PR DESCRIPTION
## 概要

Iテーブルごとに動的なカラム定義を管理できる機能を実装しました。
カラム情報はItemモデルの`meta`フィールド（JSONB型）に保存され、ユーザーが自由にテーブルの設計図を作成できるようになります。

## 実装内容

### 1. カラム型定義（`features/column/types/`）
- **6つのカラム型をサポート**: TEXT, TEXTAREA, NUMBER, DATE, SELECT, CHECKBOX
- **将来の拡張性を考慮した設計**:
  - 日付フォーマット: YYYY-MM-DD（現在）、YYYY-MM、YYYY-MM-DD HH:mm等（将来実装）
  - 選択肢: 単一選択（現在）、複数選択（将来実装）
- **Discriminated Union型**: 型安全なカラム定義とバリデーション
- **JSONBスキーマ**: `Item.meta`に以下の構造で保存
  ```json
  {
    "schema": {
      "columns": [
        {
          "id": "...",
          "name": "カラム名",
          "type": "TEXT",
          "order": 0,
          "validation": { "required": true }
        }
      ]
    },
    "version": 1
  }
  ```

### 2. スキーマ操作ユーティリティ（`features/column/utils/`）
- **イミュータブルな操作関数**:
  - `addColumnToSchema`: カラム追加
  - `updateColumnInSchema`: カラム更新
  - `removeColumnFromSchema`: カラム削除
  - `reorderColumnInSchema`: カラム並び替え
- **バリデーション関数**: カラム値の型チェックとバリデーション実行

### 3. カラム管理API（`features/column/api/`）
- **4つのServer Actions**:
  - `addColumn`: カラム追加（認証・権限チェック込み）
  - `updateColumn`: カラム更新
  - `removeColumn`: カラム削除
  - `reorderColumn`: カラム並び替え
- **包括的なテストカバレッジ**: 38テスト（全て成功）
  - 成功ケース、認証失敗、バリデーションエラー、権限エラー、DBエラー

### 4. カラム管理UI（`features/column/components/`）
- **ColumnList**: カラム一覧表示と追加ボタン
- **AddColumnDialog**: カラム追加ダイアログ（名前・型・必須フラグ）
- **EditColumnItem**: カラム編集UI
- **DeleteColumnItem**: カラム削除UI
- **ColumnListItem**: カラムアイテム表示（ドラッグ&ドロップUI準備済み）

### 5. Config-Driven UI（`features/column/constants/`）
- **COLUMN_CONFIGS**: 各カラム型の設定を一元管理
  - アイコン、ラベル、説明、入力フィールド設定
  - 新しいカラム型の追加が容易

### 6. 既存機能の改善
- **ルート変更**: `[workspaceId]` → `[itemId]`（より汎用的な命名）
- **CreateItemButton**: `workspaceId` → `parentId`プロパティ名の統一
- **テーブル詳細ページ**: TABLE型の場合にカラム管理UIを表示

## 動作確認

- [x] テーブル作成後、カラム管理セクションが表示される
- [x] カラム追加ダイアログで6種類の型を選択できる
- [x] カラム名、型、必須フラグを設定してカラムを追加できる
- [x] 追加したカラムが一覧に表示される
- [x] カラムの編集・削除ができる
- [x] 全テストが成功（38テスト）
- [x] ビルドが成功し、ESLint警告なし

## 制約事項

- **レコードデータの実装は未実装**: 今回はテーブルの「設計図」を作成する機能のみ
  - レコードの入力・表示は別Issue（次のステップ）で実装予定
- **ドラッグ&ドロップ**: UIは準備済みだが、機能は未接続
- **詳細設定**: SELECT型のoptions、NUMBER型のmin/max等は将来実装

## 関連Issue

Closes #23