### PR TITLE
セレクト/マルチセレクトカラムの選択肢設定機能

### DIFF
--- a/components/ui/breadcrumb.tsx
+++ b/components/ui/breadcrumb.tsx
@@ -13,7 +13,7 @@ function BreadcrumbList({ className, ...props }: React.ComponentProps<'ol'>) {
     <ol
       data-slot="breadcrumb-list"
       className={cn(
-        'text-muted-foreground flex flex-wrap items-center gap-1.5 text-sm break-words sm:gap-2.5',
+        'text-muted-foreground flex flex-wrap items-center gap-1.5 text-sm wrap-break-word sm:gap-2.5',
         className
       )}
       {...props}

--- a/features/column/api/__tests__/update-column.test.ts
+++ b/features/column/api/__tests__/update-column.test.ts
@@ -252,4 +252,143 @@ describe('updateColumn', () => {
       error: 'カラムの更新に失敗しました',
     });
   });
+
+  describe('SELECT/MULTI_SELECTカラムの選択肢設定', () => {
+    const mockSelectItem = {
+      id: 'item-1',
+      type: 'TABLE',
+      createdById: 'user-1',
+      meta: {
+        schema: {
+          columns: [
+            {
+              id: 'col-1',
+              name: 'ステータス',
+              type: 'SELECT',
+              order: 0,
+              config: {
+                options: [
+                  { id: 'opt-1', label: '未着手', color: '#gray' },
+                  { id: 'opt-2', label: '進行中', color: '#blue' },
+                ],
+              },
+            },
+          ],
+        },
+        version: 1,
+      },
+    };
+
+    it('SELECTカラムの選択肢を更新できる', async () => {
+      (createClient as jest.Mock).mockResolvedValue(mockUser);
+      (prisma.user.findUnique as jest.Mock).mockResolvedValue(mockDbUser);
+      (prisma.item.findUnique as jest.Mock).mockResolvedValue(mockSelectItem);
+      (prisma.item.update as jest.Mock).mockResolvedValue(mockSelectItem);
+
+      const result = await updateColumn('item-1', 'col-1', {
+        config: {
+          options: [
+            { id: 'opt-1', label: '未着手', color: '#gray' },
+            { id: 'opt-2', label: '進行中', color: '#blue' },
+            { id: 'opt-3', label: '完了', color: '#green' },
+          ],
+          defaultValue: 'opt-1',
+        } as never,
+      });
+
+      expect(result).toEqual({ success: true });
+      expect(prisma.item.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { id: 'item-1' },
+          data: {
+            meta: expect.objectContaining({
+              schema: expect.objectContaining({
+                columns: expect.arrayContaining([
+                  expect.objectContaining({
+                    id: 'col-1',
+                    config: expect.objectContaining({
+                      options: expect.arrayContaining([
+                        expect.objectContaining({ id: 'opt-3', label: '完了' }),
+                      ]),
+                      defaultValue: 'opt-1',
+                    }),
+                  }),
+                ]),
+              }),
+            }),
+          },
+        })
+      );
+    });
+
+    it('MULTI_SELECTカラムの選択肢を更新できる', async () => {
+      const mockMultiSelectItem = {
+        ...mockSelectItem,
+        meta: {
+          schema: {
+            columns: [
+              {
+                id: 'col-1',
+                name: 'タグ',
+                type: 'MULTI_SELECT',
+                order: 0,
+                config: {
+                  options: [
+                    { id: 'opt-1', label: 'タグ1', color: '#red' },
+                    { id: 'opt-2', label: 'タグ2', color: '#blue' },
+                  ],
+                },
+              },
+            ],
+          },
+          version: 1,
+        },
+      };
+
+      (createClient as jest.Mock).mockResolvedValue(mockUser);
+      (prisma.user.findUnique as jest.Mock).mockResolvedValue(mockDbUser);
+      (prisma.item.findUnique as jest.Mock).mockResolvedValue(
+        mockMultiSelectItem
+      );
+      (prisma.item.update as jest.Mock).mockResolvedValue(mockMultiSelectItem);
+
+      const result = await updateColumn('item-1', 'col-1', {
+        config: {
+          options: [
+            { id: 'opt-1', label: 'タグ1', color: '#red' },
+            { id: 'opt-2', label: 'タグ2', color: '#blue' },
+            { id: 'opt-3', label: 'タグ3', color: '#green' },
+          ],
+          defaultValue: ['opt-1', 'opt-2'],
+        } as never,
+      });
+
+      expect(result).toEqual({ success: true });
+      expect(prisma.item.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { id: 'item-1' },
+          data: {
+            meta: expect.objectContaining({
+              schema: expect.objectContaining({
+                columns: expect.arrayContaining([
+                  expect.objectContaining({
+                    id: 'col-1',
+                    config: expect.objectContaining({
+                      options: expect.arrayContaining([
+                        expect.objectContaining({
+                          id: 'opt-3',
+                          label: 'タグ3',
+                        }),
+                      ]),
+                      defaultValue: ['opt-1', 'opt-2'],
+                    }),
+                  }),
+                ]),
+              }),
+            }),
+          },
+        })
+      );
+    });
+  });
 });

