### PR TITLE
チェックボックスカラムの設定機能

### DIFF
--- a/components/ui/switch.tsx
+++ b/components/ui/switch.tsx
@@ -1,0 +1,31 @@
+"use client"
+
+import * as React from "react"
+import * as SwitchPrimitive from "@radix-ui/react-switch"
+
+import { cn } from "@/lib/utils"
+
+function Switch({
+  className,
+  ...props
+}: React.ComponentProps<typeof SwitchPrimitive.Root>) {
+  return (
+    <SwitchPrimitive.Root
+      data-slot="switch"
+      className={cn(
+        "peer data-[state=checked]:bg-primary data-[state=unchecked]:bg-input focus-visible:border-ring focus-visible:ring-ring/50 dark:data-[state=unchecked]:bg-input/80 inline-flex h-[1.15rem] w-8 shrink-0 items-center rounded-full border border-transparent shadow-xs transition-all outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50",
+        className
+      )}
+      {...props}
+    >
+      <SwitchPrimitive.Thumb
+        data-slot="switch-thumb"
+        className={cn(
+          "bg-background dark:data-[state=unchecked]:bg-foreground dark:data-[state=checked]:bg-primary-foreground pointer-events-none block size-4 rounded-full ring-0 transition-transform data-[state=checked]:translate-x-[calc(100%-2px)] data-[state=unchecked]:translate-x-0"
+        )}
+      />
+    </SwitchPrimitive.Root>
+  )
+}
+
+export { Switch }

--- a/components/ui/switch.tsx
+++ b/components/ui/switch.tsx
@@ -1,9 +1,9 @@
-"use client"
+'use client';
 
-import * as React from "react"
-import * as SwitchPrimitive from "@radix-ui/react-switch"
+import * as React from 'react';
+import * as SwitchPrimitive from '@radix-ui/react-switch';
 
