### PR TITLE
日付カラムの精度設定機能

### DIFF
--- a/features/column/components/add-column-dialog.tsx
+++ b/features/column/components/add-column-dialog.tsx
@@ -25,6 +25,9 @@ import type { ColumnType, SelectOption } from '../types/column';
 import { COLUMN_TYPE_LIST, COLUMN_CONFIGS } from '../constants';
 import { SelectConfigEditor } from './config/select-config-editor';
 import { NumberConfigEditor } from './config/number-config-editor';
+import { DateConfigEditor } from './config/date-config-editor';
+import type { DatePrecision } from '../types/column';
+import { ScrollArea } from '@/components/ui/scroll-area';
 
 /**
  * カラム追加ダイアログのProps型
@@ -65,6 +68,17 @@ export function AddColumnDialog({
     step?: number;
   }>({});
 
+  // DATE用の状態
+  const [dateConfig, setDateConfig] = useState<{
+    precision?: DatePrecision;
+    defaultValue?: number;
+    min?: string;
+    max?: string;
+    allowPast?: boolean;
+    allowFuture?: boolean;
+    placeholder?: string;
+  }>({});
+
   // ダイアログが閉じられたときに状態をリセット
   useEffect(() => {
     if (!open) {
@@ -74,6 +88,7 @@ export function AddColumnDialog({
       setSelectOptions([]);
       setDefaultValue('');
       setNumberConfig({});
+      setDateConfig({});
     }
   }, [open]);
 
@@ -118,6 +133,8 @@ export function AddColumnDialog({
         Object.keys(numberConfig).length > 0
       ) {
         config = numberConfig;
+      } else if (columnType === 'DATE' && Object.keys(dateConfig).length > 0) {
+        config = dateConfig;
       }
 
       const result = await addColumn(itemId, {
@@ -145,93 +162,106 @@ export function AddColumnDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-[600px] max-h-[90vh] overflow-y-auto">
-        <DialogHeader>
+      <DialogContent className="sm:max-w-[600px] max-h-[90vh] p-0">
+        <DialogHeader className="px-6 py-6">
           <DialogTitle>項目を追加</DialogTitle>
         </DialogHeader>
         <form onSubmit={handleSubmit}>
-          <div className="grid gap-4 py-4">
-            <div className="grid gap-2">
-              <Label htmlFor="name">項目名</Label>
-              <Input
-                id="name"
-                value={columnName}
-                onChange={(e) => setColumnName(e.target.value)}
-                placeholder="項目名"
-                required
-              />
-            </div>
+          <ScrollArea className="[&>div[data-radix-scroll-area-viewport]]:max-h-[50vh] px-6">
+            <div className="grid gap-4">
+              <div className="grid gap-2">
+                <Label htmlFor="name">項目名</Label>
+                <Input
+                  id="name"
+                  value={columnName}
+                  onChange={(e) => setColumnName(e.target.value)}
+                  placeholder="項目名"
+                  required
+                />
+              </div>
 
-            <div className="grid gap-2">
-              <Label htmlFor="type">タイプ</Label>
-              <div className="flex items-center gap-3">
-                <Select
-                  value={columnType}
-                  onValueChange={(value) => setColumnType(value as ColumnType)}
+              <div className="grid gap-2">
+                <Label htmlFor="type">タイプ</Label>
+                <div className="flex items-center gap-3">
+                  <Select
+                    value={columnType}
+                    onValueChange={(value) =>
+                      setColumnType(value as ColumnType)
+                    }
+                  >
+                    <SelectTrigger className="w-[200px]">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {COLUMN_TYPE_LIST.map((type) => {
+                        const config = COLUMN_CONFIGS[type];
+                        const Icon = config.icon;
+                        return (
+                          <SelectItem key={type} value={type}>
+                            <div className="flex items-center gap-2">
+                              <Icon className="h-4 w-4" />
+                              <span>{config.label}</span>
+                            </div>
+                          </SelectItem>
+                        );
+                      })}
+                    </SelectContent>
+                  </Select>
+                  <p className="text-xs text-muted-foreground flex-1">
+                    {COLUMN_CONFIGS[columnType].description}
+                  </p>
+                </div>
+              </div>
+
+              {/* SELECT/MULTI_SELECT用の選択肢設定 */}
+              {(columnType === 'SELECT' || columnType === 'MULTI_SELECT') && (
+                <SelectConfigEditor
+                  options={selectOptions}
+                  defaultValue={defaultValue}
+                  isMultiSelect={columnType === 'MULTI_SELECT'}
+                  onChange={(options, defValue) => {
+                    setSelectOptions(options);
+                    setDefaultValue(
+                      defValue || (columnType === 'MULTI_SELECT' ? [] : '')
+                    );
+                  }}
+                />
+              )}
+
+              {/* NUMBER用の設定 */}
+              {columnType === 'NUMBER' && (
+                <NumberConfigEditor
+                  key={open ? 'open' : 'closed'}
+                  config={numberConfig}
+                  onChange={setNumberConfig}
+                />
+              )}
+
+              {/* DATE用の設定 */}
+              {columnType === 'DATE' && (
+                <DateConfigEditor
+                  key={open ? 'open' : 'closed'}
+                  config={dateConfig}
+                  onChange={setDateConfig}
+                />
+              )}
+
+              <div className="flex items-center space-x-2">
+                <Checkbox
+                  id="required"
+                  checked={isRequired}
+                  onCheckedChange={(checked) => setIsRequired(checked === true)}
+                />
+                <label
+                  htmlFor="required"
+                  className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
                 >