--- a/features/column/components/add-column-dialog.tsx
+++ b/features/column/components/add-column-dialog.tsx
@@ -21,8 +21,9 @@ import {
 import { Checkbox } from '@/components/ui/checkbox';
 import { toast } from 'sonner';
 import { addColumn } from '../api/add-column';
-import type { ColumnType } from '../types/column';
+import type { ColumnType, SelectOption } from '../types/column';
 import { COLUMN_TYPE_LIST, COLUMN_CONFIGS } from '../constants';
+import { SelectOptionsEditor } from './config/select-options-editor';
 
 /**
  * カラム追加ダイアログのProps型
@@ -48,37 +49,77 @@ export function AddColumnDialog({
   const [isRequired, setIsRequired] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
 
+  // SELECT/MULTI_SELECT用の状態
+  const [selectOptions, setSelectOptions] = useState<SelectOption[]>([]);
+  const [defaultValue, setDefaultValue] = useState<string | string[]>('');
+
   // ダイアログが閉じられたときに状態をリセット
   useEffect(() => {
     if (!open) {
       setColumnType('TEXT');
       setColumnName('');
       setIsRequired(false);
+      setSelectOptions([]);
+      setDefaultValue('');
     }
   }, [open]);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
+
+    // SELECT/MULTI_SELECTの場合、選択肢が必須
+    if (
+      (columnType === 'SELECT' || columnType === 'MULTI_SELECT') &&
+      selectOptions.length === 0
+    ) {
+      toast.error('選択肢を少なくとも1つ追加してください');
+      return;
+    }
+
+    // 空ラベルのチェック
+    if (
+      (columnType === 'SELECT' || columnType === 'MULTI_SELECT') &&
+      selectOptions.some((opt) => !opt.label.trim())
+    ) {
+      toast.error('すべての選択肢にラベルを入力してください');
+      return;
+    }
+
     setIsSubmitting(true);
 
     try {
+      // configの構築
+      let config;
+      if (columnType === 'SELECT') {
+        config = {
+          options: selectOptions,
+          defaultValue: defaultValue as string,
+        };
+      } else if (columnType === 'MULTI_SELECT') {
+        config = {
+          options: selectOptions,
+          defaultValue: defaultValue as string[],
+        };
+      }
+
       const result = await addColumn(itemId, {
         name: columnName,
         type: columnType,
         order: nextOrder,
         validation: isRequired ? { required: true } : undefined,
+        config: config as never,
       });
 
       if (result.error) {
-        toast.error('カラムの追加に失敗しました', {
+        toast.error('項目の追加に失敗しました', {
           description: result.error,
         });
       } else if (result.success) {
-        toast.success('カラムを追加しました');
+        toast.success('項目を追加しました');
         onOpenChange(false);
       }
     } catch {
-      toast.error('カラムの追加に失敗しました');
+      toast.error('項目の追加に失敗しました');
     } finally {
       setIsSubmitting(false);
     }
@@ -86,51 +127,68 @@ export function AddColumnDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-[425px]">
+      <DialogContent className="sm:max-w-[600px] max-h-[90vh] overflow-y-auto">
         <DialogHeader>
-          <DialogTitle>カラムを追加</DialogTitle>
+          <DialogTitle>項目を追加</DialogTitle>
         </DialogHeader>
         <form onSubmit={handleSubmit}>
           <div className="grid gap-4 py-4">
             <div className="grid gap-2">
-              <Label htmlFor="name">カラム名</Label>
+              <Label htmlFor="name">項目名</Label>
               <Input
                 id="name"
                 value={columnName}
                 onChange={(e) => setColumnName(e.target.value)}
-                placeholder="顧客名"
+                placeholder="項目名"
                 required
               />
             </div>
 
             <div className="grid gap-2">
               <Label htmlFor="type">タイプ</Label>
-              <Select
-                value={columnType}
-                onValueChange={(value) => setColumnType(value as ColumnType)}
-              >
-                <SelectTrigger>
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  {COLUMN_TYPE_LIST.map((type) => {
-                    const config = COLUMN_CONFIGS[type];
-                    const Icon = config.icon;
-                    return (
-                      <SelectItem key={type} value={type}>
-                        <div className="flex items-center gap-2">
-                          <Icon className="h-4 w-4" />
-                          <span>{config.label}</span>
-                        </div>
-                      </SelectItem>
-                    );
-                  })}
-                </SelectContent>
-              </Select>
-              <p className="text-xs text-muted-foreground">
-                {COLUMN_CONFIGS[columnType].description}
-              </p>
+              <div className="flex items-center gap-3">
+                <Select
+                  value={columnType}
+                  onValueChange={(value) => setColumnType(value as ColumnType)}
+                >
+                  <SelectTrigger className="w-[200px]">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {COLUMN_TYPE_LIST.map((type) => {
+                      const config = COLUMN_CONFIGS[type];
+                      const Icon = config.icon;
+                      return (
+                        <SelectItem key={type} value={type}>
+                          <div className="flex items-center gap-2">
+                            <Icon className="h-4 w-4" />
+                            <span>{config.label}</span>
+                          </div>
+                        </SelectItem>
+                      );
+                    })}
+                  </SelectContent>
+                </Select>
+                <p className="text-xs text-muted-foreground flex-1">
+                  {COLUMN_CONFIGS[columnType].description}
+                </p>
+              </div>
             </div>
+
+            {/* SELECT/MULTI_SELECT用の選択肢設定 */}
+            {(columnType === 'SELECT' || columnType === 'MULTI_SELECT') && (
+              <SelectOptionsEditor
+                options={selectOptions}
+                defaultValue={defaultValue}
+                isMultiSelect={columnType === 'MULTI_SELECT'}
+                onChange={(options, defValue) => {
+                  setSelectOptions(options);
+                  setDefaultValue(
+                    defValue || (columnType === 'MULTI_SELECT' ? [] : '')
+                  );
+                }}
+              />
+            )}
 
             <div className="flex items-center space-x-2">
               <Checkbox

--- a/features/column/components/column-item.tsx
+++ b/features/column/components/column-item.tsx
@@ -26,6 +26,7 @@ type ColumnItemProps = {
   onUpdated?: (updated: {
     name: string;
     validation?: { required: boolean };
+    config?: unknown;
   }) => void;
 };
 