-import { cn } from "@/lib/utils"
+import { cn } from '@/lib/utils';
 
 function Switch({
   className,
@@ -13,7 +13,7 @@ function Switch({
     <SwitchPrimitive.Root
       data-slot="switch"
       className={cn(
-        "peer data-[state=checked]:bg-primary data-[state=unchecked]:bg-input focus-visible:border-ring focus-visible:ring-ring/50 dark:data-[state=unchecked]:bg-input/80 inline-flex h-[1.15rem] w-8 shrink-0 items-center rounded-full border border-transparent shadow-xs transition-all outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50",
+        'peer data-[state=checked]:bg-primary data-[state=unchecked]:bg-input focus-visible:border-ring focus-visible:ring-ring/50 dark:data-[state=unchecked]:bg-input/80 inline-flex h-[1.15rem] w-8 shrink-0 items-center rounded-full border border-transparent shadow-xs transition-all outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50',
         className
       )}
       {...props}
@@ -21,11 +21,11 @@ function Switch({
       <SwitchPrimitive.Thumb
         data-slot="switch-thumb"
         className={cn(
-          "bg-background dark:data-[state=unchecked]:bg-foreground dark:data-[state=checked]:bg-primary-foreground pointer-events-none block size-4 rounded-full ring-0 transition-transform data-[state=checked]:translate-x-[calc(100%-2px)] data-[state=unchecked]:translate-x-0"
+          'bg-background dark:data-[state=unchecked]:bg-foreground dark:data-[state=checked]:bg-primary-foreground pointer-events-none block size-4 rounded-full ring-0 transition-transform data-[state=checked]:translate-x-[calc(100%-2px)] data-[state=unchecked]:translate-x-0'
         )}
       />
     </SwitchPrimitive.Root>
-  )
+  );
 }
 
-export { Switch }
+export { Switch };

--- a/features/column/api/__tests__/add-column.test.ts
+++ b/features/column/api/__tests__/add-column.test.ts
@@ -83,7 +83,14 @@ describe('addColumn', () => {
       order: 0,
     });
 
-    expect(result).toEqual({ success: true });
+    expect(result.success).toBe(true);
+    expect(result.column).toEqual(
+      expect.objectContaining({
+        name: '顧客名',
+        type: 'TEXT',
+        order: 0,
+      })
+    );
     expect(prisma.item.update).toHaveBeenCalledWith(
       expect.objectContaining({
         where: { id: 'item-1' },
@@ -133,7 +140,14 @@ describe('addColumn', () => {
       order: 0,
     });
 
-    expect(result).toEqual({ success: true });
+    expect(result.success).toBe(true);
+    expect(result.column).toEqual(
+      expect.objectContaining({
+        name: '顧客名',
+        type: 'TEXT',
+        order: 0,
+      })
+    );
     expect(prisma.item.update).toHaveBeenCalled();
   });
 
@@ -243,7 +257,14 @@ describe('addColumn', () => {
       order: 0,
     });
 
-    expect(result).toEqual({ success: true });
+    expect(result.success).toBe(true);
+    expect(result.column).toEqual(
+      expect.objectContaining({
+        name: '顧客名',
+        type: 'TEXT',
+        order: 0,
+      })
+    );
     expect(prisma.item.update).toHaveBeenCalled();
   });
 

--- a/features/column/api/add-column.ts
+++ b/features/column/api/add-column.ts
@@ -3,7 +3,7 @@
 import { revalidatePath } from 'next/cache';
 import { createClient } from '@/lib/supabase/server';
 import { prisma } from '@/lib/prisma';
-import type { CreateColumnInput } from '../types/column';
+import type { Column, CreateColumnInput } from '../types/column';
 import { createTableMeta, getColumnSchema } from '../types/schema';
 import {
   addColumnToSchema,
@@ -13,6 +13,7 @@ import {
 type FormState = {
   error?: string;
   success?: boolean;
+  column?: Column;
 };
 
 /**
@@ -98,8 +99,11 @@ export async function addColumn(
       },
     });
 
-    revalidatePath(`/tables/${itemId}`);
-    return { success: true };
+    // 追加されたカラムを取得（最後に追加されたもの）
+    const addedColumn = newSchema.columns[newSchema.columns.length - 1];
+
+    revalidatePath(`/${itemId}`);
+    return { success: true, column: addedColumn };
   } catch (error) {
     console.error('カラム追加エラー:', error);
     return { error: 'カラムの追加に失敗しました' };

--- a/features/column/components/add-column-dialog.tsx
+++ b/features/column/components/add-column-dialog.tsx
@@ -21,7 +21,7 @@ import {
 import { Checkbox } from '@/components/ui/checkbox';
 import { toast } from 'sonner';
 import { addColumn } from '../api/add-column';
-import type { ColumnType, SelectOption } from '../types/column';
+import type { Column, ColumnType, SelectOption } from '../types/column';
 import { COLUMN_TYPE_LIST, COLUMN_CONFIGS } from '../constants';
 import { SelectConfigEditor } from './config/select-config-editor';
 import { NumberConfigEditor } from './config/number-config-editor';
@@ -40,6 +40,7 @@ type AddColumnDialogProps = {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   nextOrder: number;
+  onAdded?: (column: Column) => void;
 };
 
 /**
@@ -50,6 +51,7 @@ export function AddColumnDialog({
   open,
   onOpenChange,
   nextOrder,
+  onAdded,
 }: AddColumnDialogProps) {
   const [columnType, setColumnType] = useState<ColumnType>('TEXT');
   const [columnName, setColumnName] = useState('');
@@ -187,8 +189,9 @@ export function AddColumnDialog({
         toast.error('項目の追加に失敗しました', {
           description: result.error,
         });
-      } else if (result.success) {
+      } else if (result.success && result.column) {
         toast.success('項目を追加しました');
+        onAdded?.(result.column);
         onOpenChange(false);
       }
     } catch {

--- a/features/column/components/add-column-dialog.tsx
+++ b/features/column/components/add-column-dialog.tsx
@@ -28,6 +28,7 @@ import { NumberConfigEditor } from './config/number-config-editor';
 import { DateConfigEditor } from './config/date-config-editor';
 import { TextConfigEditor } from './config/text-config-editor';
 import { TextareaConfigEditor } from './config/textarea-config-editor';
+import { CheckboxConfigEditor } from './config/checkbox-config-editor';
 import type { DatePrecision } from '../types/column';
 import { ScrollArea } from '@/components/ui/scroll-area';
 
@@ -93,6 +94,14 @@ export function AddColumnDialog({
     placeholder?: string;
   }>({});
 
+  // CHECKBOX用の状態
+  const [checkboxConfig, setCheckboxConfig] = useState<{
+    checkedLabel?: string;
+    uncheckedLabel?: string;
+    defaultValue?: boolean;
+    displayStyle?: 'checkbox' | 'switch';
+  }>({});
+
   // ダイアログが閉じられたときに状態をリセット
   useEffect(() => {
     if (!open) {
@@ -105,6 +114,7 @@ export function AddColumnDialog({
       setTextareaConfig({});
       setNumberConfig({});
       setDateConfig({});
+      setCheckboxConfig({});
     }
   }, [open]);
 
@@ -158,6 +168,11 @@ export function AddColumnDialog({
         config = numberConfig;
       } else if (columnType === 'DATE' && Object.keys(dateConfig).length > 0) {
         config = dateConfig;
+      } else if (
+        columnType === 'CHECKBOX' &&
+        Object.keys(checkboxConfig).length > 0
+      ) {
+        config = checkboxConfig;
       }
 
       const result = await addColumn(itemId, {
@@ -287,19 +302,33 @@ export function AddColumnDialog({
                 />
               )}
 
-              <div className="flex items-center space-x-2">
-                <Checkbox
-                  id="required"
-                  checked={isRequired}
-                  onCheckedChange={(checked) => setIsRequired(checked === true)}
+              {/* CHECKBOX用の設定 */}
+              {columnType === 'CHECKBOX' && (
+                <CheckboxConfigEditor
+                  key={open ? 'open' : 'closed'}
+                  config={checkboxConfig}
+                  onChange={setCheckboxConfig}
                 />
-                <label
-                  htmlFor="required"
-                  className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
-                >
-                  必須項目にする
-                </label>
-              </div>
+              )}
+
+              {/* CHECKBOXは常にtrue/falseなので必須項目は不要 */}
+              {columnType !== 'CHECKBOX' && (
+                <div className="flex items-center space-x-2">
+                  <Checkbox
+                    id="required"
+                    checked={isRequired}
+                    onCheckedChange={(checked) =>
+                      setIsRequired(checked === true)
+                    }
+                  />
+                  <label
+                    htmlFor="required"
+                    className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
+                  >
+                    必須項目にする
+                  </label>
+                </div>
+              )}
             </div>
           </ScrollArea>
           <DialogFooter className="px-6 py-6">

--- a/features/column/components/config/checkbox-config-editor.tsx
+++ b/features/column/components/config/checkbox-config-editor.tsx
@@ -1,0 +1,111 @@
+'use client';
+
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Checkbox } from '@/components/ui/checkbox';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+
+/**
+ * CheckboxConfigEditorのProps
+ */
+type CheckboxConfigEditorProps = {
+  config: {
+    checkedLabel?: string;
+    uncheckedLabel?: string;
+    defaultValue?: boolean;
+    displayStyle?: 'checkbox' | 'switch';
+  };
+  onChange: (config: {
+    checkedLabel?: string;
+    uncheckedLabel?: string;
+    defaultValue?: boolean;
+    displayStyle?: 'checkbox' | 'switch';
+  }) => void;
+};
+
+/**
+ * CHECKBOX型カラムの設定エディタコンポーネント
+ */
+export function CheckboxConfigEditor({
+  config,
+  onChange,
+}: CheckboxConfigEditorProps) {
+  return (
+    <div className="grid gap-4">
+      <div className="grid gap-2">
+        <Label htmlFor="checkbox-displayStyle">表示スタイル</Label>
+        <Select
+          value={config.displayStyle || 'checkbox'}
+          onValueChange={(value: 'checkbox' | 'switch') =>
+            onChange({
+              ...config,
+              displayStyle: value === 'checkbox' ? undefined : value,
+            })
+          }
+        >
+          <SelectTrigger id="checkbox-displayStyle" className="w-[200px]">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="checkbox">チェックボックス</SelectItem>
+            <SelectItem value="switch">トグルスイッチ</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+
+      <div className="grid grid-cols-2 gap-4">
+        <div className="grid gap-2">
+          <Label htmlFor="checkbox-checkedLabel">チェック時のラベル</Label>
+          <Input
+            id="checkbox-checkedLabel"
+            value={config.checkedLabel || ''}
+            onChange={(e) =>
+              onChange({
+                ...config,
+                checkedLabel: e.target.value || undefined,
+              })
+            }
+            placeholder="例: 完了、有効"
+          />
+        </div>
+
+        <div className="grid gap-2">
+          <Label htmlFor="checkbox-uncheckedLabel">未チェック時のラベル</Label>
+          <Input
+            id="checkbox-uncheckedLabel"
+            value={config.uncheckedLabel || ''}
+            onChange={(e) =>
+              onChange({
+                ...config,
+                uncheckedLabel: e.target.value || undefined,
+              })
+            }
+            placeholder="例: 未完了、無効"
+          />
+        </div>
+      </div>
+
+      <div className="flex items-center space-x-2">
+        <Checkbox
+          id="checkbox-defaultValue"
+          checked={config.defaultValue || false}
+          onCheckedChange={(checked) =>
+            onChange({
+              ...config,
+              defaultValue: checked === true ? true : undefined,
+            })
+          }
+        />
+        <Label htmlFor="checkbox-defaultValue" className="font-normal">
+          デフォルトでチェック状態にする
+        </Label>
+      </div>
+    </div>
+  );
+}

--- a/features/column/components/edit-column-item.tsx
+++ b/features/column/components/edit-column-item.tsx
@@ -24,6 +24,7 @@ import { NumberConfigEditor } from './config/number-config-editor';
 import { DateConfigEditor } from './config/date-config-editor';
 import { TextConfigEditor } from './config/text-config-editor';
 import { TextareaConfigEditor } from './config/textarea-config-editor';
+import { CheckboxConfigEditor } from './config/checkbox-config-editor';
 import type { DatePrecision } from '../types/column';
 
 /**
@@ -94,6 +95,14 @@ export function EditColumnItem({
     placeholder?: string;
   }>({});
 
+  // CHECKBOX用の状態
+  const [checkboxConfig, setCheckboxConfig] = useState<{
+    checkedLabel?: string;
+    uncheckedLabel?: string;
+    defaultValue?: boolean;
+    displayStyle?: 'checkbox' | 'switch';
+  }>({});
+
   // ダイアログが開かれたときに最新の値をセット
   useEffect(() => {
     if (open) {
@@ -131,6 +140,12 @@ export function EditColumnItem({
       if (column.type === 'DATE') {
         const config = column.config;
         setDateConfig(config || {});
+      }
+
+      // CHECKBOXの場合、configから値を取得
+      if (column.type === 'CHECKBOX') {
+        const config = column.config;
+        setCheckboxConfig(config || {});
       }
     }
   }, [open, column]);
@@ -185,6 +200,11 @@ export function EditColumnItem({
         config = numberConfig;
       } else if (column.type === 'DATE' && Object.keys(dateConfig).length > 0) {
         config = dateConfig;
+      } else if (
+        column.type === 'CHECKBOX' &&
+        Object.keys(checkboxConfig).length > 0
+      ) {
+        config = checkboxConfig;
       }
 
       const result = await updateColumn(itemId, column.id, {
@@ -298,19 +318,33 @@ export function EditColumnItem({
                 />
               )}
 
-              <div className="flex items-center space-x-2">
-                <Checkbox
-                  id="edit-required"
-                  checked={isRequired}
-                  onCheckedChange={(checked) => setIsRequired(checked === true)}
+              {/* CHECKBOX用の設定 */}
+              {column.type === 'CHECKBOX' && (
+                <CheckboxConfigEditor
+                  key={open ? column.id : 'closed'}
+                  config={checkboxConfig}
+                  onChange={setCheckboxConfig}
                 />
-                <label
-                  htmlFor="edit-required"
-                  className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
-                >
-                  必須項目にする
-                </label>
-              </div>
+              )}
+
+              {/* CHECKBOXは常にtrue/falseなので必須項目は不要 */}
+              {column.type !== 'CHECKBOX' && (
+                <div className="flex items-center space-x-2">
+                  <Checkbox
+                    id="edit-required"
+                    checked={isRequired}
+                    onCheckedChange={(checked) =>
+                      setIsRequired(checked === true)
+                    }
+                  />
+                  <label
+                    htmlFor="edit-required"
+                    className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
+                  >
+                    必須項目にする
+                  </label>
+                </div>
+              )}
             </div>
           </ScrollArea>
           <DialogFooter className="px-6 py-6">

--- a/features/column/types/column.ts
+++ b/features/column/types/column.ts
@@ -76,9 +76,10 @@ export type ColumnTypeConfig = {
     defaultValue?: string[]; // デフォルト値（選択肢のIDの配列）
   };
   CHECKBOX: {
-    multiple?: boolean; // 複数選択を許可するか（将来実装）
-    options?: SelectOption[]; // multiple=trueの場合に使用（将来実装）
-    defaultValue?: boolean; // 単一選択の場合のデフォルト値
+    checkedLabel?: string; // チェック時のラベル（例: 「完了」）
+    uncheckedLabel?: string; // 未チェック時のラベル（例: 「未完了」）
+    defaultValue?: boolean; // デフォルト値
+    displayStyle?: 'checkbox' | 'switch'; // 表示スタイル（デフォルト: 'checkbox'）
   };
 };
 