-                  <SelectTrigger className="w-[200px]">
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {COLUMN_TYPE_LIST.map((type) => {
-                      const config = COLUMN_CONFIGS[type];
-                      const Icon = config.icon;
-                      return (
-                        <SelectItem key={type} value={type}>
-                          <div className="flex items-center gap-2">
-                            <Icon className="h-4 w-4" />
-                            <span>{config.label}</span>
-                          </div>
-                        </SelectItem>
-                      );
-                    })}
-                  </SelectContent>
-                </Select>
-                <p className="text-xs text-muted-foreground flex-1">
-                  {COLUMN_CONFIGS[columnType].description}
-                </p>
+                  必須項目にする
+                </label>
               </div>
             </div>
-
-            {/* SELECT/MULTI_SELECT用の選択肢設定 */}
-            {(columnType === 'SELECT' || columnType === 'MULTI_SELECT') && (
-              <SelectConfigEditor
-                options={selectOptions}
-                defaultValue={defaultValue}
-                isMultiSelect={columnType === 'MULTI_SELECT'}
-                onChange={(options, defValue) => {
-                  setSelectOptions(options);
-                  setDefaultValue(
-                    defValue || (columnType === 'MULTI_SELECT' ? [] : '')
-                  );
-                }}
-              />
-            )}
-
-            {/* NUMBER用の設定 */}
-            {columnType === 'NUMBER' && (
-              <NumberConfigEditor
-                key={open ? 'open' : 'closed'}
-                config={numberConfig}
-                onChange={setNumberConfig}
-              />
-            )}
-
-            <div className="flex items-center space-x-2">
-              <Checkbox
-                id="required"
-                checked={isRequired}
-                onCheckedChange={(checked) => setIsRequired(checked === true)}
-              />
-              <label
-                htmlFor="required"
-                className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
-              >
-                必須項目にする
-              </label>
-            </div>
-          </div>
-          <DialogFooter>
+          </ScrollArea>
+          <DialogFooter className="px-6 py-6">
             <Button
               type="button"
               variant="outline"

