### PR TITLE
日付カラムの精度設定機能

### DIFF
--- a/features/column/components/add-column-dialog.tsx
+++ b/features/column/components/add-column-dialog.tsx
@@ -25,6 +25,8 @@ import type { ColumnType, SelectOption } from '../types/column';
 import { COLUMN_TYPE_LIST, COLUMN_CONFIGS } from '../constants';
 import { SelectConfigEditor } from './config/select-config-editor';
 import { NumberConfigEditor } from './config/number-config-editor';
+import { DateConfigEditor } from './config/date-config-editor';
+import type { DatePrecision } from '../types/column';
 
 /**
  * カラム追加ダイアログのProps型
@@ -65,6 +67,18 @@ export function AddColumnDialog({
     step?: number;
   }>({});
 
+  // DATE用の状態
+  const [dateConfig, setDateConfig] = useState<{
+    precision?: DatePrecision;
+    defaultValue?: number;
+    min?: string;
+    max?: string;
+    allowPast?: boolean;
+    allowFuture?: boolean;
+    showWeekday?: boolean;
+    placeholder?: string;
+  }>({});
+
   // ダイアログが閉じられたときに状態をリセット
   useEffect(() => {
     if (!open) {
@@ -74,6 +88,7 @@ export function AddColumnDialog({
       setSelectOptions([]);
       setDefaultValue('');
       setNumberConfig({});
+      setDateConfig({});
     }
   }, [open]);
 
@@ -118,6 +133,8 @@ export function AddColumnDialog({
         Object.keys(numberConfig).length > 0
       ) {
         config = numberConfig;
+      } else if (columnType === 'DATE' && Object.keys(dateConfig).length > 0) {
+        config = dateConfig;
       }
 
       const result = await addColumn(itemId, {
@@ -214,6 +231,15 @@ export function AddColumnDialog({
                 key={open ? 'open' : 'closed'}
                 config={numberConfig}
                 onChange={setNumberConfig}
+              />
+            )}
+
+            {/* DATE用の設定 */}
+            {columnType === 'DATE' && (
+              <DateConfigEditor
+                key={open ? 'open' : 'closed'}
+                config={dateConfig}
+                onChange={setDateConfig}
               />
             )}
 