--- a/features/column/utils/validate-column-value.ts
+++ b/features/column/utils/validate-column-value.ts
@@ -286,41 +286,14 @@ function validateCheckboxValue(
   value: unknown,
   column: CheckboxColumn
 ): ValidationError | null {
-  // 単一選択の場合
+  // CHECKBOXはboolean値のみ
   if (typeof value === 'boolean') {
-    return null;
-  }
-
-  // 複数選択の場合（将来実装）
-  if (Array.isArray(value)) {
-    if (!column.config?.options) {
-      return {
-        columnId: column.id,
-        columnName: column.name,
-        message: `${column.name}の選択肢が定義されていません`,
-      };
-    }
-
-    const validOptionIds = column.config.options.map((opt) => opt.id);
-
-    const invalidValues = value.filter(
-      (v) => typeof v !== 'string' || !validOptionIds.includes(v)
-    );
-
-    if (invalidValues.length > 0) {
-      return {
-        columnId: column.id,
-        columnName: column.name,
-        message: `${column.name}は有効な選択肢から選んでください`,
-      };
-    }
-
     return null;
   }
 
   return {
     columnId: column.id,
     columnName: column.name,
-    message: `${column.name}はブール値または配列である必要があります`,
+    message: `${column.name}はブール値である必要があります`,
   };
 }

