### PR TITLE
テキストエリアカラムの設定機能

### DIFF
--- a/features/column/components/add-column-dialog.tsx
+++ b/features/column/components/add-column-dialog.tsx
@@ -27,6 +27,7 @@ import { SelectConfigEditor } from './config/select-config-editor';
 import { NumberConfigEditor } from './config/number-config-editor';
 import { DateConfigEditor } from './config/date-config-editor';
 import { TextConfigEditor } from './config/text-config-editor';
+import { TextareaConfigEditor } from './config/textarea-config-editor';
 import type { DatePrecision } from '../types/column';
 import { ScrollArea } from '@/components/ui/scroll-area';
 
@@ -64,6 +65,12 @@ export function AddColumnDialog({
     defaultValue?: string;
   }>({});
 
+  // TEXTAREA用の状態
+  const [textareaConfig, setTextareaConfig] = useState<{
+    placeholder?: string;
+    defaultValue?: string;
+  }>({});
+
   // NUMBER用の状態
   const [numberConfig, setNumberConfig] = useState<{
     min?: number;
@@ -95,6 +102,7 @@ export function AddColumnDialog({
       setSelectOptions([]);
       setDefaultValue('');
       setTextConfig({});
+      setTextareaConfig({});
       setNumberConfig({});
       setDateConfig({});
     }
@@ -128,6 +136,11 @@ export function AddColumnDialog({
       let config;
       if (columnType === 'TEXT' && Object.keys(textConfig).length > 0) {
         config = textConfig;
+      } else if (
+        columnType === 'TEXTAREA' &&
+        Object.keys(textareaConfig).length > 0
+      ) {
+        config = textareaConfig;
       } else if (columnType === 'SELECT') {
         config = {
           options: selectOptions,
@@ -229,6 +242,15 @@ export function AddColumnDialog({
                   key={open ? 'open' : 'closed'}
                   config={textConfig}
                   onChange={setTextConfig}
+                />
+              )}
+
+              {/* TEXTAREA用の設定 */}
+              {columnType === 'TEXTAREA' && (
+                <TextareaConfigEditor
+                  key={open ? 'open' : 'closed'}
+                  config={textareaConfig}
+                  onChange={setTextareaConfig}
                 />
               )}
 

--- a/features/column/components/config/textarea-config-editor.tsx
+++ b/features/column/components/config/textarea-config-editor.tsx
@@ -1,0 +1,59 @@
+'use client';
+
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+
+/**
+ * TextareaConfigEditorのProps
+ */
+type TextareaConfigEditorProps = {
+  config: {
+    placeholder?: string;
+    defaultValue?: string;
+  };
+  onChange: (config: { placeholder?: string; defaultValue?: string }) => void;
+};
+
+/**
+ * TEXTAREA型カラムの設定エディタコンポーネント
+ */
+export function TextareaConfigEditor({
+  config,
+  onChange,
+}: TextareaConfigEditorProps) {
+  return (
+    <div className="grid gap-4">
+      <div className="grid gap-2">
+        <Label htmlFor="textarea-placeholder">プレースホルダー</Label>
+        <Input
+          id="textarea-placeholder"
+          value={config.placeholder || ''}
+          onChange={(e) =>
+            onChange({
+              ...config,
+              placeholder: e.target.value || undefined,
+            })
+          }
+          placeholder="入力欄に表示するヒントテキスト"
+        />
+      </div>
+
+      <div className="grid gap-2">
+        <Label htmlFor="textarea-defaultValue">デフォルト値</Label>
+        <Textarea
+          id="textarea-defaultValue"
+          value={config.defaultValue || ''}
+          onChange={(e) =>
+            onChange({
+              ...config,
+              defaultValue: e.target.value || undefined,
+            })
+          }
+          placeholder="新規レコード作成時の初期値"
+          rows={3}
+        />
+      </div>
+    </div>
+  );
+}

--- a/features/column/components/edit-column-item.tsx
+++ b/features/column/components/edit-column-item.tsx
@@ -23,6 +23,7 @@ import { SelectConfigEditor } from './config/select-config-editor';
 import { NumberConfigEditor } from './config/number-config-editor';
 import { DateConfigEditor } from './config/date-config-editor';
 import { TextConfigEditor } from './config/text-config-editor';
+import { TextareaConfigEditor } from './config/textarea-config-editor';
 import type { DatePrecision } from '../types/column';
 
 /**
@@ -65,6 +66,12 @@ export function EditColumnItem({
     defaultValue?: string;
   }>({});
 
+  // TEXTAREA用の状態
+  const [textareaConfig, setTextareaConfig] = useState<{
+    placeholder?: string;
+    defaultValue?: string;
+  }>({});
+
   // NUMBER用の状態
   const [numberConfig, setNumberConfig] = useState<{
     min?: number;
@@ -97,6 +104,12 @@ export function EditColumnItem({
       if (column.type === 'TEXT') {
         const config = column.config;
         setTextConfig(config || {});
+      }
+
+      // TEXTAREAの場合、configから値を取得
+      if (column.type === 'TEXTAREA') {
+        const config = column.config;
+        setTextareaConfig(config || {});
       }
 
       // SELECT/MULTI_SELECTの場合、configから値を取得
@@ -150,6 +163,11 @@ export function EditColumnItem({
       let config;
       if (column.type === 'TEXT' && Object.keys(textConfig).length > 0) {
         config = textConfig;
+      } else if (
+        column.type === 'TEXTAREA' &&
+        Object.keys(textareaConfig).length > 0
+      ) {
+        config = textareaConfig;
       } else if (column.type === 'SELECT') {
         config = {
           options: selectOptions,
@@ -235,6 +253,15 @@ export function EditColumnItem({
                   key={open ? column.id : 'closed'}
                   config={textConfig}
                   onChange={setTextConfig}
+                />
+              )}
+
+              {/* TEXTAREA用の設定 */}
+              {column.type === 'TEXTAREA' && (
+                <TextareaConfigEditor
+                  key={open ? column.id : 'closed'}
+                  config={textareaConfig}
+                  onChange={setTextareaConfig}
                 />
               )}
 

--- a/features/column/types/column.ts
+++ b/features/column/types/column.ts
@@ -44,9 +44,8 @@ export type ColumnTypeConfig = {
     defaultValue?: string; // デフォルト値
   };
   TEXTAREA: {
-    maxLength?: number;
-    placeholder?: string;
-    rows?: number;
+    placeholder?: string; // プレースホルダー
+    defaultValue?: string; // デフォルト値
   };
   NUMBER: {
     min?: number; // 最小値

--- a/features/column/utils/apply-default-values.ts
+++ b/features/column/utils/apply-default-values.ts
@@ -12,6 +12,8 @@ export function applyDefaultValues(columns: Column[]): RecordData {
     // デフォルト値が定義されているカラムタイプを処理
     if (column.type === 'TEXT' && column.config?.defaultValue) {
       data[column.id] = column.config.defaultValue;
+    } else if (column.type === 'TEXTAREA' && column.config?.defaultValue) {
+      data[column.id] = column.config.defaultValue;
     } else if (column.type === 'SELECT' && column.config?.defaultValue) {
       data[column.id] = column.config.defaultValue;
     } else if (column.type === 'MULTI_SELECT' && column.config?.defaultValue) {

--- a/features/column/utils/validate-column-value.ts
+++ b/features/column/utils/validate-column-value.ts
@@ -97,15 +97,6 @@ function validateTextareaValue(
     };
   }
 
-  const maxLength = column.config?.maxLength;
-  if (maxLength && value.length > maxLength) {
-    return {
-      columnId: column.id,
-      columnName: column.name,
-      message: `${column.name}は${maxLength}文字以内で入力してください`,
-    };
-  }
-
   return null;
 }
 

--- a/features/table/components/cells/textarea-cell.tsx
+++ b/features/table/components/cells/textarea-cell.tsx
@@ -7,7 +7,6 @@ type TextareaCellProps = {
   value: string;
   onChange: (value: string) => void;
   placeholder?: string;
-  maxLength?: number;
 };
 
 /**
@@ -17,7 +16,6 @@ export function TextareaCell({
   value,
   onChange,
   placeholder,
-  maxLength,
 }: TextareaCellProps) {
   const [isEditing, setIsEditing] = useState(false);
   const [editValue, setEditValue] = useState('');
@@ -61,19 +59,22 @@ export function TextareaCell({
         onBlur={handleSave}
         onKeyDown={handleKeyDown}
         placeholder={placeholder}
-        maxLength={maxLength}
+        rows={3}
         className="min-h-[60px] w-full border-0 bg-transparent focus-visible:ring-1 focus-visible:ring-primary resize-none"
       />
     );
   }
+
+  // 最初の1行だけを表示
+  const firstLine = value ? value.split('\n')[0] : '';
 
   return (
     <div
       className="cursor-text min-h-[32px] px-2 py-1 hover:bg-muted/50 rounded flex items-center w-full"
       onClick={handleStartEdit}
     >
-      <span className={value ? 'line-clamp-2' : 'text-muted-foreground'}>
-        {value || placeholder || '-'}
+      <span className={firstLine ? '' : 'text-muted-foreground'}>
+        {firstLine || placeholder || '-'}
       </span>
     </div>
   );

--- a/features/table/components/columns.tsx
+++ b/features/table/components/columns.tsx
@@ -86,7 +86,6 @@ export const createColumns = (
               value={(value as string) ?? ''}
               onChange={handleChange}
               placeholder={column.config?.placeholder}
-              maxLength={column.config?.maxLength}
             />
           );
         case 'NUMBER':


### PR DESCRIPTION
## 概要

テキストエリア（TEXTAREA）カラムの設定機能を実装しました。

## 実装内容

- TextareaConfigEditorコンポーネント: TEXTAREA型カラムの設定UIを追加
- プレースホルダー設定
- デフォルト値設定（複数行対応）
- 項目追加ダイアログへの統合: TEXTAREA選択時に設定エディタを表示
- 項目編集ダイアログへの統合: 既存設定の編集に対応
- TextareaCellでのplaceholder表示: 値が空の場合にプレースホルダーを表示
- デフォルト値の適用: 新規レコード作成時に初期値を設定

## 動作確認

- [x] TEXTAREA型カラムの追加時にプレースホルダーを設定できる
- [x] TEXTAREA型カラムの追加時にデフォルト値を設定できる
- [x] 既存TEXTAREA型カラムの設定を編集できる
- [x] 新規レコード作成時にデフォルト値が適用される
- [x] 値が空の場合にプレースホルダーが表示される

## 関連 Issue

<!-- 関連するIssueがあれば記載してください -->

Closes #37 