--- a/features/column/components/config/date-config-editor.tsx
+++ b/features/column/components/config/date-config-editor.tsx
@@ -1,0 +1,226 @@
+'use client';
+
+import { useState } from 'react';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Checkbox } from '@/components/ui/checkbox';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import type {
+  DatePrecision,
+  DateFormatType,
+} from '../../types/column';
+
+/**
+ * DATE設定の型
+ */
+type DateConfig = {
+  precision?: DatePrecision;
+  format?: DateFormatType;
+  defaultValue?: number; // 相対日数: 0=今日、正数=未来、負数=過去
+  min?: string;
+  max?: string;
+  allowPast?: boolean;
+  allowFuture?: boolean;
+  showWeekday?: boolean;
+  placeholder?: string;
+};
+
+/**
+ * DateConfigEditorのProps型
+ */
+type DateConfigEditorProps = {
+  config?: DateConfig;
+  onChange: (config: DateConfig) => void;
+};
+
+/**
+ * 精度の選択肢
+ */
+const PRECISION_OPTIONS: { value: DatePrecision; label: string }[] = [
+  { value: 'year', label: '年のみ（YYYY）' },
+  { value: 'month', label: '年月（YYYY-MM）' },
+  { value: 'day', label: '年月日（YYYY-MM-DD）' },
+];
+
+/**
+ * DATE用の設定エディターコンポーネント
+ */
+export function DateConfigEditor({
+  config,
+  onChange,
+}: DateConfigEditorProps) {
+  const [localConfig, setLocalConfig] = useState<DateConfig>(config || {});
+
+  const handleChange = (updates: Partial<DateConfig>) => {
+    const newConfig = { ...localConfig, ...updates };
+    setLocalConfig(newConfig);
+    onChange(newConfig);
+  };
+
+  const handleDateInput = (field: 'min' | 'max', value: string) => {
+    if (value === '') {
+      const newConfig = { ...localConfig };
+      delete newConfig[field];
+      setLocalConfig(newConfig);
+      onChange(newConfig);
+      return;
+    }
+    handleChange({ [field]: value });
+  };
+
+  return (
+    <div className="space-y-4">
+      {/* 精度設定 */}
+      <div className="grid gap-2">
+        <Label htmlFor="date-precision">精度</Label>
+        <Select
+          value={localConfig.precision || 'day'}
+          onValueChange={(value) =>
+            handleChange({ precision: value as DatePrecision })
+          }
+        >
+          <SelectTrigger>
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {PRECISION_OPTIONS.map((option) => (
+              <SelectItem key={option.value} value={option.value}>
+                {option.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      {/* デフォルト値（相対日数） */}
+      <div className="grid gap-2">
+        <Label htmlFor="date-default">デフォルト値（相対日数）</Label>
+        <Input
+          id="date-default"
+          type="number"
+          value={localConfig.defaultValue ?? ''}
+          onChange={(e) => {
+            const value = e.target.value;
+            if (value === '') {
+              const newConfig = { ...localConfig };
+              delete newConfig.defaultValue;
+              setLocalConfig(newConfig);
+              onChange(newConfig);
+            } else {
+              const numValue = parseInt(value, 10);
+              if (!isNaN(numValue)) {
+                handleChange({ defaultValue: numValue });
+              }
+            }
+          }}
+          placeholder="0（今日）"
+        />
+        <p className="text-xs text-muted-foreground">
+          0=今日、正数=未来（例: 7=7日後）、負数=過去（例: -7=7日前）
+        </p>
+      </div>
+
+      {/* 最小値・最大値 */}
+      <div className="grid grid-cols-2 gap-3">
+        <div className="grid gap-2">
+          <Label htmlFor="date-min">最小日付</Label>
+          <Input
+            id="date-min"
+            type="date"
+            value={localConfig.min ?? ''}
+            onChange={(e) => handleDateInput('min', e.target.value)}
+            placeholder="制限なし"
+          />
+        </div>
+        <div className="grid gap-2">
+          <Label htmlFor="date-max">最大日付</Label>
+          <Input
+            id="date-max"
+            type="date"
+            value={localConfig.max ?? ''}
+            onChange={(e) => handleDateInput('max', e.target.value)}
+            placeholder="制限なし"
+          />
+        </div>
+      </div>
+
+      {/* 過去/未来の許可 */}
+      <div className="grid gap-3">
+        <div className="flex items-center space-x-2">
+          <Checkbox
+            id="date-allow-past"
+            checked={localConfig.allowPast !== false}
+            onCheckedChange={(checked) =>
+              handleChange({ allowPast: checked === true })
+            }
+          />
+          <label
+            htmlFor="date-allow-past"
+            className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
+          >
+            過去日付を許可
+          </label>
+        </div>
+        <div className="flex items-center space-x-2">
+          <Checkbox
+            id="date-allow-future"
+            checked={localConfig.allowFuture !== false}
+            onCheckedChange={(checked) =>
+              handleChange({ allowFuture: checked === true })
+            }
+          />
+          <label
+            htmlFor="date-allow-future"
+            className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
+          >
+            未来日付を許可
+          </label>
+        </div>
+      </div>
+
+      {/* 曜日表示 */}
+      <div className="flex items-center space-x-2">
+        <Checkbox
+          id="date-show-weekday"
+          checked={localConfig.showWeekday || false}
+          onCheckedChange={(checked) =>
+            handleChange({ showWeekday: checked === true })
+          }
+        />
+        <label
+          htmlFor="date-show-weekday"
+          className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
+        >
+          曜日を表示（例: 2025/01/15（水））
+        </label>
+      </div>
+
+      {/* プレースホルダー */}
+      <div className="grid gap-2">
+        <Label htmlFor="date-placeholder">プレースホルダー</Label>
+        <Input
+          id="date-placeholder"
+          value={localConfig.placeholder ?? ''}
+          onChange={(e) => {
+            const value = e.target.value;
+            if (value === '') {
+              const newConfig = { ...localConfig };
+              delete newConfig.placeholder;
+              setLocalConfig(newConfig);
+              onChange(newConfig);
+            } else {
+              handleChange({ placeholder: value });
+            }
+          }}
+          placeholder="日付を選択"
+        />
+      </div>
+    </div>
+  );
+}

--- a/features/column/components/edit-column-item.tsx
+++ b/features/column/components/edit-column-item.tsx
@@ -20,6 +20,8 @@ import { updateColumn } from '../api/update-column';
 import type { Column, SelectOption } from '../types/column';
 import { SelectConfigEditor } from './config/select-config-editor';
 import { NumberConfigEditor } from './config/number-config-editor';
+import { DateConfigEditor } from './config/date-config-editor';
+import type { DatePrecision } from '../types/column';
 
 /**
  * カラム編集アイテムのProps型
@@ -66,6 +68,18 @@ export function EditColumnItem({
     step?: number;
   }>({});
 
+  // DATE用の状態
+  const [dateConfig, setDateConfig] = useState<{
+    precision?: DatePrecision;
+    defaultValue?: number;
+    min?: string;
+    max?: string;
+    allowPast?: boolean;
+    allowFuture?: boolean;
+    showWeekday?: boolean;
+    placeholder?: string;
+  }>({});
+
   // ダイアログが開かれたときに最新の値をセット
   useEffect(() => {
     if (open) {
@@ -85,6 +99,12 @@ export function EditColumnItem({
       if (column.type === 'NUMBER') {
         const config = column.config;
         setNumberConfig(config || {});
+      }
+
+      // DATEの場合、configから値を取得
+      if (column.type === 'DATE') {
+        const config = column.config;
+        setDateConfig(config || {});
       }
     }
   }, [open, column]);
@@ -130,6 +150,8 @@ export function EditColumnItem({
         Object.keys(numberConfig).length > 0
       ) {
         config = numberConfig;
+      } else if (column.type === 'DATE' && Object.keys(dateConfig).length > 0) {
+        config = dateConfig;
       }
 
       const result = await updateColumn(itemId, column.id, {
@@ -212,6 +234,15 @@ export function EditColumnItem({
                 key={open ? column.id : 'closed'}
                 config={numberConfig}
                 onChange={setNumberConfig}
+              />
+            )}
+
+            {/* DATE用の設定 */}
+            {column.type === 'DATE' && (
+              <DateConfigEditor
+                key={open ? column.id : 'closed'}
+                config={dateConfig}
+                onChange={setDateConfig}
               />
             )}
 

--- a/features/column/types/column.ts
+++ b/features/column/types/column.ts
@@ -23,15 +23,17 @@ export type SelectOption = {
 };
 
 /**
+ * 日付精度の型
+ */
+export type DatePrecision = 'year' | 'month' | 'day';
+
+/**
  * 日付フォーマットの型
- * 将来的に年月のみ、日時、秒数までなど細かい設定に対応可能
  */
 export type DateFormatType =
   | 'YYYY-MM-DD' // 日付のみ
   | 'YYYY/MM/DD' // 日付のみ（スラッシュ区切り）
-  | 'YYYY-MM' // 年月のみ（将来実装）
-  | 'YYYY-MM-DD HH:mm' // 日時（将来実装）
-  | 'YYYY-MM-DD HH:mm:ss'; // 日時秒（将来実装）
+  | 'YYYY-MM'; // 年月のみ
 
 /**
  * 各カラムタイプ固有の設定
@@ -57,9 +59,15 @@ export type ColumnTypeConfig = {
     placeholder?: string;
   };
   DATE: {
-    format?: DateFormatType;
-    min?: string; // ISO 8601形式
-    max?: string; // ISO 8601形式
+    precision?: DatePrecision; // 精度（デフォルト: 'day'）
+    format?: DateFormatType; // 表示フォーマット
+    defaultValue?: number; // デフォルト値（相対日数: 0=今日、正数=未来、負数=過去）
+    min?: string; // 入力可能な最小日付（ISO 8601形式）
+    max?: string; // 入力可能な最大日付（ISO 8601形式）
+    allowPast?: boolean; // 過去日付を許可（デフォルト: true）
+    allowFuture?: boolean; // 未来日付を許可（デフォルト: true）
+    showWeekday?: boolean; // 曜日を表示
+    placeholder?: string; // プレースホルダー
   };
   SELECT: {
     options: SelectOption[];

--- a/features/column/utils/apply-default-values.ts
+++ b/features/column/utils/apply-default-values.ts
@@ -1,3 +1,4 @@
+import { format } from 'date-fns';
 import type { Column } from '../types/column';
 import type { RecordData } from '@/features/record/types';
 
@@ -23,6 +24,22 @@ export function applyDefaultValues(columns: Column[]): RecordData {
       column.config?.defaultValue !== undefined
     ) {
       data[column.id] = column.config.defaultValue;
+    } else if (
+      column.type === 'DATE' &&
+      column.config?.defaultValue !== undefined
+    ) {
+      // DATE型のデフォルト値処理（相対日数）
+      const relativeDay = column.config.defaultValue;
+      const today = new Date();
+      today.setDate(today.getDate() + relativeDay); // 相対日数を加算
+
+      const precision = column.config.precision || 'day';
+      const formats = {
+        year: 'yyyy',
+        month: 'yyyy-MM',
+        day: 'yyyy-MM-dd',
+      };
+      data[column.id] = format(today, formats[precision]);
     }
     // 他のカラムタイプは明示的に値を設定しない（undefined）
   }

--- a/features/column/utils/validate-column-value.ts
+++ b/features/column/utils/validate-column-value.ts
@@ -199,6 +199,34 @@ function validateDateValue(
     };
   }
 
+  // 過去日付の許可チェック
+  const allowPast = column.config?.allowPast !== false; // デフォルトtrue
+  if (!allowPast) {
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+    if (date < today) {
+      return {
+        columnId: column.id,
+        columnName: column.name,
+        message: `${column.name}は今日以降の日付を入力してください`,
+      };
+    }
+  }
+
+  // 未来日付の許可チェック
+  const allowFuture = column.config?.allowFuture !== false; // デフォルトtrue
+  if (!allowFuture) {
+    const today = new Date();
+    today.setHours(23, 59, 59, 999);
+    if (date > today) {
+      return {
+        columnId: column.id,
+        columnName: column.name,
+        message: `${column.name}は今日以前の日付を入力してください`,
+      };
+    }
+  }
+
   return null;
 }
 

--- a/features/table/components/cells/date-cell.tsx
+++ b/features/table/components/cells/date-cell.tsx
@@ -12,18 +12,62 @@ import {
   PopoverTrigger,
 } from '@/components/ui/popover';
 import { cn } from '@/lib/utils';
+import type { DatePrecision } from '@/features/column/types/column';
 
 type DateCellProps = {
   value: string | null;
   onChange: (value: string | null) => void;
+  precision?: DatePrecision;
   min?: string;
   max?: string;
+  showWeekday?: boolean;
+  placeholder?: string;
 };
+
+/**
+ * 精度に応じたフォーマット文字列を取得
+ */
+function getFormatString(precision?: DatePrecision, showWeekday?: boolean): string {
+  const baseFormats = {
+    year: 'yyyy',
+    month: 'yyyy/MM',
+    day: 'yyyy/MM/dd',
+  };
+
+  const baseFormat = baseFormats[precision || 'day'];
+
+  if (showWeekday && (precision === 'day' || !precision)) {
+    return `${baseFormat}（E）`;
+  }
+
+  return baseFormat;
+}
+
+/**
+ * 精度に応じた保存形式を取得
+ */
+function getSaveFormat(precision?: DatePrecision): string {
+  const formats = {
+    year: 'yyyy',
+    month: 'yyyy-MM',
+    day: 'yyyy-MM-dd',
+  };
+
+  return formats[precision || 'day'];
+}
 
 /**
  * 日付セルコンポーネント
  */
-export function DateCell({ value, onChange, min, max }: DateCellProps) {
+export function DateCell({
+  value,
+  onChange,
+  precision = 'day',
+  min,
+  max,
+  showWeekday = false,
+  placeholder = '-',
+}: DateCellProps) {
   const [open, setOpen] = useState(false);
 
   const date = value ? new Date(value) : undefined;
@@ -32,8 +76,8 @@ export function DateCell({ value, onChange, min, max }: DateCellProps) {
 
   const handleSelect = (selectedDate: Date | undefined) => {
     if (selectedDate) {
-      // YYYY-MM-DD形式で保存
-      const formatted = format(selectedDate, 'yyyy-MM-dd');
+      const saveFormat = getSaveFormat(precision);
+      const formatted = format(selectedDate, saveFormat);
       onChange(formatted);
     } else {
       onChange(null);
@@ -42,9 +86,10 @@ export function DateCell({ value, onChange, min, max }: DateCellProps) {
   };
 
   const formatDisplayDate = (dateStr: string | null) => {
-    if (!dateStr) return '-';
+    if (!dateStr) return placeholder;
     try {
-      return format(new Date(dateStr), 'yyyy/MM/dd', { locale: ja });
+      const displayFormat = getFormatString(precision, showWeekday);
+      return format(new Date(dateStr), displayFormat, { locale: ja });
     } catch {
       return dateStr;
     }

--- a/features/table/components/columns.tsx
+++ b/features/table/components/columns.tsx
@@ -109,8 +109,11 @@ export const createColumns = (
             <DateCell
               value={(value as string) ?? null}
               onChange={handleChange}
+              precision={column.config?.precision}
               min={column.config?.min}
               max={column.config?.max}
+              showWeekday={column.config?.showWeekday}
+              placeholder={column.config?.placeholder}
             />
           );
         case 'SELECT':


### PR DESCRIPTION
## 概要

DATE型カラムに精度設定、デフォルト値、バリデーションなどの設定機能を実装しました。

## 実装内容

- **DateConfigEditor コンポーネント**: DATE型カラムの設定エディタを実装
  - 精度設定（年のみ/年月/年月日）
  - デフォルト値（相対日数: 0=今日、正数=未来、負数=過去）
  - 最小日付・最大日付の設定
  - 過去日付を許可/未来日付を許可のチェックボックス
  - 曜日表示オプション
  - プレースホルダー設定
- **date-cell.tsx拡張**: 日付セルの表示・編集機能を拡張
  - 精度に応じたフォーマット（年/月/日）
  - 曜日表示（例: 2025/01/15（水））
  - プレースホルダー対応
- **バリデーション機能**: validate-column-value.tsにDATE型のバリデーションを追加
  - allowPast=falseの場合、今日以降のみ許可
  - allowFuture=falseの場合、今日以前のみ許可
- **デフォルト値適用**: apply-default-values.tsにDATE型のデフォルト値適用ロジックを追加
  - 相対日数で指定（0=今日、7=7日後、-7=7日前）
  - 精度に応じたフォーマットで保存

## 設計方針

- NUMBER型の実装パターンに従い、統一感のあるコード
- useEffectなし、key propによるリマウント制御
- 精度は日付のみ（年/月/日）に限定（時刻は今回対象外）

## 動作確認

- [x] カラム追加ダイアログでDATE型の設定ができることを確認
- [x] カラム編集ダイアログでDATE型の設定を変更できることを確認
- [x] テーブルでDATE型のセルが設定に従って表示・編集できることを確認
- [x] 精度（年/月/日）が正しく反映されることを確認
- [x] 曜日表示が正しく機能することを確認
- [x] デフォルト値（相対日数）が新規レコード作成時に適用されることを確認
- [x] 過去/未来制限のバリデーションが機能することを確認

## 関連 Issue

Closes #35