### PR TITLE
数値カラムの範囲設定機能

### DIFF
--- a/features/column/components/add-column-dialog.tsx
+++ b/features/column/components/add-column-dialog.tsx
@@ -211,6 +211,7 @@ export function AddColumnDialog({
             {/* NUMBER用の設定 */}
             {columnType === 'NUMBER' && (
               <NumberConfigEditor
+                key={open ? 'open' : 'closed'}
                 config={numberConfig}
                 onChange={setNumberConfig}
               />

--- a/features/column/components/add-column-dialog.tsx
+++ b/features/column/components/add-column-dialog.tsx
@@ -23,7 +23,8 @@ import { toast } from 'sonner';
 import { addColumn } from '../api/add-column';
 import type { ColumnType, SelectOption } from '../types/column';
 import { COLUMN_TYPE_LIST, COLUMN_CONFIGS } from '../constants';
-import { SelectOptionsEditor } from './config/select-options-editor';
+import { SelectConfigEditor } from './config/select-config-editor';
+import { NumberConfigEditor } from './config/number-config-editor';
 
 /**
  * カラム追加ダイアログのProps型
@@ -53,6 +54,17 @@ export function AddColumnDialog({
   const [selectOptions, setSelectOptions] = useState<SelectOption[]>([]);
   const [defaultValue, setDefaultValue] = useState<string | string[]>('');
 
+  // NUMBER用の状態
+  const [numberConfig, setNumberConfig] = useState<{
+    min?: number;
+    max?: number;
+    unit?: string;
+    unitPosition?: 'prefix' | 'suffix';
+    thousandSeparator?: boolean;
+    defaultValue?: number;
+    step?: number;
+  }>({});
+
   // ダイアログが閉じられたときに状態をリセット
   useEffect(() => {
     if (!open) {
@@ -61,6 +73,7 @@ export function AddColumnDialog({
       setIsRequired(false);
       setSelectOptions([]);
       setDefaultValue('');
+      setNumberConfig({});
     }
   }, [open]);
 
@@ -100,6 +113,11 @@ export function AddColumnDialog({
           options: selectOptions,
           defaultValue: defaultValue as string[],
         };
+      } else if (
+        columnType === 'NUMBER' &&
+        Object.keys(numberConfig).length > 0
+      ) {
+        config = numberConfig;
       }
 
       const result = await addColumn(itemId, {
@@ -177,7 +195,7 @@ export function AddColumnDialog({
 
             {/* SELECT/MULTI_SELECT用の選択肢設定 */}
             {(columnType === 'SELECT' || columnType === 'MULTI_SELECT') && (
-              <SelectOptionsEditor
+              <SelectConfigEditor
                 options={selectOptions}
                 defaultValue={defaultValue}
                 isMultiSelect={columnType === 'MULTI_SELECT'}
@@ -187,6 +205,14 @@ export function AddColumnDialog({
                     defValue || (columnType === 'MULTI_SELECT' ? [] : '')
                   );
                 }}
+              />
+            )}
+
+            {/* NUMBER用の設定 */}
+            {columnType === 'NUMBER' && (
+              <NumberConfigEditor
+                config={numberConfig}
+                onChange={setNumberConfig}
               />
             )}
 

--- a/features/column/components/config/number-config-editor.tsx
+++ b/features/column/components/config/number-config-editor.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Checkbox } from '@/components/ui/checkbox';
@@ -42,13 +42,6 @@ export function NumberConfigEditor({
 }: NumberConfigEditorProps) {
   const [localConfig, setLocalConfig] = useState<NumberConfig>(config || {});
 
-  // 親から受け取ったconfigが変更されたらローカルステートを更新
-  useEffect(() => {
-    if (config) {
-      setLocalConfig(config);
-    }
-  }, [config]);
-
   const handleChange = (updates: Partial<NumberConfig>) => {
     const newConfig = { ...localConfig, ...updates };
     setLocalConfig(newConfig);
@@ -57,10 +50,10 @@ export function NumberConfigEditor({
 
   const handleNumberInput = (field: keyof NumberConfig, value: string) => {
     if (value === '') {
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      const { [field]: _, ...rest } = localConfig;
-      setLocalConfig(rest);
-      onChange(rest);
+      const newConfig = { ...localConfig };
+      delete newConfig[field];
+      setLocalConfig(newConfig);
+      onChange(newConfig);
       return;
     }
 
@@ -148,10 +141,11 @@ export function NumberConfigEditor({
             onChange={(e) => {
               const value = e.target.value;
               if (value === '') {
-                // eslint-disable-next-line @typescript-eslint/no-unused-vars
-                const { unit: _, unitPosition: __, ...rest } = localConfig;
-                setLocalConfig(rest);
-                onChange(rest);
+                const newConfig = { ...localConfig };
+                delete newConfig.unit;
+                delete newConfig.unitPosition;
+                setLocalConfig(newConfig);
+                onChange(newConfig);
               } else {
                 handleChange({ unit: value });
               }

--- a/features/column/components/config/number-config-editor.tsx
+++ b/features/column/components/config/number-config-editor.tsx
@@ -1,0 +1,186 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Checkbox } from '@/components/ui/checkbox';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+
+/**
+ * NUMBER設定の型
+ */
+type NumberConfig = {
+  min?: number;
+  max?: number;
+  unit?: string;
+  unitPosition?: 'prefix' | 'suffix';
+  thousandSeparator?: boolean;
+  defaultValue?: number;
+  step?: number;
+};
+
+/**
+ * NumberConfigEditorのProps型
+ */
+type NumberConfigEditorProps = {
+  config?: NumberConfig;
+  onChange: (config: NumberConfig) => void;
+};
+
+/**
+ * NUMBER用の設定エディターコンポーネント
+ */
+export function NumberConfigEditor({
+  config,
+  onChange,
+}: NumberConfigEditorProps) {
+  const [localConfig, setLocalConfig] = useState<NumberConfig>(config || {});
+
+  // 親から受け取ったconfigが変更されたらローカルステートを更新
+  useEffect(() => {
+    if (config) {
+      setLocalConfig(config);
+    }
+  }, [config]);
+
+  const handleChange = (updates: Partial<NumberConfig>) => {
+    const newConfig = { ...localConfig, ...updates };
+    setLocalConfig(newConfig);
+    onChange(newConfig);
+  };
+
+  const handleNumberInput = (field: keyof NumberConfig, value: string) => {
+    if (value === '') {
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const { [field]: _, ...rest } = localConfig;
+      setLocalConfig(rest);
+      onChange(rest);
+      return;
+    }
+
+    const numValue = parseFloat(value);
+    if (!isNaN(numValue)) {
+      handleChange({ [field]: numValue });
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      {/* 最小値・最大値 */}
+      <div className="grid grid-cols-2 gap-3">
+        <div className="grid gap-2">
+          <Label htmlFor="number-min">最小値</Label>
+          <Input
+            id="number-min"
+            type="number"
+            value={localConfig.min ?? ''}
+            onChange={(e) => handleNumberInput('min', e.target.value)}
+            placeholder="制限なし"
+          />
+        </div>
+        <div className="grid gap-2">
+          <Label htmlFor="number-max">最大値</Label>
+          <Input
+            id="number-max"
+            type="number"
+            value={localConfig.max ?? ''}
+            onChange={(e) => handleNumberInput('max', e.target.value)}
+            placeholder="制限なし"
+          />
+        </div>
+      </div>
+
+      {/* ステップ値 */}
+      <div className="grid gap-2">
+        <Label htmlFor="number-step">ステップ値</Label>
+        <Input
+          id="number-step"
+          type="number"
+          min="0"
+          step="any"
+          value={localConfig.step ?? ''}
+          onChange={(e) => handleNumberInput('step', e.target.value)}
+          placeholder="1"
+        />
+      </div>
+
+      {/* デフォルト値 */}
+      <div className="grid gap-2">
+        <Label htmlFor="number-default">デフォルト値</Label>
+        <Input
+          id="number-default"
+          type="number"
+          value={localConfig.defaultValue ?? ''}
+          onChange={(e) => handleNumberInput('defaultValue', e.target.value)}
+          placeholder="なし"
+        />
+      </div>
+
+      {/* 単位設定 */}
+      <div className="grid gap-2">
+        <Label htmlFor="number-unit">単位</Label>
+        <div className="flex gap-2">
+          <Select
+            value={localConfig.unitPosition || 'suffix'}
+            onValueChange={(value) =>
+              handleChange({
+                unitPosition: value as 'prefix' | 'suffix',
+              })
+            }
+          >
+            <SelectTrigger className="w-[100px]">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="prefix">前</SelectItem>
+              <SelectItem value="suffix">後</SelectItem>
+            </SelectContent>
+          </Select>
+          <Input
+            id="number-unit"
+            value={localConfig.unit ?? ''}
+            onChange={(e) => {
+              const value = e.target.value;
+              if (value === '') {
+                // eslint-disable-next-line @typescript-eslint/no-unused-vars
+                const { unit: _, unitPosition: __, ...rest } = localConfig;
+                setLocalConfig(rest);
+                onChange(rest);
+              } else {
+                handleChange({ unit: value });
+              }
+            }}
+            placeholder="円、個、kg など"
+            className="flex-1"
+          />
+        </div>
+        <p className="text-xs text-muted-foreground">
+          表示専用（例: ¥100、100円）
+        </p>
+      </div>
+
+      {/* 千の位区切り */}
+      <div className="flex items-center space-x-2">
+        <Checkbox
+          id="number-thousand-separator"
+          checked={localConfig.thousandSeparator || false}
+          onCheckedChange={(checked) =>
+            handleChange({ thousandSeparator: checked === true })
+          }
+        />
+        <label
+          htmlFor="number-thousand-separator"
+          className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
+        >
+          千の位区切りを表示（例: 1,000）
+        </label>
+      </div>
+    </div>
+  );
+}

--- a/features/column/components/config/select-config-editor.tsx
+++ b/features/column/components/config/select-config-editor.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { Plus, GripVertical, Trash2, Check } from 'lucide-react';
 import { nanoid } from 'nanoid';
 import {
@@ -31,9 +31,9 @@ import { COLOR_PALETTE, DEFAULT_COLOR } from '../../constants';
 import type { SelectOption } from '../../types';
 
 /**
- * SelectOptionsEditorのProps型
+ * SelectConfigEditorのProps型
  */
-type SelectOptionsEditorProps = {
+type SelectConfigEditorProps = {
   options: SelectOption[];
   defaultValue?: string | string[];
   isMultiSelect?: boolean;
@@ -166,18 +166,27 @@ function OptionItem({
 }
 
 /**
- * SELECT/MULTI_SELECT用の選択肢エディターコンポーネント
+ * SELECT/MULTI_SELECT用の設定エディターコンポーネント
  */
-export function SelectOptionsEditor({
+export function SelectConfigEditor({
   options,
   defaultValue,
   isMultiSelect = false,
   onChange,
-}: SelectOptionsEditorProps) {
+}: SelectConfigEditorProps) {
   const [localOptions, setLocalOptions] = useState<SelectOption[]>(options);
   const [localDefaultValue, setLocalDefaultValue] = useState<string | string[]>(
     defaultValue || (isMultiSelect ? [] : '')
   );
+
+  // 親から受け取ったpropsが変更されたらローカルステートを更新
+  useEffect(() => {
+    setLocalOptions(options);
+  }, [options]);
+
+  useEffect(() => {
+    setLocalDefaultValue(defaultValue || (isMultiSelect ? [] : ''));
+  }, [defaultValue, isMultiSelect]);
 
   // DnDセンサーの設定
   const sensors = useSensors(

--- a/features/column/components/edit-column-item.tsx
+++ b/features/column/components/edit-column-item.tsx
@@ -18,7 +18,8 @@ import { Pencil } from 'lucide-react';
 import { toast } from 'sonner';
 import { updateColumn } from '../api/update-column';
 import type { Column, SelectOption } from '../types/column';
-import { SelectOptionsEditor } from './config/select-options-editor';
+import { SelectConfigEditor } from './config/select-config-editor';
+import { NumberConfigEditor } from './config/number-config-editor';
 
 /**
  * カラム編集アイテムのProps型
@@ -54,6 +55,17 @@ export function EditColumnItem({
   const [selectOptions, setSelectOptions] = useState<SelectOption[]>([]);
   const [defaultValue, setDefaultValue] = useState<string | string[]>('');
 
+  // NUMBER用の状態
+  const [numberConfig, setNumberConfig] = useState<{
+    min?: number;
+    max?: number;
+    unit?: string;
+    unitPosition?: 'prefix' | 'suffix';
+    thousandSeparator?: boolean;
+    defaultValue?: number;
+    step?: number;
+  }>({});
+
   // ダイアログが開かれたときに最新の値をセット
   useEffect(() => {
     if (open) {
@@ -67,6 +79,12 @@ export function EditColumnItem({
         setDefaultValue(
           config?.defaultValue || (column.type === 'MULTI_SELECT' ? [] : '')
         );
+      }
+
+      // NUMBERの場合、configから値を取得
+      if (column.type === 'NUMBER') {
+        const config = column.config;
+        setNumberConfig(config || {});
       }
     }
   }, [open, column]);
@@ -107,6 +125,11 @@ export function EditColumnItem({
           options: selectOptions,
           defaultValue: defaultValue as string[],
         };
+      } else if (
+        column.type === 'NUMBER' &&
+        Object.keys(numberConfig).length > 0
+      ) {
+        config = numberConfig;
       }
 
       const result = await updateColumn(itemId, column.id, {
@@ -170,7 +193,7 @@ export function EditColumnItem({
 
             {/* SELECT/MULTI_SELECT用の選択肢設定 */}
             {(column.type === 'SELECT' || column.type === 'MULTI_SELECT') && (
-              <SelectOptionsEditor
+              <SelectConfigEditor
                 options={selectOptions}
                 defaultValue={defaultValue}
                 isMultiSelect={column.type === 'MULTI_SELECT'}
@@ -180,6 +203,14 @@ export function EditColumnItem({
                     defValue || (column.type === 'MULTI_SELECT' ? [] : '')
                   );
                 }}
+              />
+            )}
+
+            {/* NUMBER用の設定 */}
+            {column.type === 'NUMBER' && (
+              <NumberConfigEditor
+                config={numberConfig}
+                onChange={setNumberConfig}
               />
             )}
 

--- a/features/column/components/edit-column-item.tsx
+++ b/features/column/components/edit-column-item.tsx
@@ -209,6 +209,7 @@ export function EditColumnItem({
             {/* NUMBER用の設定 */}
             {column.type === 'NUMBER' && (
               <NumberConfigEditor
+                key={open ? column.id : 'closed'}
                 config={numberConfig}
                 onChange={setNumberConfig}
               />

--- a/features/column/types/column.ts
+++ b/features/column/types/column.ts
@@ -47,9 +47,13 @@ export type ColumnTypeConfig = {
     rows?: number;
   };
   NUMBER: {
-    min?: number;
-    max?: number;
-    step?: number;
+    min?: number; // 最小値
+    max?: number; // 最大値
+    unit?: string; // 単位（円、個など）表示専用
+    unitPosition?: 'prefix' | 'suffix'; // 単位の位置
+    thousandSeparator?: boolean; // 千の位区切り表示
+    defaultValue?: number; // デフォルト値
+    step?: number; // 増減のステップ値（デフォルト: 1）
     placeholder?: string;
   };
   DATE: {

--- a/features/column/utils/__tests__/apply-default-values.test.ts
+++ b/features/column/utils/__tests__/apply-default-values.test.ts
@@ -3,6 +3,7 @@ import type {
   SelectColumn,
   MultiSelectColumn,
   TextColumn,
+  NumberColumn,
 } from '../../types/column';
 
 describe('applyDefaultValues', () => {
@@ -152,5 +153,66 @@ describe('applyDefaultValues', () => {
     const result = applyDefaultValues([]);
 
     expect(result).toEqual({});
+  });
+
+  it('NUMBER型のデフォルト値を適用する', () => {
+    const columns: NumberColumn[] = [
+      {
+        id: 'col-1',
+        name: '金額',
+        type: 'NUMBER',
+        order: 0,
+        config: {
+          defaultValue: 100,
+        },
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+    ];
+
+    const result = applyDefaultValues(columns);
+
+    expect(result).toEqual({
+      'col-1': 100,
+    });
+  });
+
+  it('デフォルト値がないNUMBER型は値を設定しない', () => {
+    const columns: NumberColumn[] = [
+      {
+        id: 'col-1',
+        name: '金額',
+        type: 'NUMBER',
+        order: 0,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+    ];
+
+    const result = applyDefaultValues(columns);
+
+    expect(result).toEqual({});
+  });
+
+  it('NUMBER型のデフォルト値が0の場合も適用する', () => {
+    const columns: NumberColumn[] = [
+      {
+        id: 'col-1',
+        name: '金額',
+        type: 'NUMBER',
+        order: 0,
+        config: {
+          defaultValue: 0,
+        },
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+    ];
+
+    const result = applyDefaultValues(columns);
+
+    expect(result).toEqual({
+      'col-1': 0,
+    });
   });
 });

--- a/features/column/utils/__tests__/validate-column-value.test.ts
+++ b/features/column/utils/__tests__/validate-column-value.test.ts
@@ -3,6 +3,7 @@ import type {
   SelectColumn,
   MultiSelectColumn,
   TextColumn,
+  NumberColumn,
 } from '../../types/column';
 
 describe('validateColumnValue', () => {
@@ -118,6 +119,61 @@ describe('validateColumnValue', () => {
         columnId: 'col-1',
         columnName: 'タグ',
         message: 'タグは配列である必要があります',
+      });
+    });
+  });
+
+  describe('NUMBER型のバリデーション', () => {
+    const numberColumn: NumberColumn = {
+      id: 'col-1',
+      name: '金額',
+      type: 'NUMBER',
+      order: 0,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+
+    it('有効な数値はバリデーションを通過する', () => {
+      const result = validateColumnValue(100, numberColumn);
+      expect(result).toBeNull();
+    });
+
+    it('min値未満の場合はエラーを返す', () => {
+      const columnWithMin: NumberColumn = {
+        ...numberColumn,
+        config: { min: 0 },
+      };
+      const result = validateColumnValue(-10, columnWithMin);
+      expect(result).toEqual({
+        columnId: 'col-1',
+        columnName: '金額',
+        message: '金額は0以上である必要があります',
+      });
+    });
+
+    it('max値超過の場合はエラーを返す', () => {
+      const columnWithMax: NumberColumn = {
+        ...numberColumn,
+        config: { max: 100 },
+      };
+      const result = validateColumnValue(200, columnWithMax);
+      expect(result).toEqual({
+        columnId: 'col-1',
+        columnName: '金額',
+        message: '金額は100以下である必要があります',
+      });
+    });
+
+    it('required=trueで空値の場合はエラーを返す', () => {
+      const requiredColumn: NumberColumn = {
+        ...numberColumn,
+        validation: { required: true },
+      };
+      const result = validateColumnValue(null, requiredColumn);
+      expect(result).toEqual({
+        columnId: 'col-1',
+        columnName: '金額',
+        message: '金額は必須項目です',
       });
     });
   });

--- a/features/column/utils/apply-default-values.ts
+++ b/features/column/utils/apply-default-values.ts
@@ -18,6 +18,11 @@ export function applyDefaultValues(columns: Column[]): RecordData {
       column.config?.defaultValue !== undefined
     ) {
       data[column.id] = column.config.defaultValue;
+    } else if (
+      column.type === 'NUMBER' &&
+      column.config?.defaultValue !== undefined
+    ) {
+      data[column.id] = column.config.defaultValue;
     }
     // 他のカラムタイプは明示的に値を設定しない（undefined）
   }

--- a/features/table/components/cells/number-cell.tsx
+++ b/features/table/components/cells/number-cell.tsx
@@ -10,6 +10,9 @@ type NumberCellProps = {
   max?: number;
   step?: number;
   placeholder?: string;
+  unit?: string;
+  unitPosition?: 'prefix' | 'suffix';
+  thousandSeparator?: boolean;
 };
 
 /**
@@ -22,6 +25,9 @@ export function NumberCell({
   max,
   step,
   placeholder,
+  unit,
+  unitPosition = 'suffix',
+  thousandSeparator = false,
 }: NumberCellProps) {
   const [isEditing, setIsEditing] = useState(false);
   const [editValue, setEditValue] = useState('');
@@ -57,6 +63,31 @@ export function NumberCell({
     }
   };
 
+  /**
+   * 数値をフォーマットして表示
+   */
+  const formatNumber = (num: number): string => {
+    let formatted = num.toString();
+
+    // 千の位区切りを適用
+    if (thousandSeparator) {
+      const parts = formatted.split('.');
+      parts[0] = parts[0].replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+      formatted = parts.join('.');
+    }
+
+    // 単位を適用
+    if (unit) {
+      if (unitPosition === 'prefix') {
+        formatted = unit + formatted;
+      } else {
+        formatted = formatted + unit;
+      }
+    }
+
+    return formatted;
+  };
+
   if (isEditing) {
     return (
       <Input
@@ -81,7 +112,7 @@ export function NumberCell({
       onClick={handleStartEdit}
     >
       <span className={value != null ? '' : 'text-muted-foreground'}>
-        {value ?? placeholder ?? '-'}
+        {value != null ? formatNumber(value) : (placeholder ?? '-')}
       </span>
     </div>
   );

--- a/features/table/components/columns.tsx
+++ b/features/table/components/columns.tsx
@@ -99,6 +99,9 @@ export const createColumns = (
               max={column.config?.max}
               step={column.config?.step}
               placeholder={column.config?.placeholder}
+              unit={column.config?.unit}
+              unitPosition={column.config?.unitPosition}
+              thousandSeparator={column.config?.thousandSeparator}
             />
           );
         case 'DATE':


### PR DESCRIPTION
## 概要

NUMBERカラムに最小値・最大値・ステップ・単位・デフォルト値などの設定機能を実装しました。

## 実装内容

- **NumberConfigEditor コンポーネント**: NUMBER型カラムの設定エディタを実装
  - 最小値・最大値の設定
  - ステップ値の設定
  - デフォルト値の設定
  - 単位（前置/後置）の設定
  - 千の位区切り表示の設定
- **NumberCell コンポーネント**: 数値セルの表示・編集機能を実装
  - 単位表示（前置/後置）
  - 千の位区切り表示
  - min/max/stepのバリデーション
- **型定義の追加**: `NumberColumn`型と`NumberConfig`型を定義
- **バリデーション機能**: `validate-column-value.ts`にNUMBER型のバリデーションを追加
- **デフォルト値適用**: `apply-default-values.ts`にNUMBER型のデフォルト値適用ロジックを追加

## 動作確認

- [x] カラム追加ダイアログでNUMBER型の設定ができることを確認
- [x] カラム編集ダイアログでNUMBER型の設定を変更できることを確認
- [x] テーブルでNUMBER型のセルが設定に従って表示・編集できることを確認
- [x] 単位が前置/後置で正しく表示されることを確認
- [x] 千の位区切りが正しく表示されることを確認
- [x] min/max/stepのバリデーションが機能することを確認
- [x] デフォルト値が新規レコード作成時に適用されることを確認

## 関連 Issue

Closes #34 