--- a/features/column/components/config/select-options-editor.tsx
+++ b/features/column/components/config/select-options-editor.tsx
@@ -1,0 +1,315 @@
+'use client';
+
+import { useState } from 'react';
+import { Plus, GripVertical, Trash2, Check } from 'lucide-react';
+import { nanoid } from 'nanoid';
+import {
+  DndContext,
+  closestCenter,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+} from '@dnd-kit/core';
+import {
+  SortableContext,
+  sortableKeyboardCoordinates,
+  verticalListSortingStrategy,
+  useSortable,
+} from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Checkbox } from '@/components/ui/checkbox';
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@/components/ui/popover';
+import { COLOR_PALETTE, DEFAULT_COLOR } from '../../constants';
+import type { SelectOption } from '../../types';
+
+/**
+ * SelectOptionsEditorのProps型
+ */
+type SelectOptionsEditorProps = {
+  options: SelectOption[];
+  defaultValue?: string | string[];
+  isMultiSelect?: boolean;
+  onChange: (options: SelectOption[], defaultValue?: string | string[]) => void;
+};
+
+/**
+ * 選択肢アイテムのProps型
+ */
+type OptionItemProps = {
+  option: SelectOption;
+  isDefault: boolean;
+  isMultiSelect: boolean;
+  onLabelChange: (id: string, label: string) => void;
+  onColorChange: (id: string, color: string) => void;
+  onDelete: (id: string) => void;
+  onToggleDefault: (id: string) => void;
+};
+
+/**
+ * 選択肢アイテムコンポーネント
+ */
+function OptionItem({
+  option,
+  isDefault,
+  isMultiSelect,
+  onLabelChange,
+  onColorChange,
+  onDelete,
+  onToggleDefault,
+}: OptionItemProps) {
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id: option.id });
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.5 : 1,
+  };
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={style}
+      className="flex items-center gap-2 p-2 bg-background border rounded-lg"
+    >
+      {/* ドラッグハンドル */}
+      <button
+        type="button"
+        className="cursor-grab active:cursor-grabbing text-muted-foreground hover:text-foreground"
+        {...attributes}
+        {...listeners}
+      >
+        <GripVertical className="size-4" />
+      </button>
+
+      {/* カラー選択 */}
+      <Popover>
+        <PopoverTrigger asChild>
+          <button
+            type="button"
+            className="size-6 rounded-full border-2 border-border hover:scale-110 transition-transform"
+            style={{ backgroundColor: option.color || DEFAULT_COLOR }}
+          />
+        </PopoverTrigger>
+        <PopoverContent className="w-auto p-3">
+          <div className="grid grid-cols-3 gap-2">
+            {COLOR_PALETTE.map((color) => (
+              <button
+                key={color.value}
+                type="button"
+                className="size-8 rounded-full border-2 border-border hover:scale-110 transition-transform relative"
+                style={{ backgroundColor: color.value }}
+                onClick={() => onColorChange(option.id, color.value)}
+                title={color.name}
+              >
+                {option.color === color.value && (
+                  <Check className="size-4 text-white absolute inset-0 m-auto" />
+                )}
+              </button>
+            ))}
+          </div>
+        </PopoverContent>
+      </Popover>
+
+      {/* ラベル入力 */}
+      <Input
+        value={option.label}
+        onChange={(e) => onLabelChange(option.id, e.target.value)}
+        placeholder="選択肢のラベル"
+        className="flex-1"
+      />
+
+      {/* デフォルト値設定 */}
+      {isMultiSelect ? (
+        <Checkbox
+          checked={isDefault}
+          onCheckedChange={() => onToggleDefault(option.id)}
+          title="デフォルト値に設定"
+        />
+      ) : (
+        <button
+          type="button"
+          onClick={() => onToggleDefault(option.id)}
+          className={`size-5 rounded-full border-2 ${
+            isDefault ? 'border-primary bg-primary' : 'border-muted-foreground'
+          }`}
+          title="デフォルト値に設定"
+        >
+          {isDefault && <Check className="size-3 text-white m-auto" />}
+        </button>
+      )}
+
+      {/* 削除ボタン */}
+      <button
+        type="button"
+        onClick={() => onDelete(option.id)}
+        className="text-muted-foreground hover:text-destructive transition-colors"
+      >
+        <Trash2 className="size-4" />
+      </button>
+    </div>
+  );
+}
+
+/**
+ * SELECT/MULTI_SELECT用の選択肢エディターコンポーネント
+ */
+export function SelectOptionsEditor({
+  options,
+  defaultValue,
+  isMultiSelect = false,
+  onChange,
+}: SelectOptionsEditorProps) {
+  const [localOptions, setLocalOptions] = useState<SelectOption[]>(options);
+  const [localDefaultValue, setLocalDefaultValue] = useState<string | string[]>(
+    defaultValue || (isMultiSelect ? [] : '')
+  );
+
+  // DnDセンサーの設定
+  const sensors = useSensors(
+    useSensor(PointerSensor),
+    useSensor(KeyboardSensor, {
+      coordinateGetter: sortableKeyboardCoordinates,
+    })
+  );
+
+  // 選択肢追加
+  const handleAddOption = () => {
+    const newOption: SelectOption = {
+      id: nanoid(),
+      label: '',
+      color: DEFAULT_COLOR,
+    };
+    const newOptions = [...localOptions, newOption];
+    setLocalOptions(newOptions);
+    onChange(newOptions, localDefaultValue);
+  };
+
+  // ラベル変更
+  const handleLabelChange = (id: string, label: string) => {
+    const newOptions = localOptions.map((opt) =>
+      opt.id === id ? { ...opt, label } : opt
+    );
+    setLocalOptions(newOptions);
+    onChange(newOptions, localDefaultValue);
+  };
+
+  // カラー変更
+  const handleColorChange = (id: string, color: string) => {
+    const newOptions = localOptions.map((opt) =>
+      opt.id === id ? { ...opt, color } : opt
+    );
+    setLocalOptions(newOptions);
+    onChange(newOptions, localDefaultValue);
+  };
+
+  // 選択肢削除
+  const handleDelete = (id: string) => {
+    const newOptions = localOptions.filter((opt) => opt.id !== id);
+    setLocalOptions(newOptions);
+
+    // デフォルト値から削除
+    let newDefaultValue = localDefaultValue;
+    if (isMultiSelect && Array.isArray(localDefaultValue)) {
+      newDefaultValue = localDefaultValue.filter((val) => val !== id);
+    } else if (localDefaultValue === id) {
+      newDefaultValue = '';
+    }
+    setLocalDefaultValue(newDefaultValue);
+    onChange(newOptions, newDefaultValue);
+  };
+
+  // デフォルト値のトグル
+  const handleToggleDefault = (id: string) => {
+    let newDefaultValue: string | string[];
+    if (isMultiSelect) {
+      const current = (localDefaultValue as string[]) || [];
+      if (current.includes(id)) {
+        newDefaultValue = current.filter((val) => val !== id);
+      } else {
+        newDefaultValue = [...current, id];
+      }
+    } else {
+      newDefaultValue = localDefaultValue === id ? '' : id;
+    }
+    setLocalDefaultValue(newDefaultValue);
+    onChange(localOptions, newDefaultValue);
+  };
+
+  // ドラッグ終了時のハンドラ
+  const handleDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event;
+
+    if (over && active.id !== over.id) {
+      const oldIndex = localOptions.findIndex((opt) => opt.id === active.id);
+      const newIndex = localOptions.findIndex((opt) => opt.id === over.id);
+
+      const newOptions = [...localOptions];
+      const [movedOption] = newOptions.splice(oldIndex, 1);
+      newOptions.splice(newIndex, 0, movedOption);
+      setLocalOptions(newOptions);
+      onChange(newOptions, localDefaultValue);
+    }
+  };
+
+  return (
+    <div>
+      <div>
+        <Label className="mb-3">選択肢</Label>
+        <DndContext
+          sensors={sensors}
+          collisionDetection={closestCenter}
+          onDragEnd={handleDragEnd}
+        >
+          <SortableContext
+            items={localOptions.map((opt) => opt.id)}
+            strategy={verticalListSortingStrategy}
+          >
+            <div className="space-y-2">
+              {localOptions.map((option) => (
+                <OptionItem
+                  key={option.id}
+                  option={option}
+                  isDefault={
+                    isMultiSelect
+                      ? (localDefaultValue as string[])?.includes(option.id) ||
+                        false
+                      : localDefaultValue === option.id
+                  }
+                  isMultiSelect={isMultiSelect}
+                  onLabelChange={handleLabelChange}
+                  onColorChange={handleColorChange}
+                  onDelete={handleDelete}
+                  onToggleDefault={handleToggleDefault}
+                />
+              ))}
+              {/* 選択肢を追加ボタン */}
+              <button
+                type="button"
+                onClick={handleAddOption}
+                className="flex items-center gap-2 w-full p-3 border border-dashed rounded-lg text-muted-foreground hover:bg-accent/50 hover:text-foreground transition-colors"
+              >
+                <Plus className="size-4" />
+                <span className="text-sm">選択肢を追加</span>
+              </button>
+            </div>
+          </SortableContext>
+        </DndContext>
+      </div>
+    </div>
+  );
+}