--- a/features/column/components/config/date-config-editor.tsx
+++ b/features/column/components/config/date-config-editor.tsx
@@ -1,0 +1,256 @@
+'use client';
+
+import { useState } from 'react';
+import { format } from 'date-fns';
+import { CalendarIcon } from 'lucide-react';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Button } from '@/components/ui/button';
+import { DatePickerCalendar } from '@/components/ui/date-picker-calendar';
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@/components/ui/popover';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { cn } from '@/lib/utils';
+import type { DatePrecision, DateFormatType } from '../../types/column';
+
+/**
+ * DATE設定の型
+ */
+type DateConfig = {
+  precision?: DatePrecision;
+  format?: DateFormatType;
+  defaultValue?: number; // 相対日数: 0=今日、正数=未来、負数=過去
+  min?: string;
+  max?: string;
+  allowPast?: boolean;
+  allowFuture?: boolean;
+  placeholder?: string;
+};
+
+/**
+ * DateConfigEditorのProps型
+ */
+type DateConfigEditorProps = {
+  config?: DateConfig;
+  onChange: (config: DateConfig) => void;
+};
+
+/**
+ * 精度の選択肢
+ */
+const PRECISION_OPTIONS: { value: DatePrecision; label: string }[] = [
+  { value: 'year', label: '年のみ（YYYY）' },
+  { value: 'month', label: '年月（YYYY-MM）' },
+  { value: 'day', label: '年月日（YYYY-MM-DD）' },
+  { value: 'day_weekday', label: '年月日（曜日）（YYYY-MM-DD（曜日））' },
+];
+
+/**
+ * DATE用の設定エディターコンポーネント
+ */
+export function DateConfigEditor({ config, onChange }: DateConfigEditorProps) {
+  const [localConfig, setLocalConfig] = useState<DateConfig>(config || {});
+  const [minOpen, setMinOpen] = useState(false);
+  const [maxOpen, setMaxOpen] = useState(false);
+
+  const handleChange = (updates: Partial<DateConfig>) => {
+    const newConfig = { ...localConfig, ...updates };
+    setLocalConfig(newConfig);
+    onChange(newConfig);
+  };
+
+  const handleDateInput = (field: 'min' | 'max', value: string) => {
+    if (value === '') {
+      const newConfig = { ...localConfig };
+      delete newConfig[field];
+      setLocalConfig(newConfig);
+      onChange(newConfig);
+      return;
+    }
+    handleChange({ [field]: value });
+  };
+
+  return (
+    <div className="space-y-4">
+      {/* 精度設定 */}
+      <div className="grid gap-2">
+        <Label htmlFor="date-precision">表示形式</Label>
+        <Select
+          value={localConfig.precision || 'day'}
+          onValueChange={(value) =>
+            handleChange({ precision: value as DatePrecision })
+          }
+        >
+          <SelectTrigger>
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {PRECISION_OPTIONS.map((option) => (
+              <SelectItem key={option.value} value={option.value}>
+                {option.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      {/* デフォルト値（相対日数） */}
+      <div className="grid gap-2">
+        <Label htmlFor="date-default">デフォルト値</Label>
+        <Input
+          id="date-default"
+          type="number"
+          value={localConfig.defaultValue ?? ''}
+          onChange={(e) => {
+            const value = e.target.value;
+            if (value === '') {
+              const newConfig = { ...localConfig };
+              delete newConfig.defaultValue;
+              setLocalConfig(newConfig);
+              onChange(newConfig);
+            } else {
+              const numValue = parseInt(value, 10);
+              if (!isNaN(numValue)) {
+                handleChange({ defaultValue: numValue });
+              }
+            }
+          }}
+          placeholder="0（今日）"
+        />
+      </div>
+
+      {/* 最小値・最大値 */}
+      <div className="grid grid-cols-2 gap-3">
+        <div className="grid gap-2">
+          <Label htmlFor="date-min">最小日付</Label>
+          <Popover open={minOpen} onOpenChange={setMinOpen}>
+            <PopoverTrigger asChild>
+              <Button
+                variant="outline"
+                className={cn(
+                  'w-full justify-start text-left font-normal',
+                  !localConfig.min && 'text-muted-foreground'
+                )}
+              >
+                <CalendarIcon className="mr-2 h-4 w-4" />
+                {localConfig.min || '制限なし'}
+              </Button>
+            </PopoverTrigger>
+            <PopoverContent className="w-auto p-0" align="start">
+              <DatePickerCalendar
+                selected={
+                  localConfig.min ? new Date(localConfig.min) : undefined
+                }
+                onSelect={(date) => {
+                  if (date) {
+                    handleDateInput('min', format(date, 'yyyy-MM-dd'));
+                  } else {
+                    handleDateInput('min', '');
+                  }
+                  setMinOpen(false);
+                }}
+              />
+            </PopoverContent>
+          </Popover>
+        </div>
+        <div className="grid gap-2">
+          <Label htmlFor="date-max">最大日付</Label>
+          <Popover open={maxOpen} onOpenChange={setMaxOpen}>
+            <PopoverTrigger asChild>
+              <Button
+                variant="outline"
+                className={cn(
+                  'w-full justify-start text-left font-normal',
+                  !localConfig.max && 'text-muted-foreground'
+                )}
+              >
+                <CalendarIcon className="mr-2 h-4 w-4" />
+                {localConfig.max || '制限なし'}
+              </Button>
+            </PopoverTrigger>
+            <PopoverContent className="w-auto p-0" align="start">
+              <DatePickerCalendar
+                selected={
+                  localConfig.max ? new Date(localConfig.max) : undefined
+                }
+                onSelect={(date) => {
+                  if (date) {
+                    handleDateInput('max', format(date, 'yyyy-MM-dd'));
+                  } else {
+                    handleDateInput('max', '');
+                  }
+                  setMaxOpen(false);
+                }}
+              />
+            </PopoverContent>
+          </Popover>
+        </div>
+      </div>
+
+      {/* 過去/未来の許可 */}
+      <div className="grid gap-3">
+        <div className="flex items-center space-x-2">
+          <Checkbox
+            id="date-allow-past"
+            checked={localConfig.allowPast !== false}
+            onCheckedChange={(checked) =>
+              handleChange({ allowPast: checked === true })
+            }
+          />
+          <label
+            htmlFor="date-allow-past"
+            className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
+          >
+            過去日付を許可
+          </label>
+        </div>
+        <div className="flex items-center space-x-2">
+          <Checkbox
+            id="date-allow-future"
+            checked={localConfig.allowFuture !== false}
+            onCheckedChange={(checked) =>
+              handleChange({ allowFuture: checked === true })
+            }
+          />
+          <label
+            htmlFor="date-allow-future"
+            className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
+          >
+            未来日付を許可
+          </label>
+        </div>
+      </div>
+
+      {/* プレースホルダー */}
+      <div className="grid gap-2">
+        <Label htmlFor="date-placeholder">プレースホルダー</Label>
+        <Input
+          id="date-placeholder"
+          value={localConfig.placeholder ?? ''}
+          onChange={(e) => {
+            const value = e.target.value;
+            if (value === '') {
+              const newConfig = { ...localConfig };
+              delete newConfig.placeholder;
+              setLocalConfig(newConfig);
+              onChange(newConfig);
+            } else {
+              handleChange({ placeholder: value });
+            }
+          }}
+          placeholder="日付を選択"
+        />
+      </div>
+    </div>
+  );
+}

--- a/features/column/components/edit-column-item.tsx
+++ b/features/column/components/edit-column-item.tsx
@@ -14,12 +14,15 @@ import { DropdownMenuItem } from '@/components/ui/dropdown-menu';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Checkbox } from '@/components/ui/checkbox';
+import { ScrollArea } from '@/components/ui/scroll-area';
 import { Pencil } from 'lucide-react';
 import { toast } from 'sonner';
 import { updateColumn } from '../api/update-column';
 import type { Column, SelectOption } from '../types/column';
 import { SelectConfigEditor } from './config/select-config-editor';
 import { NumberConfigEditor } from './config/number-config-editor';
+import { DateConfigEditor } from './config/date-config-editor';
+import type { DatePrecision } from '../types/column';
 
 /**
  * カラム編集アイテムのProps型
@@ -66,6 +69,17 @@ export function EditColumnItem({
     step?: number;
   }>({});
 
+  // DATE用の状態
+  const [dateConfig, setDateConfig] = useState<{
+    precision?: DatePrecision;
+    defaultValue?: number;
+    min?: string;
+    max?: string;
+    allowPast?: boolean;
+    allowFuture?: boolean;
+    placeholder?: string;
+  }>({});
+
   // ダイアログが開かれたときに最新の値をセット
   useEffect(() => {
     if (open) {
@@ -85,6 +99,12 @@ export function EditColumnItem({
       if (column.type === 'NUMBER') {
         const config = column.config;
         setNumberConfig(config || {});
+      }
+
+      // DATEの場合、configから値を取得
+      if (column.type === 'DATE') {
+        const config = column.config;
+        setDateConfig(config || {});
       }
     }
   }, [open, column]);
@@ -130,6 +150,8 @@ export function EditColumnItem({
         Object.keys(numberConfig).length > 0
       ) {
         config = numberConfig;
+      } else if (column.type === 'DATE' && Object.keys(dateConfig).length > 0) {
+        config = dateConfig;
       }
 
       const result = await updateColumn(itemId, column.id, {
@@ -174,62 +196,73 @@ export function EditColumnItem({
           編集
         </DropdownMenuItem>
       </DialogTrigger>
-      <DialogContent className="sm:max-w-[600px] max-h-[90vh] overflow-y-auto">
-        <DialogHeader>
+      <DialogContent className="sm:max-w-[600px] max-h-[90vh] p-0">
+        <DialogHeader className="px-6 py-6">
           <DialogTitle>項目を編集</DialogTitle>
         </DialogHeader>
         <form onSubmit={handleSubmit}>
-          <div className="grid gap-4 py-4">
-            <div className="grid gap-2">
-              <Label htmlFor="edit-name">項目名</Label>
-              <Input
-                id="edit-name"
-                value={columnName}
-                onChange={(e) => setColumnName(e.target.value)}
-                placeholder="項目名"
-                required
-              />
+          <ScrollArea className="[&>div[data-radix-scroll-area-viewport]]:max-h-[50vh] px-6">
+            <div className="grid gap-4">
+              <div className="grid gap-2">
+                <Label htmlFor="edit-name">項目名</Label>
+                <Input
+                  id="edit-name"
+                  value={columnName}
+                  onChange={(e) => setColumnName(e.target.value)}
+                  placeholder="項目名"
+                  required
+                />
+              </div>
+
+              {/* SELECT/MULTI_SELECT用の選択肢設定 */}
+              {(column.type === 'SELECT' || column.type === 'MULTI_SELECT') && (
+                <SelectConfigEditor
+                  options={selectOptions}
+                  defaultValue={defaultValue}
+                  isMultiSelect={column.type === 'MULTI_SELECT'}
+                  onChange={(options, defValue) => {
+                    setSelectOptions(options);
+                    setDefaultValue(
+                      defValue || (column.type === 'MULTI_SELECT' ? [] : '')
+                    );
+                  }}
+                />
+              )}
+
+              {/* NUMBER用の設定 */}
+              {column.type === 'NUMBER' && (
+                <NumberConfigEditor
+                  key={open ? column.id : 'closed'}
+                  config={numberConfig}
+                  onChange={setNumberConfig}
+                />
+              )}
+
+              {/* DATE用の設定 */}
+              {column.type === 'DATE' && (
+                <DateConfigEditor
+                  key={open ? column.id : 'closed'}
+                  config={dateConfig}
+                  onChange={setDateConfig}
+                />
+              )}
+
+              <div className="flex items-center space-x-2">
+                <Checkbox
+                  id="edit-required"
+                  checked={isRequired}
+                  onCheckedChange={(checked) => setIsRequired(checked === true)}
+                />
+                <label
+                  htmlFor="edit-required"
+                  className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
+                >
+                  必須項目にする
+                </label>
+              </div>
             </div>
-
-            {/* SELECT/MULTI_SELECT用の選択肢設定 */}
-            {(column.type === 'SELECT' || column.type === 'MULTI_SELECT') && (
-              <SelectConfigEditor
-                options={selectOptions}
-                defaultValue={defaultValue}
-                isMultiSelect={column.type === 'MULTI_SELECT'}
-                onChange={(options, defValue) => {
-                  setSelectOptions(options);
-                  setDefaultValue(
-                    defValue || (column.type === 'MULTI_SELECT' ? [] : '')
-                  );
-                }}
-              />
-            )}
-
-            {/* NUMBER用の設定 */}
-            {column.type === 'NUMBER' && (
-              <NumberConfigEditor
-                key={open ? column.id : 'closed'}
-                config={numberConfig}
-                onChange={setNumberConfig}
-              />
-            )}
-
-            <div className="flex items-center space-x-2">
-              <Checkbox
-                id="edit-required"
-                checked={isRequired}
-                onCheckedChange={(checked) => setIsRequired(checked === true)}
-              />
-              <label
-                htmlFor="edit-required"
-                className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
-              >
-                必須項目にする
-              </label>
-            </div>
-          </div>
-          <DialogFooter>
+          </ScrollArea>
+          <DialogFooter className="px-6 py-6">
             <Button
               type="button"
               variant="outline"

--- a/features/column/types/column.ts
+++ b/features/column/types/column.ts
@@ -23,15 +23,17 @@ export type SelectOption = {
 };
 
 /**
+ * 日付精度の型
+ */
+export type DatePrecision = 'year' | 'month' | 'day';
+
+/**
  * 日付フォーマットの型
- * 将来的に年月のみ、日時、秒数までなど細かい設定に対応可能
  */
 export type DateFormatType =
   | 'YYYY-MM-DD' // 日付のみ
   | 'YYYY/MM/DD' // 日付のみ（スラッシュ区切り）
-  | 'YYYY-MM' // 年月のみ（将来実装）
-  | 'YYYY-MM-DD HH:mm' // 日時（将来実装）
-  | 'YYYY-MM-DD HH:mm:ss'; // 日時秒（将来実装）
+  | 'YYYY-MM'; // 年月のみ
 
 /**
  * 各カラムタイプ固有の設定
@@ -57,9 +59,15 @@ export type ColumnTypeConfig = {
     placeholder?: string;
   };
   DATE: {
-    format?: DateFormatType;
-    min?: string; // ISO 8601形式
-    max?: string; // ISO 8601形式
+    precision?: DatePrecision; // 精度（デフォルト: 'day'）
+    format?: DateFormatType; // 表示フォーマット
+    defaultValue?: number; // デフォルト値（相対日数: 0=今日、正数=未来、負数=過去）
+    min?: string; // 入力可能な最小日付（ISO 8601形式）
+    max?: string; // 入力可能な最大日付（ISO 8601形式）
+    allowPast?: boolean; // 過去日付を許可（デフォルト: true）
+    allowFuture?: boolean; // 未来日付を許可（デフォルト: true）
+    showWeekday?: boolean; // 曜日を表示
+    placeholder?: string; // プレースホルダー
   };
   SELECT: {
     options: SelectOption[];

--- a/features/column/types/column.ts
+++ b/features/column/types/column.ts
@@ -25,7 +25,7 @@ export type SelectOption = {
 /**
  * 日付精度の型
  */
-export type DatePrecision = 'year' | 'month' | 'day';
+export type DatePrecision = 'year' | 'month' | 'day' | 'day_weekday';
 
 /**
  * 日付フォーマットの型
@@ -66,7 +66,6 @@ export type ColumnTypeConfig = {
     max?: string; // 入力可能な最大日付（ISO 8601形式）
     allowPast?: boolean; // 過去日付を許可（デフォルト: true）
     allowFuture?: boolean; // 未来日付を許可（デフォルト: true）
-    showWeekday?: boolean; // 曜日を表示
     placeholder?: string; // プレースホルダー
   };
   SELECT: {

--- a/features/column/utils/apply-default-values.ts
+++ b/features/column/utils/apply-default-values.ts
@@ -1,3 +1,4 @@
+import { format } from 'date-fns';
 import type { Column } from '../types/column';
 import type { RecordData } from '@/features/record/types';
 
@@ -23,6 +24,23 @@ export function applyDefaultValues(columns: Column[]): RecordData {
       column.config?.defaultValue !== undefined
     ) {
       data[column.id] = column.config.defaultValue;
+    } else if (
+      column.type === 'DATE' &&
+      column.config?.defaultValue !== undefined
+    ) {
+      // DATE型のデフォルト値処理（相対日数）
+      const relativeDay = column.config.defaultValue;
+      const today = new Date();
+      today.setDate(today.getDate() + relativeDay); // 相対日数を加算
+
+      const precision = column.config.precision || 'day';
+      const formats: Record<string, string> = {
+        year: 'yyyy',
+        month: 'yyyy-MM',
+        day: 'yyyy-MM-dd',
+        day_weekday: 'yyyy-MM-dd', // 保存時は day と同じ
+      };
+      data[column.id] = format(today, formats[precision]);
     }
     // 他のカラムタイプは明示的に値を設定しない（undefined）
   }

--- a/features/column/utils/validate-column-value.ts
+++ b/features/column/utils/validate-column-value.ts
@@ -199,6 +199,34 @@ function validateDateValue(
     };
   }
 
+  // 過去日付の許可チェック
+  const allowPast = column.config?.allowPast !== false; // デフォルトtrue
+  if (!allowPast) {
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+    if (date < today) {
+      return {
+        columnId: column.id,
+        columnName: column.name,
+        message: `${column.name}は今日以降の日付を入力してください`,
+      };
+    }
+  }
+
+  // 未来日付の許可チェック
+  const allowFuture = column.config?.allowFuture !== false; // デフォルトtrue
+  if (!allowFuture) {
+    const today = new Date();
+    today.setHours(23, 59, 59, 999);
+    if (date > today) {
+      return {
+        columnId: column.id,
+        columnName: column.name,
+        message: `${column.name}は今日以前の日付を入力してください`,
+      };
+    }
+  }
+
   return null;
 }
 

--- a/features/table/components/cells/date-cell.tsx
+++ b/features/table/components/cells/date-cell.tsx
@@ -3,7 +3,6 @@
 import { useState } from 'react';
 import { format } from 'date-fns';
 import { ja } from 'date-fns/locale';
-import { CalendarIcon } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { DatePickerCalendar } from '@/components/ui/date-picker-calendar';
 import {
@@ -12,18 +11,57 @@ import {
   PopoverTrigger,
 } from '@/components/ui/popover';
 import { cn } from '@/lib/utils';
+import type { DatePrecision } from '@/features/column/types/column';
 
 type DateCellProps = {
   value: string | null;
   onChange: (value: string | null) => void;
+  precision?: DatePrecision;
   min?: string;
   max?: string;
+  placeholder?: string;
 };
+
+/**
+ * 精度に応じたフォーマット文字列を取得
+ */
+function getFormatString(precision?: DatePrecision): string {
+  const formats: Record<DatePrecision, string> = {
+    year: 'yyyy',
+    month: 'yyyy/MM',
+    day: 'yyyy/MM/dd',
+    day_weekday: 'yyyy/MM/dd（E）',
+  };
+
+  return formats[precision || 'day'];
+}
+
+/**
+ * 精度に応じた保存形式を取得
+ * day_weekday は day と同じフォーマットで保存
+ */
+function getSaveFormat(precision?: DatePrecision): string {
+  const formats: Record<DatePrecision, string> = {
+    year: 'yyyy',
+    month: 'yyyy-MM',
+    day: 'yyyy-MM-dd',
+    day_weekday: 'yyyy-MM-dd',
+  };
+
+  return formats[precision || 'day'];
+}
 
 /**
  * 日付セルコンポーネント
  */
-export function DateCell({ value, onChange, min, max }: DateCellProps) {
+export function DateCell({
+  value,
+  onChange,
+  precision = 'day',
+  min,
+  max,
+  placeholder = '-',
+}: DateCellProps) {
   const [open, setOpen] = useState(false);
 
   const date = value ? new Date(value) : undefined;
@@ -32,8 +70,8 @@ export function DateCell({ value, onChange, min, max }: DateCellProps) {
 
   const handleSelect = (selectedDate: Date | undefined) => {
     if (selectedDate) {
-      // YYYY-MM-DD形式で保存
-      const formatted = format(selectedDate, 'yyyy-MM-dd');
+      const saveFormat = getSaveFormat(precision);
+      const formatted = format(selectedDate, saveFormat);
       onChange(formatted);
     } else {
       onChange(null);
@@ -42,9 +80,10 @@ export function DateCell({ value, onChange, min, max }: DateCellProps) {
   };
 
   const formatDisplayDate = (dateStr: string | null) => {
-    if (!dateStr) return '-';
+    if (!dateStr) return placeholder;
     try {
-      return format(new Date(dateStr), 'yyyy/MM/dd', { locale: ja });
+      const displayFormat = getFormatString(precision);
+      return format(new Date(dateStr), displayFormat, { locale: ja });
     } catch {
       return dateStr;
     }
@@ -60,7 +99,6 @@ export function DateCell({ value, onChange, min, max }: DateCellProps) {
             !value && 'text-muted-foreground'
           )}
         >
-          <CalendarIcon className="mr-2 h-4 w-4" />
           {formatDisplayDate(value)}
         </Button>
       </PopoverTrigger>

--- a/features/table/components/columns.tsx
+++ b/features/table/components/columns.tsx
@@ -109,8 +109,10 @@ export const createColumns = (
             <DateCell
               value={(value as string) ?? null}
               onChange={handleChange}
+              precision={column.config?.precision}
               min={column.config?.min}
               max={column.config?.max}
+              placeholder={column.config?.placeholder}
             />
           );
         case 'SELECT':


### PR DESCRIPTION
## 概要

DATE型カラムに精度設定、デフォルト値、バリデーションなどの設定機能を実装しました。

## 実装内容

- **DateConfigEditor コンポーネント**: DATE型カラムの設定エディタを実装
  - 精度設定（年のみ/年月/年月日/年月日（曜日））
  - デフォルト値（相対日数: 0=今日、正数=未来、負数=過去）
  - 最小日付・最大日付の設定
  - 過去日付を許可/未来日付を許可のチェックボックス
  - プレースホルダー設定
- **`date-cell.tsx`拡張**: 日付セルの表示・編集機能を拡張
  - 精度に応じたフォーマット（年/月/日/日（曜日））
  - 曜日表示は `day_weekday` 精度で対応（例: 2025/01/15（水））
  - プレースホルダー対応
- **バリデーション機能**: `validate-column-value.ts` にDATE型のバリデーションを追加
  - `allowPast=false`の場合、今日以降のみ許可
  - `allowFuture=false`の場合、今日以前のみ許可
- **デフォルト値適用**: `apply-default-values.ts`にDATE型のデフォルト値適用ロジックを追加
  - 相対日数で指定（0=今日、7=7日後、-7=7日前）
  - 精度に応じたフォーマットで保存（`day_weekday`はdayと同じフォーマットで保存）

## 設計方針

- NUMBER型の実装パターンに従い、統一感のあるコード
- useEffectなし、key propによるリマウント制御
- 精度は日付のみ（年/月/日）に限定（時刻は今回対象外）
- 曜日表示は独立したオプションではなく、精度の一種（`day_weekday`）として実装

## 動作確認

- [x] カラム追加ダイアログでDATE型の設定ができることを確認
- [x] カラム編集ダイアログでDATE型の設定を変更できることを確認
- [x] テーブルでDATE型のセルが設定に従って表示・編集できることを確認
- [x] 精度（年/月/日/日（曜日））が正しく反映されることを確認
- [x] 曜日表示（day_weekday）が正しく機能することを確認
- [x] デフォルト値（相対日数）が新規レコード作成時に適用されることを確認
- [x] 過去/未来制限のバリデーションが機能することを確認

## 関連 Issue

Closes #35