--- a/features/table/components/cells/checkbox-cell.tsx
+++ b/features/table/components/cells/checkbox-cell.tsx
@@ -1,22 +1,40 @@
 'use client';
 
 import { Checkbox } from '@/components/ui/checkbox';
+import { Switch } from '@/components/ui/switch';
 
 type CheckboxCellProps = {
   value: boolean;
   onChange: (value: boolean) => void;
+  displayStyle?: 'checkbox' | 'switch';
+  checkedLabel?: string;
+  uncheckedLabel?: string;
 };
 
 /**
  * チェックボックスセルコンポーネント
  */
-export function CheckboxCell({ value, onChange }: CheckboxCellProps) {
+export function CheckboxCell({
+  value,
+  onChange,
+  displayStyle = 'checkbox',
+  checkedLabel,
+  uncheckedLabel,
+}: CheckboxCellProps) {
+  // ラベルを取得
+  const label = value ? checkedLabel : uncheckedLabel;
+
   return (
-    <div className="min-h-[32px] px-2 py-1 flex items-center justify-center w-full">
-      <Checkbox
-        checked={value}
-        onCheckedChange={(checked) => onChange(checked === true)}
-      />
+    <div className="min-h-[32px] px-2 py-1 flex items-center gap-2 w-full">
+      {displayStyle === 'switch' ? (
+        <Switch checked={value} onCheckedChange={onChange} />
+      ) : (
+        <Checkbox
+          checked={value}
+          onCheckedChange={(checked) => onChange(checked === true)}
+        />
+      )}
+      {label && <span className="text-sm">{label}</span>}
     </div>
   );
 }

--- a/features/table/components/columns.tsx
+++ b/features/table/components/columns.tsx
@@ -134,6 +134,9 @@ export const createColumns = (
             <CheckboxCell
               value={(value as boolean) ?? false}
               onChange={handleChange}
+              displayStyle={column.config?.displayStyle}
+              checkedLabel={column.config?.checkedLabel}
+              uncheckedLabel={column.config?.uncheckedLabel}
             />
           );
         default:

--- a/features/table/components/edit/columns-content.tsx
+++ b/features/table/components/edit/columns-content.tsx
@@ -45,6 +45,11 @@ export function ColumnsContent({ itemId, columns }: ColumnsContentProps) {
     })
   );
 