--- a/features/column/components/edit-column-item.tsx
+++ b/features/column/components/edit-column-item.tsx
@@ -17,7 +17,8 @@ import { Checkbox } from '@/components/ui/checkbox';
 import { Pencil } from 'lucide-react';
 import { toast } from 'sonner';
 import { updateColumn } from '../api/update-column';
-import type { Column } from '../types/column';
+import type { Column, SelectOption } from '../types/column';
+import { SelectOptionsEditor } from './config/select-options-editor';
 
 /**
  * カラム編集アイテムのProps型
@@ -29,6 +30,7 @@ type EditColumnItemProps = {
   onUpdated?: (updated: {
     name: string;
     validation?: { required: boolean };
+    config?: unknown;
   }) => void;
 };
 
@@ -48,38 +50,86 @@ export function EditColumnItem({
   );
   const [isSubmitting, setIsSubmitting] = useState(false);
 
+  // SELECT/MULTI_SELECT用の状態
+  const [selectOptions, setSelectOptions] = useState<SelectOption[]>([]);
+  const [defaultValue, setDefaultValue] = useState<string | string[]>('');
+
   // ダイアログが開かれたときに最新の値をセット
   useEffect(() => {
     if (open) {
       setColumnName(column.name);
       setIsRequired(column.validation?.required || false);
+
+      // SELECT/MULTI_SELECTの場合、configから値を取得
+      if (column.type === 'SELECT' || column.type === 'MULTI_SELECT') {
+        const config = column.config;
+        setSelectOptions(config?.options || []);
+        setDefaultValue(
+          config?.defaultValue || (column.type === 'MULTI_SELECT' ? [] : '')
+        );
+      }
     }
   }, [open, column]);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
+
+    // SELECT/MULTI_SELECTの場合、選択肢が必須
+    if (
+      (column.type === 'SELECT' || column.type === 'MULTI_SELECT') &&
+      selectOptions.length === 0
+    ) {
+      toast.error('選択肢を少なくとも1つ追加してください');
+      return;
+    }
+
+    // 空ラベルのチェック
+    if (
+      (column.type === 'SELECT' || column.type === 'MULTI_SELECT') &&
+      selectOptions.some((opt) => !opt.label.trim())
+    ) {
+      toast.error('すべての選択肢にラベルを入力してください');
+      return;
+    }
+
     setIsSubmitting(true);
 
     try {
+      // configの構築
+      let config;
+      if (column.type === 'SELECT') {
+        config = {
+          options: selectOptions,
+          defaultValue: defaultValue as string,
+        };
+      } else if (column.type === 'MULTI_SELECT') {
+        config = {
+          options: selectOptions,
+          defaultValue: defaultValue as string[],
+        };
+      }
+
       const result = await updateColumn(itemId, column.id, {
         name: columnName,
-        validation: isRequired ? { required: true } : { required: false },
+        validation: isRequired ? { required: true } : undefined,
+        config: config as never,
       });
 
       if (result.error) {
-        toast.error('カラムの更新に失敗しました', {
+        toast.error('項目の更新に失敗しました', {
           description: result.error,
         });
       } else if (result.success) {
-        toast.success('カラムを更新しました');
+        toast.success('項目を更新しました');
         setOpen(false);
         onUpdated?.({
           name: columnName,
           validation: { required: isRequired },
+          config: config as never,
         });
       }
     } catch {
-      toast.error('カラムの更新に失敗しました');
+      toast.error('項目の更新に失敗しました');
     } finally {
       setIsSubmitting(false);
     }
@@ -101,22 +151,37 @@ export function EditColumnItem({
           編集
         </DropdownMenuItem>
       </DialogTrigger>
-      <DialogContent className="sm:max-w-[425px]">
+      <DialogContent className="sm:max-w-[600px] max-h-[90vh] overflow-y-auto">
         <DialogHeader>
-          <DialogTitle>カラムを編集</DialogTitle>
+          <DialogTitle>項目を編集</DialogTitle>
         </DialogHeader>
         <form onSubmit={handleSubmit}>
           <div className="grid gap-4 py-4">
             <div className="grid gap-2">
-              <Label htmlFor="edit-name">カラム名</Label>
+              <Label htmlFor="edit-name">項目名</Label>
               <Input
                 id="edit-name"
                 value={columnName}
                 onChange={(e) => setColumnName(e.target.value)}
-                placeholder="顧客名"
+                placeholder="項目名"
                 required
               />
             </div>
+
+            {/* SELECT/MULTI_SELECT用の選択肢設定 */}
+            {(column.type === 'SELECT' || column.type === 'MULTI_SELECT') && (
+              <SelectOptionsEditor
+                options={selectOptions}
+                defaultValue={defaultValue}
+                isMultiSelect={column.type === 'MULTI_SELECT'}
+                onChange={(options, defValue) => {
+                  setSelectOptions(options);
+                  setDefaultValue(
+                    defValue || (column.type === 'MULTI_SELECT' ? [] : '')
+                  );
+                }}
+              />
+            )}
 
             <div className="flex items-center space-x-2">
               <Checkbox

--- a/features/column/constants/color-palette.ts
+++ b/features/column/constants/color-palette.ts
@@ -1,0 +1,19 @@
+/**
+ * 選択肢に使用できるカラーパレット
+ */
+export const COLOR_PALETTE = [
+  { name: 'グレー', value: '#6b7280' },
+  { name: 'レッド', value: '#ef4444' },
+  { name: 'オレンジ', value: '#f97316' },
+  { name: 'イエロー', value: '#eab308' },
+  { name: 'グリーン', value: '#22c55e' },
+  { name: 'ブルー', value: '#3b82f6' },
+  { name: 'インディゴ', value: '#6366f1' },
+  { name: 'パープル', value: '#a855f7' },
+  { name: 'ピンク', value: '#ec4899' },
+] as const;
+
+/**
+ * デフォルトのカラー（グレー）
+ */
+export const DEFAULT_COLOR = COLOR_PALETTE[0].value;

--- a/features/column/constants/index.ts
+++ b/features/column/constants/index.ts
@@ -1,1 +1,2 @@
 export * from './column-config';
+export * from './color-palette';

--- a/features/column/types/column.ts
+++ b/features/column/types/column.ts
@@ -59,11 +59,11 @@ export type ColumnTypeConfig = {
   };
   SELECT: {
     options: SelectOption[];
-    allowCustom?: boolean; // カスタム入力を許可するか
+    defaultValue?: string; // デフォルト値（選択肢のID）
   };
   MULTI_SELECT: {
     options: SelectOption[];
-    allowCustom?: boolean; // カスタム入力を許可するか
+    defaultValue?: string[]; // デフォルト値（選択肢のIDの配列）
   };
   CHECKBOX: {
     multiple?: boolean; // 複数選択を許可するか（将来実装）

--- a/features/column/utils/__tests__/apply-default-values.test.ts
+++ b/features/column/utils/__tests__/apply-default-values.test.ts
@@ -1,0 +1,156 @@
+import { applyDefaultValues } from '../apply-default-values';
+import type {
+  SelectColumn,
+  MultiSelectColumn,
+  TextColumn,
+} from '../../types/column';
+
+describe('applyDefaultValues', () => {
+  it('SELECT型のデフォルト値を適用する', () => {
+    const columns: SelectColumn[] = [
+      {
+        id: 'col-1',
+        name: 'ステータス',
+        type: 'SELECT',
+        order: 0,
+        config: {
+          options: [
+            { id: 'opt-1', label: '未着手' },
+            { id: 'opt-2', label: '進行中' },
+          ],
+          defaultValue: 'opt-1',
+        },
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+    ];
+
+    const result = applyDefaultValues(columns);
+
+    expect(result).toEqual({
+      'col-1': 'opt-1',
+    });
+  });
+
+  it('MULTI_SELECT型のデフォルト値を適用する', () => {
+    const columns: MultiSelectColumn[] = [
+      {
+        id: 'col-1',
+        name: 'タグ',
+        type: 'MULTI_SELECT',
+        order: 0,
+        config: {
+          options: [
+            { id: 'opt-1', label: 'タグ1' },
+            { id: 'opt-2', label: 'タグ2' },
+          ],
+          defaultValue: ['opt-1', 'opt-2'],
+        },
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+    ];
+
+    const result = applyDefaultValues(columns);
+
+    expect(result).toEqual({
+      'col-1': ['opt-1', 'opt-2'],
+    });
+  });
+
+  it('デフォルト値がないSELECT型は値を設定しない', () => {
+    const columns: SelectColumn[] = [
+      {
+        id: 'col-1',
+        name: 'ステータス',
+        type: 'SELECT',
+        order: 0,
+        config: {
+          options: [
+            { id: 'opt-1', label: '未着手' },
+            { id: 'opt-2', label: '進行中' },
+          ],
+        },
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+    ];
+
+    const result = applyDefaultValues(columns);
+
+    expect(result).toEqual({});
+  });
+
+  it('TEXT型など他のカラムタイプは値を設定しない', () => {
+    const columns: TextColumn[] = [
+      {
+        id: 'col-1',
+        name: '顧客名',
+        type: 'TEXT',
+        order: 0,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+    ];
+
+    const result = applyDefaultValues(columns);
+
+    expect(result).toEqual({});
+  });
+
+  it('複数のカラムがある場合、デフォルト値があるものだけ適用する', () => {
+    const columns = [
+      {
+        id: 'col-1',
+        name: '顧客名',
+        type: 'TEXT' as const,
+        order: 0,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+      {
+        id: 'col-2',
+        name: 'ステータス',
+        type: 'SELECT' as const,
+        order: 1,
+        config: {
+          options: [
+            { id: 'opt-1', label: '未着手' },
+            { id: 'opt-2', label: '進行中' },
+          ],
+          defaultValue: 'opt-1',
+        },
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+      {
+        id: 'col-3',
+        name: 'タグ',
+        type: 'MULTI_SELECT' as const,
+        order: 2,
+        config: {
+          options: [
+            { id: 'tag-1', label: 'タグ1' },
+            { id: 'tag-2', label: 'タグ2' },
+          ],
+          defaultValue: ['tag-1'],
+        },
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+    ];
+
+    const result = applyDefaultValues(columns);
+
+    expect(result).toEqual({
+      'col-2': 'opt-1',
+      'col-3': ['tag-1'],
+    });
+  });
+
+  it('空のカラム配列の場合は空オブジェクトを返す', () => {
+    const result = applyDefaultValues([]);
+
+    expect(result).toEqual({});
+  });
+});

--- a/features/column/utils/__tests__/validate-column-value.test.ts
+++ b/features/column/utils/__tests__/validate-column-value.test.ts
@@ -1,0 +1,161 @@
+import { validateColumnValue } from '../validate-column-value';
+import type {
+  SelectColumn,
+  MultiSelectColumn,
+  TextColumn,
+} from '../../types/column';
+
+describe('validateColumnValue', () => {
+  describe('SELECT型のバリデーション', () => {
+    const selectColumn: SelectColumn = {
+      id: 'col-1',
+      name: 'ステータス',
+      type: 'SELECT',
+      order: 0,
+      config: {
+        options: [
+          { id: 'opt-1', label: '未着手' },
+          { id: 'opt-2', label: '進行中' },
+          { id: 'opt-3', label: '完了' },
+        ],
+      },
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+
+    it('有効な選択肢のIDはバリデーションを通過する', () => {
+      const result = validateColumnValue('opt-1', selectColumn);
+      expect(result).toBeNull();
+    });
+
+    it('無効な選択肢はエラーを返す', () => {
+      const result = validateColumnValue('invalid', selectColumn);
+      expect(result).toEqual({
+        columnId: 'col-1',
+        columnName: 'ステータス',
+        message: 'ステータスは有効な選択肢から選んでください',
+      });
+    });
+
+    it('required=trueで空値の場合はエラーを返す', () => {
+      const requiredColumn: SelectColumn = {
+        ...selectColumn,
+        validation: { required: true },
+      };
+      const result = validateColumnValue('', requiredColumn);
+      expect(result).toEqual({
+        columnId: 'col-1',
+        columnName: 'ステータス',
+        message: 'ステータスは必須項目です',
+      });
+    });
+
+    it('文字列以外の値はエラーを返す', () => {
+      const result = validateColumnValue(123, selectColumn);
+      expect(result).toEqual({
+        columnId: 'col-1',
+        columnName: 'ステータス',
+        message: 'ステータスは文字列である必要があります',
+      });
+    });
+  });
+
+  describe('MULTI_SELECT型のバリデーション', () => {
+    const multiSelectColumn: MultiSelectColumn = {
+      id: 'col-1',
+      name: 'タグ',
+      type: 'MULTI_SELECT',
+      order: 0,
+      config: {
+        options: [
+          { id: 'opt-1', label: 'タグ1' },
+          { id: 'opt-2', label: 'タグ2' },
+          { id: 'opt-3', label: 'タグ3' },
+        ],
+      },
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+
+    it('有効な選択肢のIDの配列はバリデーションを通過する', () => {
+      const result = validateColumnValue(['opt-1', 'opt-2'], multiSelectColumn);
+      expect(result).toBeNull();
+    });
+
+    it('空配列はバリデーションを通過する', () => {
+      const result = validateColumnValue([], multiSelectColumn);
+      expect(result).toBeNull();
+    });
+
+    it('無効な選択肢を含む配列はエラーを返す', () => {
+      const result = validateColumnValue(
+        ['opt-1', 'invalid'],
+        multiSelectColumn
+      );
+      expect(result).toEqual({
+        columnId: 'col-1',
+        columnName: 'タグ',
+        message: 'タグは有効な選択肢から選んでください',
+      });
+    });
+
+    it('required=trueで空配列の場合はエラーを返す', () => {
+      const requiredColumn: MultiSelectColumn = {
+        ...multiSelectColumn,
+        validation: { required: true },
+      };
+      const result = validateColumnValue([], requiredColumn);
+      expect(result).toEqual({
+        columnId: 'col-1',
+        columnName: 'タグ',
+        message: 'タグは必須項目です',
+      });
+    });
+
+    it('配列以外の値はエラーを返す', () => {
+      const result = validateColumnValue('string', multiSelectColumn);
+      expect(result).toEqual({
+        columnId: 'col-1',
+        columnName: 'タグ',
+        message: 'タグは配列である必要があります',
+      });
+    });
+  });
+
+  describe('その他のカラムタイプのバリデーション', () => {
+    it('TEXT型の基本的なバリデーション', () => {
+      const textColumn: TextColumn = {
+        id: 'col-1',
+        name: '顧客名',
+        type: 'TEXT',
+        order: 0,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+
+      const result = validateColumnValue('テスト', textColumn);
+      expect(result).toBeNull();
+    });
+
+    it('TEXT型でmaxLengthを超える場合はエラー', () => {
+      const textColumn: TextColumn = {
+        id: 'col-1',
+        name: '顧客名',
+        type: 'TEXT',
+        order: 0,
+        config: {
+          maxLength: 5,
+        },
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+
+      const result = validateColumnValue('あいうえおかきくけこ', textColumn);
+      expect(result).toEqual({
+        columnId: 'col-1',
+        columnName: '顧客名',
+        message: '顧客名は5文字以内で入力してください',
+      });
+    });
+  });
+});

--- a/features/column/utils/apply-default-values.ts
+++ b/features/column/utils/apply-default-values.ts
@@ -1,0 +1,26 @@
+import type { Column } from '../types/column';
+import type { RecordData } from '@/features/record/types';
+
+/**
+ * カラム定義に基づいてデフォルト値を適用
+ */
+export function applyDefaultValues(columns: Column[]): RecordData {
+  const data: RecordData = {};
+
+  for (const column of columns) {
+    // デフォルト値が定義されているカラムタイプを処理
+    if (column.type === 'SELECT' && column.config?.defaultValue) {
+      data[column.id] = column.config.defaultValue;
+    } else if (column.type === 'MULTI_SELECT' && column.config?.defaultValue) {
+      data[column.id] = column.config.defaultValue;
+    } else if (
+      column.type === 'CHECKBOX' &&
+      column.config?.defaultValue !== undefined
+    ) {
+      data[column.id] = column.config.defaultValue;
+    }
+    // 他のカラムタイプは明示的に値を設定しない（undefined）
+  }
+
+  return data;
+}

--- a/features/column/utils/index.ts
+++ b/features/column/utils/index.ts
@@ -1,2 +1,3 @@
 export * from './schema-operations';
 export * from './validate-column-value';
+export * from './apply-default-values';

--- a/features/column/utils/validate-column-value.ts
+++ b/features/column/utils/validate-column-value.ts
@@ -2,6 +2,7 @@ import type {
   Column,
   CheckboxColumn,
   DateColumn,
+  MultiSelectColumn,
   NumberColumn,
   SelectColumn,
   TextColumn,
@@ -42,6 +43,8 @@ export function validateColumnValue(
       return validateDateValue(value, column);
     case 'SELECT':
       return validateSelectValue(value, column);
+    case 'MULTI_SELECT':
+      return validateMultiSelectValue(value, column);
     case 'CHECKBOX':
       return validateCheckboxValue(value, column);
     default:
@@ -206,45 +209,64 @@ function validateSelectValue(
   value: unknown,
   column: SelectColumn
 ): ValidationError | null {
-  // 単一選択の場合
-  if (typeof value === 'string') {
-    const validOptionIds = column.config.options.map((opt) => opt.id);
+  if (typeof value !== 'string') {
+    return {
+      columnId: column.id,
+      columnName: column.name,
+      message: `${column.name}は文字列である必要があります`,
+    };
+  }
 
-    if (!validOptionIds.includes(value)) {
-      return {
-        columnId: column.id,
-        columnName: column.name,
-        message: `${column.name}は有効な選択肢から選んでください`,
-      };
-    }
+  const validOptionIds = column.config.options.map((opt) => opt.id);
 
+  // 選択肢のIDにマッチしない場合はエラー
+  if (!validOptionIds.includes(value)) {
+    return {
+      columnId: column.id,
+      columnName: column.name,
+      message: `${column.name}は有効な選択肢から選んでください`,
+    };
+  }
+
+  return null;
+}
+
+/**
+ * MULTI_SELECT型のバリデーション
+ */
+function validateMultiSelectValue(
+  value: unknown,
+  column: MultiSelectColumn
+): ValidationError | null {
+  if (!Array.isArray(value)) {
+    return {
+      columnId: column.id,
+      columnName: column.name,
+      message: `${column.name}は配列である必要があります`,
+    };
+  }
+
+  // 空配列の場合はOK
+  if (value.length === 0) {
     return null;
   }
 
-  // 複数選択の場合（将来実装）
-  if (Array.isArray(value)) {
-    const validOptionIds = column.config.options.map((opt) => opt.id);
+  const validOptionIds = column.config.options.map((opt) => opt.id);
 
-    const invalidValues = value.filter(
-      (v) => typeof v !== 'string' || !validOptionIds.includes(v)
-    );
+  // すべての値が選択肢のIDにマッチするかチェック
+  const invalidValues = value.filter(
+    (v) => typeof v !== 'string' || !validOptionIds.includes(v)
+  );
 
-    if (invalidValues.length > 0) {
-      return {
-        columnId: column.id,
-        columnName: column.name,
-        message: `${column.name}は有効な選択肢から選んでください`,
-      };
-    }
-
-    return null;
+  if (invalidValues.length > 0) {
+    return {
+      columnId: column.id,
+      columnName: column.name,
+      message: `${column.name}は有効な選択肢から選んでください`,
+    };
   }
 
-  return {
-    columnId: column.id,
-    columnName: column.name,
-    message: `${column.name}は文字列または配列である必要があります`,
-  };
+  return null;
 }
 
 /**

--- a/features/table/components/cells/multi-select-cell.tsx
+++ b/features/table/components/cells/multi-select-cell.tsx
@@ -10,20 +10,27 @@ type MultiSelectCellProps = {
   options: SelectOption[];
 };
 
-// タグの背景色
-const TAG_COLORS: Record<string, string> = {
-  gray: 'bg-gray-500/20 text-gray-300',
-  red: 'bg-red-500/20 text-red-300',
-  orange: 'bg-orange-500/20 text-orange-300',
-  yellow: 'bg-yellow-500/20 text-yellow-300',
-  green: 'bg-green-500/20 text-green-300',
-  blue: 'bg-blue-500/20 text-blue-300',
-  purple: 'bg-purple-500/20 text-purple-300',
-  pink: 'bg-pink-500/20 text-pink-300',
-};
+/**
+ * hex色から背景色と文字色のスタイルを生成
+ */
+function getColorStyles(color?: string): React.CSSProperties {
+  if (!color) {
+    return {
+      backgroundColor: 'rgba(107, 114, 128, 0.2)', // gray-500/20
+      color: 'rgb(209, 213, 219)', // gray-300
+    };
+  }
 
-function getColorClass(color?: string): string {
-  return TAG_COLORS[color || 'gray'] || TAG_COLORS.gray;
+  // hex色をrgbaに変換して20%透明度の背景色を作成
+  const hex = color.replace('#', '');
+  const r = parseInt(hex.substring(0, 2), 16);
+  const g = parseInt(hex.substring(2, 4), 16);
+  const b = parseInt(hex.substring(4, 6), 16);
+
+  return {
+    backgroundColor: `rgba(${r}, ${g}, ${b}, 0.2)`,
+    color: `rgb(${r}, ${g}, ${b})`,
+  };
 }
 
 /**
@@ -71,12 +78,6 @@ export function MultiSelectCell({
     }
   };
 
-  const handleRemove = (optionId: string, e: React.MouseEvent) => {
-    e.stopPropagation();
-    const newValue = selectedIds.filter((id) => id !== optionId);
-    onChange(newValue.length > 0 ? newValue : null);
-  };
-
   const handleKeyDown = (e: React.KeyboardEvent) => {
     if (e.key === 'Escape') {
       setIsOpen(false);
@@ -97,16 +98,10 @@ export function MultiSelectCell({
           selectedOptions.map((option) => (
             <span
               key={option.id}
-              className={`inline-flex items-center gap-1 px-2 py-0.5 rounded text-sm ${getColorClass(option.color)}`}
+              className="inline-flex items-center px-2 py-0.5 rounded text-sm"
+              style={getColorStyles(option.color)}
             >
               {option.label}
-              <button
-                type="button"
-                className="hover:bg-white/20 rounded-full p-0.5"
-                onClick={(e) => handleRemove(option.id, e)}
-              >
-                <X className="size-3" />
-              </button>
             </span>
           ))
         ) : (
@@ -129,7 +124,8 @@ export function MultiSelectCell({
                     onClick={() => handleToggle(option.id)}
                   >
                     <span
-                      className={`inline-flex items-center px-2 py-0.5 rounded text-sm ${getColorClass(option.color)}`}
+                      className="inline-flex items-center px-2 py-0.5 rounded text-sm"
+                      style={getColorStyles(option.color)}
                     >
                       {option.label}
                     </span>
@@ -153,7 +149,8 @@ export function MultiSelectCell({
                     onClick={() => handleToggle(option.id)}
                   >
                     <span
-                      className={`inline-flex items-center px-2 py-0.5 rounded text-sm ${getColorClass(option.color)}`}
+                      className="inline-flex items-center px-2 py-0.5 rounded text-sm"
+                      style={getColorStyles(option.color)}
                     >
                       {option.label}
                     </span>

--- a/features/table/components/cells/select-cell.tsx
+++ b/features/table/components/cells/select-cell.tsx
@@ -9,20 +9,27 @@ type SelectCellProps = {
   options: SelectOption[];
 };
 
-// タグの背景色
-const TAG_COLORS: Record<string, string> = {
-  gray: 'bg-gray-500/20 text-gray-300',
-  red: 'bg-red-500/20 text-red-300',
-  orange: 'bg-orange-500/20 text-orange-300',
-  yellow: 'bg-yellow-500/20 text-yellow-300',
-  green: 'bg-green-500/20 text-green-300',
-  blue: 'bg-blue-500/20 text-blue-300',
-  purple: 'bg-purple-500/20 text-purple-300',
-  pink: 'bg-pink-500/20 text-pink-300',
-};
+/**
+ * hex色から背景色と文字色のスタイルを生成
+ */
+function getColorStyles(color?: string): React.CSSProperties {
+  if (!color) {
+    return {
+      backgroundColor: 'rgba(107, 114, 128, 0.2)', // gray-500/20
+      color: 'rgb(209, 213, 219)', // gray-300
+    };
+  }
 
-function getColorClass(color?: string): string {
-  return TAG_COLORS[color || 'gray'] || TAG_COLORS.gray;
+  // hex色をrgbaに変換して20%透明度の背景色を作成
+  const hex = color.replace('#', '');
+  const r = parseInt(hex.substring(0, 2), 16);
+  const g = parseInt(hex.substring(2, 4), 16);
+  const b = parseInt(hex.substring(4, 6), 16);
+
+  return {
+    backgroundColor: `rgba(${r}, ${g}, ${b}, 0.2)`,
+    color: `rgb(${r}, ${g}, ${b})`,
+  };
 }
 
 /**
@@ -73,7 +80,8 @@ export function SelectCell({ value, onChange, options }: SelectCellProps) {
       >
         {selectedOption ? (
           <span
-            className={`inline-flex items-center px-2 py-0.5 rounded text-sm ${getColorClass(selectedOption.color)}`}
+            className="inline-flex items-center px-2 py-0.5 rounded text-sm"
+            style={getColorStyles(selectedOption.color)}
           >
             {selectedOption.label}
           </span>
@@ -98,7 +106,8 @@ export function SelectCell({ value, onChange, options }: SelectCellProps) {
                 onClick={() => handleSelect(option.id)}
               >
                 <span
-                  className={`inline-flex items-center px-2 py-0.5 rounded text-sm ${getColorClass(option.color)}`}
+                  className="inline-flex items-center px-2 py-0.5 rounded text-sm"
+                  style={getColorStyles(option.color)}
                 >
                   {option.label}
                 </span>

--- a/features/table/components/data-table.tsx
+++ b/features/table/components/data-table.tsx
@@ -30,6 +30,7 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { updateRecord } from '@/features/record/api/update-record';
 import { createRecord } from '@/features/record/api/create-record';
+import { applyDefaultValues } from '@/features/column/utils';
 import { createColumns } from './columns';
 import { BulkDeleteButton } from './bulk-delete-button';
 
@@ -90,9 +91,12 @@ export function DataTable({
   // 新規レコード作成
   const handleCreateRecord = useCallback(() => {
     startTransition(async () => {
+      // デフォルト値を適用
+      const defaultData = applyDefaultValues(columns);
+
       const formData = new FormData();
       formData.set('tableId', tableId);
-      formData.set('data', JSON.stringify({}));
+      formData.set('data', JSON.stringify(defaultData));
 
       const result = await createRecord({}, formData);
       if (result.error) {
@@ -105,7 +109,7 @@ export function DataTable({
         setRecords((prev) => [...prev, result.record as Record]);
       }
     });
-  }, [tableId]);
+  }, [tableId, columns]);
 
   // 削除完了時のハンドラ
   const handleDeleteComplete = useCallback((deletedIds: string[]) => {

--- a/features/table/components/edit/columns-content.tsx
+++ b/features/table/components/edit/columns-content.tsx
@@ -53,14 +53,29 @@ export function ColumnsContent({ itemId, columns }: ColumnsContentProps) {
   // カラム更新時のハンドラ
   const handleColumnUpdated = (
     columnId: string,
-    updated: { name: string; validation?: { required: boolean } }
+    updated: {
+      name: string;
+      validation?: { required: boolean };
+      config?: unknown;
+    }
   ) => {
     setLocalColumns((prev) =>
-      prev.map((col) =>
-        col.id === columnId
-          ? { ...col, name: updated.name, validation: updated.validation }
-          : col
-      )
+      prev.map((col) => {
+        if (col.id !== columnId) return col;
+
+        const updatedCol = {
+          ...col,
+          name: updated.name,
+          validation: updated.validation,
+        };
+
+        // configが提供されている場合は更新
+        if (updated.config !== undefined) {
+          return { ...updatedCol, config: updated.config } as Column;
+        }
+
+        return updatedCol;
+      })
     );
   };
 


### PR DESCRIPTION
## 概要

セレクト（SELECT）およびマルチセレクト（MULTI_SELECT）カラムの選択肢設定機能を実装しました。

## 実装内容

### 選択肢エディタ（SelectOptionsEditor）
- **選択肢の管理**: 追加・編集・削除機能
- **並び替え**: @dnd-kit/coreを使用したドラッグ&ドロップ対応
- **カラー設定**: 事前定義パレット（9色）から選択
- **デフォルト値**: 
  - SELECT: ラジオボタン形式（単一選択）
  - MULTI_SELECT: チェックボックス形式（複数選択可）

### デフォルト値の適用
- `applyDefaultValues`ユーティリティを実装
- レコード作成時に自動的にデフォルト値を適用

### バリデーション
- 選択肢が空の場合のエラー表示
- 空ラベルのチェック
- IDベースのバリデーション（データ整合性確保）
- 必須項目のバリデーション

### UI改善
- セレクトセルとマルチセレクトセルにカラー表示
- hex値をrgbaに変換して動的スタイル適用
- マルチセレクト: 通常表示では×マークを非表示、選択時のみ表示

## 動作確認

- [x] 選択肢の追加・編集・削除が正常に動作
- [x] ドラッグ&ドロップで並び替えが可能
- [x] カラー選択が反映される
- [x] デフォルト値がレコード作成時に適用される
- [x] バリデーションが正常に機能

## 関連Issue

Closes #33