+  // カラム追加時のハンドラ
+  const handleColumnAdded = (column: Column) => {
+    setLocalColumns((prev) => [...prev, column]);
+  };
+
   // カラム削除時のハンドラ
   const handleColumnDeleted = (columnId: string) => {
     setLocalColumns((prev) => prev.filter((col) => col.id !== columnId));
@@ -145,6 +150,7 @@ export function ColumnsContent({ itemId, columns }: ColumnsContentProps) {
         open={isAddDialogOpen}
         onOpenChange={setIsAddDialogOpen}
         nextOrder={localColumns.length}
+        onAdded={handleColumnAdded}
       />
     </>
   );

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "@radix-ui/react-select": "^2.2.6",
         "@radix-ui/react-separator": "^1.1.7",
         "@radix-ui/react-slot": "^1.2.4",
+        "@radix-ui/react-switch": "^1.2.6",
         "@radix-ui/react-tabs": "^1.1.13",
         "@radix-ui/react-tooltip": "^1.2.8",
         "@supabase/ssr": "^0.7.0",
@@ -3216,6 +3217,35 @@
       },
       "peerDependenciesMeta": {
         "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-switch": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-switch/-/react-switch-1.2.6.tgz",
+      "integrity": "sha512-bByzr1+ep1zk4VubeEVViV592vu2lHE2BZY5OnzehZqOOgogN80+mNtCqPkhn2gklJqOpxWgPoYTSnhBCqpOXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-previous": "1.1.1",
+        "@radix-ui/react-use-size": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
           "optional": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@radix-ui/react-select": "^2.2.6",
     "@radix-ui/react-separator": "^1.1.7",
     "@radix-ui/react-slot": "^1.2.4",
+    "@radix-ui/react-switch": "^1.2.6",
     "@radix-ui/react-tabs": "^1.1.13",
     "@radix-ui/react-tooltip": "^1.2.8",
     "@supabase/ssr": "^0.7.0",


### PR DESCRIPTION
## 概要

チェックボックス（CHECKBOX）カラムの表示とデフォルト値を設定できるようにしました。

## 実装内容

- CHECKBOX型の設定型定義を更新
- CheckboxConfigEditorコンポーネントを作成
- 項目追加/編集ダイアログへの統合
- CheckboxCellで表示スタイルとラベル対応
- 項目追加時の画面更新を修正

## 動作確認

- [x] CHECKBOX型カラムの追加時に表示スタイルを設定できる
- [x] CHECKBOX型カラムの追加時にラベルを設定できる
- [x] CHECKBOX型カラムの追加時にデフォルト値を設定できる
- [x] 既存CHECKBOX型カラムの設定を編集できる
- [x] 表示スタイルに応じてCheckbox/Switchが切り替わる
- [x] チェック状態に応じたラベルが表示される
- [x] 項目追加後に画面が即座に更新される

## 関連 Issue

Closes #38 
