### PR TITLE
グループによるアイテム権限管理機能の実装

### DIFF
--- a/app/(protected)/[itemId]/page.tsx
+++ b/app/(protected)/[itemId]/page.tsx
@@ -4,6 +4,8 @@ import { getRecords } from '@/features/record/api';
 import { TableLayout } from '@/features/table/components';
 import { FolderLayout } from '@/features/folder/components';
 import { notFound } from 'next/navigation';
+import { getCurrentUser } from '@/lib/auth';
+import { canAccessItem } from '@/lib/permissions';
 
 export const dynamic = 'force-dynamic';
 
@@ -20,10 +22,38 @@ type ItemPageProps = {
 export default async function ItemPage({ params }: ItemPageProps) {
   const { itemId } = await params;
 
+  // 認証チェック
+  const currentUser = await getCurrentUser();
+  if (!currentUser) {
+    notFound();
+  }
+
   const item = await getItemById(itemId);
 
   if (!item) {
     notFound();
+  }
+
+  // 権限チェック
+  const { canAccess } = await canAccessItem(
+    itemId,
+    currentUser.id,
+    currentUser.role
+  );
+
+  if (!canAccess) {
+    return (
+      <div className="container mx-auto p-6">
+        <div className="rounded-lg border border-destructive bg-destructive/10 p-8 text-center">
+          <h1 className="text-2xl font-bold text-destructive mb-4">
+            アクセス権限がありません
+          </h1>
+          <p className="text-muted-foreground">
+            このアイテムにアクセスする権限がありません。
+          </p>
+        </div>
+      </div>
+    );
   }
 
   // TABLE型の場合

--- a/app/(protected)/[itemId]/page.tsx
+++ b/app/(protected)/[itemId]/page.tsx
@@ -35,7 +35,7 @@ export default async function ItemPage({ params }: ItemPageProps) {
   }
 
   // 権限チェック
-  const { canAccess } = await canAccessItem(
+  const { canAccess, level } = await canAccessItem(
     itemId,
     currentUser.id,
     currentUser.role
@@ -68,6 +68,7 @@ export default async function ItemPage({ params }: ItemPageProps) {
         itemName={item.name}
         columns={columns}
         records={records}
+        permissionLevel={level}
       />
     );
   }

--- a/features/folder/components/edit/folder-edit-layout.tsx
+++ b/features/folder/components/edit/folder-edit-layout.tsx
@@ -5,6 +5,7 @@ import { ArrowLeft } from 'lucide-react';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import type { Item } from '@/features/item/types';
 import { SettingsContent } from './settings-content';
+import { AccessContent } from '@/features/table/components/edit/access-content';
 
 /**
  * FolderEditLayoutのProps型
@@ -42,6 +43,9 @@ export function FolderEditLayout({ folder }: FolderEditLayoutProps) {
         </div>
         <TabsContent value="settings" className="flex-1 mt-6">
           <SettingsContent folderId={folder.id} folderName={folder.name} />
+        </TabsContent>
+        <TabsContent value="access" className="flex-1 mt-6">
+          <AccessContent itemId={folder.id} />
         </TabsContent>
       </Tabs>
     </div>

--- a/features/item/api/__tests__/get-items.test.ts
+++ b/features/item/api/__tests__/get-items.test.ts
@@ -1,20 +1,54 @@
 import { getItems } from '../get-items';
 
+// Supabaseクライアントをモック化
+jest.mock('@/lib/supabase/server', () => ({
+  createClient: jest.fn(),
+}));
+
 // Prismaクライアントをモック化
 jest.mock('@/lib/prisma', () => ({
   prisma: {
+    user: {
+      findUnique: jest.fn(),
+    },
     item: {
       findMany: jest.fn(),
       findUnique: jest.fn(),
     },
+    itemPermission: {
+      findUnique: jest.fn(),
+    },
+    groupMember: {
+      findMany: jest.fn(),
+    },
   },
 }));
 
+import { createClient } from '@/lib/supabase/server';
 import { prisma } from '@/lib/prisma';
 
 describe('getItems', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+
+    // デフォルトでADMINユーザーを設定
+    (createClient as jest.Mock).mockResolvedValue({
+      auth: {
+        getUser: jest.fn().mockResolvedValue({
+          data: { user: { email: 'admin@example.com' } },
+        }),
+      },
+    });
+
+    (prisma.user.findUnique as jest.Mock).mockResolvedValue({
+      id: 'user-1',
+      email: 'admin@example.com',
+      role: 'ADMIN',
+    });
+
+    // 権限チェック用のデフォルトモック（ADMIN権限なので常にアクセス可能）
+    (prisma.itemPermission.findUnique as jest.Mock).mockResolvedValue(null);
+    (prisma.groupMember.findMany as jest.Mock).mockResolvedValue([]);
   });
 
   it('ルートアイテムを取得できる', async () => {

--- a/features/item/api/__tests__/get-items.test.ts
+++ b/features/item/api/__tests__/get-items.test.ts
@@ -17,6 +17,7 @@ jest.mock('@/lib/prisma', () => ({
     },
     itemPermission: {
       findUnique: jest.fn(),
+      findMany: jest.fn(),
     },
     groupMember: {
       findMany: jest.fn(),
@@ -152,5 +153,167 @@ describe('getItems', () => {
     const result = await getItems();
 
     expect(result).toEqual([]);
+  });
+
+  it('認証されていない場合は空配列を返す', async () => {
+    (createClient as jest.Mock).mockResolvedValue({
+      auth: {
+        getUser: jest.fn().mockResolvedValue({
+          data: { user: null },
+        }),
+      },
+    });
+
+    const result = await getItems();
+
+    expect(result).toEqual([]);
+    expect(prisma.item.findMany).not.toHaveBeenCalled();
+  });
+
+  it('権限のないアイテムは除外される', async () => {
+    // MEMBER roleを設定（権限チェックが実行される）
+    (createClient as jest.Mock).mockResolvedValue({
+      auth: {
+        getUser: jest.fn().mockResolvedValue({
+          data: { user: { email: 'member@example.com' } },
+        }),
+      },
+    });
+
+    (prisma.user.findUnique as jest.Mock).mockResolvedValue({
+      id: 'user-1',
+      email: 'member@example.com',
+      role: 'MEMBER',
+    });
+
+    const mockRootFolders = [{ id: 'folder-1' }, { id: 'folder-2' }];
+
+    const mockItem1 = {
+      id: 'folder-1',
+      name: 'アクセス可能なアイテム',
+      parentId: null,
+      order: 0,
+      createdAt: new Date('2024-01-01'),
+      updatedAt: new Date('2024-01-01'),
+      createdById: 'user-1',
+      children: [],
+      _count: {
+        children: 0,
+      },
+    };
+
+    const mockItem2 = {
+      id: 'folder-2',
+      name: 'アクセス不可なアイテム',
+      parentId: null,
+      order: 1,
+      createdAt: new Date('2024-01-02'),
+      updatedAt: new Date('2024-01-02'),
+      createdById: 'user-1',
+      children: [],
+      _count: {
+        children: 0,
+      },
+    };
+
+    (prisma.item.findMany as jest.Mock).mockResolvedValue(mockRootFolders);
+    (prisma.item.findUnique as jest.Mock)
+      .mockResolvedValueOnce(mockItem1)
+      .mockResolvedValueOnce(mockItem2);
+
+    // folder-1 はアクセス可能、folder-2 はアクセス不可
+    (prisma.itemPermission.findUnique as jest.Mock)
+      .mockResolvedValueOnce(null) // folder-1: user permission not found
+      .mockResolvedValueOnce({ level: 'NONE' }); // folder-2: explicitly NONE
+
+    // グループ権限チェック（両方とも見つからない）
+    (prisma.itemPermission.findMany as jest.Mock)
+      .mockResolvedValueOnce([]) // folder-1: group permissions (デフォルトREAD)
+      .mockResolvedValueOnce([]); // folder-2: group permissions
+
+    const result = await getItems();
+
+    // folder-2 は除外され、folder-1 のみ返される
+    expect(result).toHaveLength(1);
+    expect(result[0]?.id).toBe('folder-1');
+  });
+
+  it('子アイテムで権限のないものは除外される', async () => {
+    // MEMBER roleを設定（権限チェックが実行される）
+    (createClient as jest.Mock).mockResolvedValue({
+      auth: {
+        getUser: jest.fn().mockResolvedValue({
+          data: { user: { email: 'member@example.com' } },
+        }),
+      },
+    });
+
+    (prisma.user.findUnique as jest.Mock).mockResolvedValue({
+      id: 'user-1',
+      email: 'member@example.com',
+      role: 'MEMBER',
+    });
+
+    const mockRootFolders = [{ id: 'folder-1' }];
+
+    const mockChildWithAccess = {
+      id: 'child-1',
+      name: 'アクセス可能な子',
+      parentId: 'folder-1',
+      order: 0,
+      createdAt: new Date('2024-01-02'),
+      updatedAt: new Date('2024-01-02'),
+      createdById: 'user-1',
+      children: [],
+      _count: { children: 0 },
+    };
+
+    const mockChildWithoutAccess = {
+      id: 'child-2',
+      name: 'アクセス不可な子',
+      parentId: 'folder-1',
+      order: 1,
+      createdAt: new Date('2024-01-03'),
+      updatedAt: new Date('2024-01-03'),
+      createdById: 'user-1',
+      children: [],
+      _count: { children: 0 },
+    };
+
+    const mockItem1 = {
+      id: 'folder-1',
+      name: '親アイテム',
+      parentId: null,
+      order: 0,
+      createdAt: new Date('2024-01-01'),
+      updatedAt: new Date('2024-01-01'),
+      createdById: 'user-1',
+      children: [mockChildWithAccess, mockChildWithoutAccess],
+      _count: { children: 2 },
+    };
+
+    (prisma.item.findMany as jest.Mock).mockResolvedValue(mockRootFolders);
+    (prisma.item.findUnique as jest.Mock)
+      .mockResolvedValueOnce(mockItem1)
+      .mockResolvedValueOnce(mockChildWithAccess)
+      .mockResolvedValueOnce(mockChildWithoutAccess);
+
+    // 親とchild-1はアクセス可、child-2はアクセス不可
+    (prisma.itemPermission.findUnique as jest.Mock)
+      .mockResolvedValueOnce(null) // folder-1: user permission
+      .mockResolvedValueOnce(null) // child-1: user permission
+      .mockResolvedValueOnce({ level: 'NONE' }); // child-2: explicitly NONE
+
+    // グループ権限チェック
+    (prisma.itemPermission.findMany as jest.Mock)
+      .mockResolvedValueOnce([]) // folder-1: group permissions (デフォルトREAD)
+      .mockResolvedValueOnce([]) // child-1: group permissions (デフォルトREAD)
+      .mockResolvedValueOnce([]); // child-2: group permissions
+
+    const result = await getItems();
+
+    expect(result).toHaveLength(1);
+    expect(result[0]?.children).toHaveLength(1);
+    expect(result[0]?.children?.[0]?.id).toBe('child-1');
   });
 });

--- a/features/item/api/get-items.ts
+++ b/features/item/api/get-items.ts
@@ -1,12 +1,18 @@
 'use server';
 
 import { prisma } from '@/lib/prisma';
+import { getCurrentUser } from '@/lib/auth';
+import { canAccessItem } from '@/lib/permissions';
 import type { Item } from '../types';
 
 /**
  * 再帰的に子アイテムを取得するヘルパー関数
  */
-async function getItemWithChildren(itemId: string): Promise<Item> {
+async function getItemWithChildren(
+  itemId: string,
+  userId: string,
+  userRole: 'ADMIN' | 'DEVELOPER' | 'MEMBER'
+): Promise<Item | null> {
   const item = await prisma.item.findUnique({
     where: { id: itemId },
     include: {
@@ -24,15 +30,26 @@ async function getItemWithChildren(itemId: string): Promise<Item> {
   });
 
   if (!item) {
-    throw new Error('Item not found');
+    return null;
   }
 
-  // 子アイテムがある場合、再帰的に取得
+  // 権限チェック
+  const { canAccess } = await canAccessItem(itemId, userId, userRole);
+  if (!canAccess) {
+    return null;
+  }
+
+  // 子アイテムがある場合、再帰的に取得（権限チェックも行う）
   if (item.children && item.children.length > 0) {
     const childrenWithGrandchildren = await Promise.all(
-      item.children.map((child) => getItemWithChildren(child.id))
+      item.children.map((child) =>
+        getItemWithChildren(child.id, userId, userRole)
+      )
     );
-    item.children = childrenWithGrandchildren;
+    // nullを除外
+    item.children = childrenWithGrandchildren.filter(
+      (child): child is Item => child !== null
+    );
   }
 
   return item as Item;
@@ -42,6 +59,12 @@ async function getItemWithChildren(itemId: string): Promise<Item> {
  * すべてのアイテムを再帰的に取得するServer Action
  */
 export async function getItems(): Promise<Item[]> {
+  // 認証チェック
+  const currentUser = await getCurrentUser();
+  if (!currentUser) {
+    return [];
+  }
+
   // ルートアイテムのみ取得
   const rootItems = await prisma.item.findMany({
     where: {
@@ -55,10 +78,13 @@ export async function getItems(): Promise<Item[]> {
     },
   });
 
-  // 各ルートアイテムの子を再帰的に取得
+  // 各ルートアイテムの子を再帰的に取得（権限チェックも行う）
   const itemsWithChildren = await Promise.all(
-    rootItems.map((item) => getItemWithChildren(item.id))
+    rootItems.map((item) =>
+      getItemWithChildren(item.id, currentUser.id, currentUser.role)
+    )
   );
 
-  return itemsWithChildren;
+  // nullを除外
+  return itemsWithChildren.filter((item): item is Item => item !== null);
 }

--- a/features/permission/api/__tests__/add-permission.test.ts
+++ b/features/permission/api/__tests__/add-permission.test.ts
@@ -1,0 +1,268 @@
+import { addPermission } from '../add-permission';
+import { createClient } from '@/lib/supabase/server';
+
+// Supabaseクライアントをモック化
+jest.mock('@/lib/supabase/server', () => ({
+  createClient: jest.fn(),
+}));
+
+// Prismaクライアントをモック化
+jest.mock('@/lib/prisma', () => ({
+  prisma: {
+    user: {
+      findUnique: jest.fn(),
+    },
+    item: {
+      findUnique: jest.fn(),
+    },
+    group: {
+      findUnique: jest.fn(),
+    },
+    itemPermission: {
+      create: jest.fn(),
+    },
+  },
+}));
+
+import { prisma } from '@/lib/prisma';
+
+// DEVELOPERユーザーのモック
+const mockDeveloperUser = {
+  auth: {
+    getUser: jest.fn().mockResolvedValue({
+      data: { user: { email: 'developer@example.com' } },
+    }),
+  },
+};
+
+describe('addPermission', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // デフォルトでDEVELOPERユーザーを設定
+    (createClient as jest.Mock).mockResolvedValue(mockDeveloperUser);
+    (prisma.user.findUnique as jest.Mock).mockResolvedValue({
+      id: 'user-1',
+      role: 'DEVELOPER',
+    });
+  });
+
+  it('ユーザーに権限を追加できる', async () => {
+    const itemId = 'item-1';
+    const userId = 'user-2';
+
+    (prisma.item.findUnique as jest.Mock).mockResolvedValue({
+      id: itemId,
+      name: 'テストアイテム',
+    });
+
+    (prisma.user.findUnique as jest.Mock)
+      .mockResolvedValueOnce({
+        id: 'user-1',
+        role: 'DEVELOPER',
+      })
+      .mockResolvedValueOnce({
+        id: userId,
+        name: 'テストユーザー',
+      });
+
+    (prisma.itemPermission.create as jest.Mock).mockResolvedValue({
+      id: 'permission-1',
+      itemId,
+      userId,
+      groupId: null,
+      level: 'WRITE',
+    });
+
+    const result = await addPermission(itemId, 'user', userId, 'WRITE');
+
+    expect(result).toEqual({ success: true });
+    expect(prisma.itemPermission.create).toHaveBeenCalledWith({
+      data: {
+        itemId,
+        userId,
+        groupId: null,
+        level: 'WRITE',
+      },
+    });
+  });
+
+  it('グループに権限を追加できる', async () => {
+    const itemId = 'item-1';
+    const groupId = 'group-1';
+
+    (prisma.item.findUnique as jest.Mock).mockResolvedValue({
+      id: itemId,
+      name: 'テストアイテム',
+    });
+
+    (prisma.group.findUnique as jest.Mock).mockResolvedValue({
+      id: groupId,
+      name: 'テストグループ',
+    });
+
+    (prisma.itemPermission.create as jest.Mock).mockResolvedValue({
+      id: 'permission-1',
+      itemId,
+      userId: null,
+      groupId,
+      level: 'READ',
+    });
+
+    const result = await addPermission(itemId, 'group', groupId, 'READ');
+
+    expect(result).toEqual({ success: true });
+    expect(prisma.itemPermission.create).toHaveBeenCalledWith({
+      data: {
+        itemId,
+        userId: null,
+        groupId,
+        level: 'READ',
+      },
+    });
+  });
+
+  it('認証されていない場合はエラーを返す', async () => {
+    (createClient as jest.Mock).mockResolvedValue({
+      auth: {
+        getUser: jest.fn().mockResolvedValue({
+          data: { user: null },
+        }),
+      },
+    });
+
+    const result = await addPermission('item-1', 'user', 'user-1', 'READ');
+
+    expect(result).toEqual({ error: '認証が必要です' });
+    expect(prisma.itemPermission.create).not.toHaveBeenCalled();
+  });
+
+  it('MEMBER権限ではエラーを返す', async () => {
+    (prisma.user.findUnique as jest.Mock).mockResolvedValue({
+      id: 'user-1',
+      role: 'MEMBER',
+    });
+
+    const result = await addPermission('item-1', 'user', 'user-2', 'WRITE');
+
+    expect(result).toEqual({ error: '権限がありません' });
+    expect(prisma.itemPermission.create).not.toHaveBeenCalled();
+  });
+
+  it('アイテムが見つからない場合はエラーを返す', async () => {
+    (prisma.item.findUnique as jest.Mock).mockResolvedValue(null);
+
+    const result = await addPermission('item-1', 'user', 'user-2', 'WRITE');
+
+    expect(result).toEqual({ error: 'アイテムが見つかりません' });
+    expect(prisma.itemPermission.create).not.toHaveBeenCalled();
+  });
+
+  it('ユーザーが見つからない場合はエラーを返す', async () => {
+    (prisma.item.findUnique as jest.Mock).mockResolvedValue({
+      id: 'item-1',
+      name: 'テストアイテム',
+    });
+
+    (prisma.user.findUnique as jest.Mock)
+      .mockResolvedValueOnce({
+        id: 'user-1',
+        role: 'DEVELOPER',
+      })
+      .mockResolvedValueOnce(null);
+
+    const result = await addPermission('item-1', 'user', 'user-2', 'WRITE');
+
+    expect(result).toEqual({ error: 'ユーザーが見つかりません' });
+    expect(prisma.itemPermission.create).not.toHaveBeenCalled();
+  });
+
+  it('グループが見つからない場合はエラーを返す', async () => {
+    (prisma.item.findUnique as jest.Mock).mockResolvedValue({
+      id: 'item-1',
+      name: 'テストアイテム',
+    });
+
+    (prisma.group.findUnique as jest.Mock).mockResolvedValue(null);
+
+    const result = await addPermission('item-1', 'group', 'group-1', 'READ');
+
+    expect(result).toEqual({ error: 'グループが見つかりません' });
+    expect(prisma.itemPermission.create).not.toHaveBeenCalled();
+  });
+
+  it('既に権限が設定されている場合はエラーを返す（ユーザー）', async () => {
+    (prisma.item.findUnique as jest.Mock).mockResolvedValue({
+      id: 'item-1',
+      name: 'テストアイテム',
+    });
+
+    (prisma.user.findUnique as jest.Mock)
+      .mockResolvedValueOnce({
+        id: 'user-1',
+        role: 'DEVELOPER',
+      })
+      .mockResolvedValueOnce({
+        id: 'user-2',
+        name: 'テストユーザー',
+      });
+
+    (prisma.itemPermission.create as jest.Mock).mockRejectedValue({
+      code: 'P2002',
+    });
+
+    const result = await addPermission('item-1', 'user', 'user-2', 'WRITE');
+
+    expect(result).toEqual({
+      error: 'このユーザーには既に権限が設定されています',
+    });
+  });
+
+  it('既に権限が設定されている場合はエラーを返す（グループ）', async () => {
+    (prisma.item.findUnique as jest.Mock).mockResolvedValue({
+      id: 'item-1',
+      name: 'テストアイテム',
+    });
+
+    (prisma.group.findUnique as jest.Mock).mockResolvedValue({
+      id: 'group-1',
+      name: 'テストグループ',
+    });
+
+    (prisma.itemPermission.create as jest.Mock).mockRejectedValue({
+      code: 'P2002',
+    });
+
+    const result = await addPermission('item-1', 'group', 'group-1', 'READ');
+
+    expect(result).toEqual({
+      error: 'このグループには既に権限が設定されています',
+    });
+  });
+
+  it('データベースエラーが発生した場合はエラーを返す', async () => {
+    (prisma.item.findUnique as jest.Mock).mockResolvedValue({
+      id: 'item-1',
+      name: 'テストアイテム',
+    });
+
+    (prisma.user.findUnique as jest.Mock)
+      .mockResolvedValueOnce({
+        id: 'user-1',
+        role: 'DEVELOPER',
+      })
+      .mockResolvedValueOnce({
+        id: 'user-2',
+        name: 'テストユーザー',
+      });
+
+    (prisma.itemPermission.create as jest.Mock).mockRejectedValue(
+      new Error('Database error')
+    );
+
+    const result = await addPermission('item-1', 'user', 'user-2', 'WRITE');
+
+    expect(result).toEqual({
+      error: '権限の追加に失敗しました',
+    });
+  });
+});

--- a/features/permission/api/__tests__/get-permissions.test.ts
+++ b/features/permission/api/__tests__/get-permissions.test.ts
@@ -1,0 +1,191 @@
+import { getPermissions } from '../get-permissions';
+import { createClient } from '@/lib/supabase/server';
+
+// Supabaseクライアントをモック化
+jest.mock('@/lib/supabase/server', () => ({
+  createClient: jest.fn(),
+}));
+
+// Prismaクライアントをモック化
+jest.mock('@/lib/prisma', () => ({
+  prisma: {
+    user: {
+      findUnique: jest.fn(),
+    },
+    item: {
+      findUnique: jest.fn(),
+    },
+    itemPermission: {
+      findMany: jest.fn(),
+    },
+  },
+}));
+
+import { prisma } from '@/lib/prisma';
+
+// DEVELOPERユーザーのモック
+const mockDeveloperUser = {
+  auth: {
+    getUser: jest.fn().mockResolvedValue({
+      data: { user: { email: 'developer@example.com' } },
+    }),
+  },
+};
+
+describe('getPermissions', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // デフォルトでDEVELOPERユーザーを設定
+    (createClient as jest.Mock).mockResolvedValue(mockDeveloperUser);
+    (prisma.user.findUnique as jest.Mock).mockResolvedValue({
+      id: 'user-1',
+      role: 'DEVELOPER',
+    });
+  });
+
+  it('権限一覧を取得できる', async () => {
+    const itemId = 'item-1';
+    const mockPermissions = [
+      {
+        id: 'permission-1',
+        itemId,
+        userId: 'user-2',
+        groupId: null,
+        level: 'WRITE',
+        user: {
+          id: 'user-2',
+          name: 'テストユーザー',
+          email: 'test@example.com',
+        },
+        group: null,
+      },
+      {
+        id: 'permission-2',
+        itemId,
+        userId: null,
+        groupId: 'group-1',
+        level: 'READ',
+        user: null,
+        group: {
+          id: 'group-1',
+          name: 'テストグループ',
+          description: 'テストグループの説明',
+        },
+      },
+    ];
+
+    (prisma.item.findUnique as jest.Mock).mockResolvedValue({
+      id: itemId,
+      name: 'テストアイテム',
+    });
+
+    (prisma.itemPermission.findMany as jest.Mock).mockResolvedValue(
+      mockPermissions
+    );
+
+    const result = await getPermissions(itemId);
+
+    expect(result).toEqual({
+      success: true,
+      permissions: mockPermissions,
+    });
+    expect(prisma.item.findUnique).toHaveBeenCalledWith({
+      where: { id: itemId },
+    });
+    expect(prisma.itemPermission.findMany).toHaveBeenCalledWith({
+      where: { itemId },
+      include: {
+        user: {
+          select: {
+            id: true,
+            name: true,
+            email: true,
+          },
+        },
+        group: {
+          select: {
+            id: true,
+            name: true,
+            description: true,
+          },
+        },
+      },
+      orderBy: { createdAt: 'desc' },
+    });
+  });
+
+  it('権限がない場合は空配列を返す', async () => {
+    const itemId = 'item-1';
+
+    (prisma.item.findUnique as jest.Mock).mockResolvedValue({
+      id: itemId,
+      name: 'テストアイテム',
+    });
+
+    (prisma.itemPermission.findMany as jest.Mock).mockResolvedValue([]);
+
+    const result = await getPermissions(itemId);
+
+    expect(result).toEqual({
+      success: true,
+      permissions: [],
+    });
+  });
+
+  it('認証されていない場合はエラーを返す', async () => {
+    (createClient as jest.Mock).mockResolvedValue({
+      auth: {
+        getUser: jest.fn().mockResolvedValue({
+          data: { user: null },
+        }),
+      },
+    });
+
+    const result = await getPermissions('item-1');
+
+    expect(result).toEqual({ error: '認証が必要です', permissions: [] });
+    expect(prisma.itemPermission.findMany).not.toHaveBeenCalled();
+  });
+
+  it('MEMBER権限ではエラーを返す', async () => {
+    (prisma.user.findUnique as jest.Mock).mockResolvedValue({
+      id: 'user-1',
+      role: 'MEMBER',
+    });
+
+    const result = await getPermissions('item-1');
+
+    expect(result).toEqual({ error: '権限がありません', permissions: [] });
+    expect(prisma.itemPermission.findMany).not.toHaveBeenCalled();
+  });
+
+  it('アイテムが見つからない場合はエラーを返す', async () => {
+    (prisma.item.findUnique as jest.Mock).mockResolvedValue(null);
+
+    const result = await getPermissions('item-1');
+
+    expect(result).toEqual({
+      error: 'アイテムが見つかりません',
+      permissions: [],
+    });
+    expect(prisma.itemPermission.findMany).not.toHaveBeenCalled();
+  });
+
+  it('データベースエラーが発生した場合はエラーを返す', async () => {
+    (prisma.item.findUnique as jest.Mock).mockResolvedValue({
+      id: 'item-1',
+      name: 'テストアイテム',
+    });
+
+    (prisma.itemPermission.findMany as jest.Mock).mockRejectedValue(
+      new Error('Database error')
+    );
+
+    const result = await getPermissions('item-1');
+
+    expect(result).toEqual({
+      error: '権限の取得に失敗しました',
+      permissions: [],
+    });
+  });
+});

--- a/features/permission/api/__tests__/remove-permission.test.ts
+++ b/features/permission/api/__tests__/remove-permission.test.ts
@@ -1,0 +1,122 @@
+import { removePermission } from '../remove-permission';
+import { createClient } from '@/lib/supabase/server';
+
+// Supabaseクライアントをモック化
+jest.mock('@/lib/supabase/server', () => ({
+  createClient: jest.fn(),
+}));
+
+// Prismaクライアントをモック化
+jest.mock('@/lib/prisma', () => ({
+  prisma: {
+    user: {
+      findUnique: jest.fn(),
+    },
+    itemPermission: {
+      findUnique: jest.fn(),
+      delete: jest.fn(),
+    },
+  },
+}));
+
+import { prisma } from '@/lib/prisma';
+
+// DEVELOPERユーザーのモック
+const mockDeveloperUser = {
+  auth: {
+    getUser: jest.fn().mockResolvedValue({
+      data: { user: { email: 'developer@example.com' } },
+    }),
+  },
+};
+
+describe('removePermission', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // デフォルトでDEVELOPERユーザーを設定
+    (createClient as jest.Mock).mockResolvedValue(mockDeveloperUser);
+    (prisma.user.findUnique as jest.Mock).mockResolvedValue({
+      id: 'user-1',
+      role: 'DEVELOPER',
+    });
+  });
+
+  it('権限を削除できる', async () => {
+    const permissionId = 'permission-1';
+
+    (prisma.itemPermission.findUnique as jest.Mock).mockResolvedValue({
+      id: permissionId,
+      itemId: 'item-1',
+      userId: 'user-2',
+      groupId: null,
+      level: 'WRITE',
+    });
+
+    (prisma.itemPermission.delete as jest.Mock).mockResolvedValue({
+      id: permissionId,
+    });
+
+    const result = await removePermission(permissionId);
+
+    expect(result).toEqual({ success: true });
+    expect(prisma.itemPermission.delete).toHaveBeenCalledWith({
+      where: { id: permissionId },
+    });
+  });
+
+  it('認証されていない場合はエラーを返す', async () => {
+    (createClient as jest.Mock).mockResolvedValue({
+      auth: {
+        getUser: jest.fn().mockResolvedValue({
+          data: { user: null },
+        }),
+      },
+    });
+
+    const result = await removePermission('permission-1');
+
+    expect(result).toEqual({ error: '認証が必要です' });
+    expect(prisma.itemPermission.delete).not.toHaveBeenCalled();
+  });
+
+  it('MEMBER権限ではエラーを返す', async () => {
+    (prisma.user.findUnique as jest.Mock).mockResolvedValue({
+      id: 'user-1',
+      role: 'MEMBER',
+    });
+
+    const result = await removePermission('permission-1');
+
+    expect(result).toEqual({ error: '権限がありません' });
+    expect(prisma.itemPermission.delete).not.toHaveBeenCalled();
+  });
+
+  it('権限が見つからない場合はエラーを返す', async () => {
+    (prisma.itemPermission.findUnique as jest.Mock).mockResolvedValue(null);
+
+    const result = await removePermission('permission-1');
+
+    expect(result).toEqual({ error: '権限が見つかりません' });
+    expect(prisma.itemPermission.delete).not.toHaveBeenCalled();
+  });
+
+  it('データベースエラーが発生した場合はエラーを返す', async () => {
+    (prisma.itemPermission.findUnique as jest.Mock).mockResolvedValue({
+      id: 'permission-1',
+      itemId: 'item-1',
+      userId: 'user-2',
+      groupId: null,
+      level: 'WRITE',
+    });
+
+    (prisma.itemPermission.delete as jest.Mock).mockRejectedValue(
+      new Error('Database error')
+    );
+
+    const result = await removePermission('permission-1');
+
+    expect(result).toEqual({
+      error: '権限の削除に失敗しました',
+    });
+  });
+});

--- a/features/permission/api/__tests__/update-permission.test.ts
+++ b/features/permission/api/__tests__/update-permission.test.ts
@@ -1,0 +1,155 @@
+import { updatePermission } from '../update-permission';
+import { createClient } from '@/lib/supabase/server';
+
+// Supabaseクライアントをモック化
+jest.mock('@/lib/supabase/server', () => ({
+  createClient: jest.fn(),
+}));
+
+// Prismaクライアントをモック化
+jest.mock('@/lib/prisma', () => ({
+  prisma: {
+    user: {
+      findUnique: jest.fn(),
+    },
+    itemPermission: {
+      findUnique: jest.fn(),
+      update: jest.fn(),
+    },
+  },
+}));
+
+import { prisma } from '@/lib/prisma';
+
+// DEVELOPERユーザーのモック
+const mockDeveloperUser = {
+  auth: {
+    getUser: jest.fn().mockResolvedValue({
+      data: { user: { email: 'developer@example.com' } },
+    }),
+  },
+};
+
+describe('updatePermission', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // デフォルトでDEVELOPERユーザーを設定
+    (createClient as jest.Mock).mockResolvedValue(mockDeveloperUser);
+    (prisma.user.findUnique as jest.Mock).mockResolvedValue({
+      id: 'user-1',
+      role: 'DEVELOPER',
+    });
+  });
+
+  it('権限レベルを更新できる', async () => {
+    const permissionId = 'permission-1';
+
+    (prisma.itemPermission.findUnique as jest.Mock).mockResolvedValue({
+      id: permissionId,
+      itemId: 'item-1',
+      userId: 'user-2',
+      groupId: null,
+      level: 'READ',
+    });
+
+    (prisma.itemPermission.update as jest.Mock).mockResolvedValue({
+      id: permissionId,
+      itemId: 'item-1',
+      userId: 'user-2',
+      groupId: null,
+      level: 'WRITE',
+    });
+
+    const result = await updatePermission(permissionId, 'WRITE');
+
+    expect(result).toEqual({ success: true });
+    expect(prisma.itemPermission.update).toHaveBeenCalledWith({
+      where: { id: permissionId },
+      data: { level: 'WRITE' },
+    });
+  });
+
+  it('READ から NONE に変更できる', async () => {
+    const permissionId = 'permission-1';
+
+    (prisma.itemPermission.findUnique as jest.Mock).mockResolvedValue({
+      id: permissionId,
+      itemId: 'item-1',
+      userId: 'user-2',
+      groupId: null,
+      level: 'READ',
+    });
+
+    (prisma.itemPermission.update as jest.Mock).mockResolvedValue({
+      id: permissionId,
+      itemId: 'item-1',
+      userId: 'user-2',
+      groupId: null,
+      level: 'NONE',
+    });
+
+    const result = await updatePermission(permissionId, 'NONE');
+
+    expect(result).toEqual({ success: true });
+    expect(prisma.itemPermission.update).toHaveBeenCalledWith({
+      where: { id: permissionId },
+      data: { level: 'NONE' },
+    });
+  });
+
+  it('認証されていない場合はエラーを返す', async () => {
+    (createClient as jest.Mock).mockResolvedValue({
+      auth: {
+        getUser: jest.fn().mockResolvedValue({
+          data: { user: null },
+        }),
+      },
+    });
+
+    const result = await updatePermission('permission-1', 'WRITE');
+
+    expect(result).toEqual({ error: '認証が必要です' });
+    expect(prisma.itemPermission.update).not.toHaveBeenCalled();
+  });
+
+  it('MEMBER権限ではエラーを返す', async () => {
+    (prisma.user.findUnique as jest.Mock).mockResolvedValue({
+      id: 'user-1',
+      role: 'MEMBER',
+    });
+
+    const result = await updatePermission('permission-1', 'WRITE');
+
+    expect(result).toEqual({ error: '権限がありません' });
+    expect(prisma.itemPermission.update).not.toHaveBeenCalled();
+  });
+
+  it('権限が見つからない場合はエラーを返す', async () => {
+    (prisma.itemPermission.findUnique as jest.Mock).mockResolvedValue(null);
+
+    const result = await updatePermission('permission-1', 'WRITE');
+
+    expect(result).toEqual({ error: '権限が見つかりません' });
+    expect(prisma.itemPermission.update).not.toHaveBeenCalled();
+  });
+
+  it('データベースエラーが発生した場合はエラーを返す', async () => {
+    (prisma.itemPermission.findUnique as jest.Mock).mockResolvedValue({
+      id: 'permission-1',
+      itemId: 'item-1',
+      userId: 'user-2',
+      groupId: null,
+      level: 'READ',
+    });
+
+    (prisma.itemPermission.update as jest.Mock).mockRejectedValue(
+      new Error('Database error')
+    );
+
+    const result = await updatePermission('permission-1', 'WRITE');
+
+    expect(result).toEqual({
+      error: '権限の更新に失敗しました',
+    });
+  });
+});

--- a/features/permission/api/add-permission.ts
+++ b/features/permission/api/add-permission.ts
@@ -10,7 +10,7 @@ import type { Permission } from '@prisma/client';
  */
 export async function addPermission(
   itemId: string,
-  targetType: 'user' | 'group',
+  targetType: 'group' | 'user',
   targetId: string,
   level: Permission
 ): Promise<{ success: true } | { error: string }> {
@@ -65,6 +65,22 @@ export async function addPermission(
     return { success: true };
   } catch (error) {
     console.error('権限の追加に失敗しました:', error);
+
+    // ユニーク制約違反のエラーをチェック
+    if (
+      error &&
+      typeof error === 'object' &&
+      'code' in error &&
+      error.code === 'P2002'
+    ) {
+      return {
+        error:
+          targetType === 'user'
+            ? 'このユーザーには既に権限が設定されています'
+            : 'このグループには既に権限が設定されています',
+      };
+    }
+
     return { error: '権限の追加に失敗しました' };
   }
 }

--- a/features/permission/api/add-permission.ts
+++ b/features/permission/api/add-permission.ts
@@ -1,0 +1,70 @@
+'use server';
+
+import { prisma } from '@/lib/prisma';
+import { getCurrentUser } from '@/lib/auth';
+import { canManageStructure } from '@/lib/permissions';
+import type { Permission } from '@prisma/client';
+
+/**
+ * アイテムに権限を追加
+ */
+export async function addPermission(
+  itemId: string,
+  targetType: 'user' | 'group',
+  targetId: string,
+  level: Permission
+): Promise<{ success: true } | { error: string }> {
+  try {
+    // 認証チェック
+    const currentUser = await getCurrentUser();
+    if (!currentUser) {
+      return { error: '認証が必要です' };
+    }
+
+    // 構造管理権限チェック（DEVELOPER以上）
+    if (!canManageStructure(currentUser.role)) {
+      return { error: '権限がありません' };
+    }
+
+    // アイテムの存在確認
+    const item = await prisma.item.findUnique({
+      where: { id: itemId },
+    });
+
+    if (!item) {
+      return { error: 'アイテムが見つかりません' };
+    }
+
+    // 対象の存在確認
+    if (targetType === 'user') {
+      const user = await prisma.user.findUnique({
+        where: { id: targetId },
+      });
+      if (!user) {
+        return { error: 'ユーザーが見つかりません' };
+      }
+    } else {
+      const group = await prisma.group.findUnique({
+        where: { id: targetId },
+      });
+      if (!group) {
+        return { error: 'グループが見つかりません' };
+      }
+    }
+
+    // 権限を追加
+    await prisma.itemPermission.create({
+      data: {
+        itemId,
+        userId: targetType === 'user' ? targetId : null,
+        groupId: targetType === 'group' ? targetId : null,
+        level,
+      },
+    });
+
+    return { success: true };
+  } catch (error) {
+    console.error('権限の追加に失敗しました:', error);
+    return { error: '権限の追加に失敗しました' };
+  }
+}

--- a/features/permission/api/get-permissions.ts
+++ b/features/permission/api/get-permissions.ts
@@ -1,0 +1,89 @@
+'use server';
+
+import { prisma } from '@/lib/prisma';
+import { getCurrentUser } from '@/lib/auth';
+import { canManageStructure } from '@/lib/permissions';
+import type { Prisma } from '@prisma/client';
+
+/**
+ * 権限情報の型（userとgroupをincludeした状態）
+ */
+type PermissionWithRelations = Prisma.ItemPermissionGetPayload<{
+  include: {
+    user: {
+      select: {
+        id: true;
+        name: true;
+        email: true;
+      };
+    };
+    group: {
+      select: {
+        id: true;
+        name: true;
+        description: true;
+      };
+    };
+  };
+}>;
+
+/**
+ * アイテムの権限一覧を取得
+ */
+export async function getPermissions(
+  itemId: string
+): Promise<
+  | { success: true; permissions: PermissionWithRelations[] }
+  | { error: string; permissions: [] }
+> {
+  try {
+    // 認証チェック
+    const currentUser = await getCurrentUser();
+    if (!currentUser) {
+      return { error: '認証が必要です', permissions: [] };
+    }
+
+    // 構造管理権限チェック（DEVELOPER以上）
+    if (!canManageStructure(currentUser.role)) {
+      return { error: '権限がありません', permissions: [] };
+    }
+
+    // アイテムの存在確認
+    const item = await prisma.item.findUnique({
+      where: { id: itemId },
+    });
+
+    if (!item) {
+      return { error: 'アイテムが見つかりません', permissions: [] };
+    }
+
+    // 権限一覧を取得
+    const permissions = await prisma.itemPermission.findMany({
+      where: { itemId },
+      include: {
+        user: {
+          select: {
+            id: true,
+            name: true,
+            email: true,
+          },
+        },
+        group: {
+          select: {
+            id: true,
+            name: true,
+            description: true,
+          },
+        },
+      },
+      orderBy: {
+        createdAt: 'desc',
+      },
+    });
+
+    return { success: true, permissions };
+  } catch (error) {
+    console.error('権限の取得に失敗しました:', error);
+    return { error: '権限の取得に失敗しました', permissions: [] };
+  }
+}

--- a/features/permission/api/index.ts
+++ b/features/permission/api/index.ts
@@ -1,0 +1,4 @@
+export * from './add-permission';
+export * from './remove-permission';
+export * from './update-permission';
+export * from './get-permissions';

--- a/features/permission/api/remove-permission.ts
+++ b/features/permission/api/remove-permission.ts
@@ -1,0 +1,44 @@
+'use server';
+
+import { prisma } from '@/lib/prisma';
+import { getCurrentUser } from '@/lib/auth';
+import { canManageStructure } from '@/lib/permissions';
+
+/**
+ * アイテムから権限を削除
+ */
+export async function removePermission(
+  permissionId: string
+): Promise<{ success: true } | { error: string }> {
+  try {
+    // 認証チェック
+    const currentUser = await getCurrentUser();
+    if (!currentUser) {
+      return { error: '認証が必要です' };
+    }
+
+    // 構造管理権限チェック（DEVELOPER以上）
+    if (!canManageStructure(currentUser.role)) {
+      return { error: '権限がありません' };
+    }
+
+    // 権限の存在確認
+    const permission = await prisma.itemPermission.findUnique({
+      where: { id: permissionId },
+    });
+
+    if (!permission) {
+      return { error: '権限が見つかりません' };
+    }
+
+    // 権限を削除
+    await prisma.itemPermission.delete({
+      where: { id: permissionId },
+    });
+
+    return { success: true };
+  } catch (error) {
+    console.error('権限の削除に失敗しました:', error);
+    return { error: '権限の削除に失敗しました' };
+  }
+}

--- a/features/permission/api/update-permission.ts
+++ b/features/permission/api/update-permission.ts
@@ -1,0 +1,47 @@
+'use server';
+
+import { prisma } from '@/lib/prisma';
+import { getCurrentUser } from '@/lib/auth';
+import { canManageStructure } from '@/lib/permissions';
+import type { Permission } from '@prisma/client';
+
+/**
+ * アイテムの権限レベルを更新
+ */
+export async function updatePermission(
+  permissionId: string,
+  level: Permission
+): Promise<{ success: true } | { error: string }> {
+  try {
+    // 認証チェック
+    const currentUser = await getCurrentUser();
+    if (!currentUser) {
+      return { error: '認証が必要です' };
+    }
+
+    // 構造管理権限チェック（DEVELOPER以上）
+    if (!canManageStructure(currentUser.role)) {
+      return { error: '権限がありません' };
+    }
+
+    // 権限の存在確認
+    const permission = await prisma.itemPermission.findUnique({
+      where: { id: permissionId },
+    });
+
+    if (!permission) {
+      return { error: '権限が見つかりません' };
+    }
+
+    // 権限レベルを更新
+    await prisma.itemPermission.update({
+      where: { id: permissionId },
+      data: { level },
+    });
+
+    return { success: true };
+  } catch (error) {
+    console.error('権限の更新に失敗しました:', error);
+    return { error: '権限の更新に失敗しました' };
+  }
+}

--- a/features/permission/components/add-permission-dialog.tsx
+++ b/features/permission/components/add-permission-dialog.tsx
@@ -1,0 +1,193 @@
+'use client';
+
+import { useState } from 'react';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Label } from '@/components/ui/label';
+import { Plus } from 'lucide-react';
+import {
+  PERMISSION_LIST,
+  getPermissionLabel,
+  getPermissionDescription,
+} from '@/features/permission/constants';
+import type { Permission } from '@prisma/client';
+
+/**
+ * 権限追加ダイアログのProps型
+ */
+type AddPermissionDialogProps = {
+  users: Array<{ id: string; name: string | null; email: string }>;
+  groups: Array<{ id: string; name: string; description: string | null }>;
+  onAdd: (
+    targetType: 'group' | 'user',
+    targetId: string,
+    level: Permission
+  ) => Promise<void>;
+};
+
+/**
+ * 権限追加ダイアログコンポーネント
+ */
+export function AddPermissionDialog({
+  users,
+  groups,
+  onAdd,
+}: AddPermissionDialogProps) {
+  const [open, setOpen] = useState(false);
+  const [targetType, setTargetType] = useState<'group' | 'user'>('group');
+  const [targetId, setTargetId] = useState('');
+  const [level, setLevel] = useState<Permission>('READ');
+  const [loading, setLoading] = useState(false);
+
+  // フォームをリセット
+  const resetForm = () => {
+    setTargetType('group');
+    setTargetId('');
+    setLevel('READ');
+  };
+
+  // 追加処理
+  const handleAdd = async () => {
+    if (!targetId) {
+      alert('グループまたはユーザーを選択してください');
+      return;
+    }
+
+    setLoading(true);
+    try {
+      await onAdd(targetType, targetId, level);
+      setOpen(false);
+      resetForm();
+    } catch (error) {
+      console.error('権限の追加に失敗しました:', error);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button size="sm" variant="outline">
+          <Plus className="size-4 mr-2" />
+          権限を追加
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="sm:max-w-[500px]">
+        <DialogHeader>
+          <DialogTitle>権限を追加</DialogTitle>
+          <DialogDescription>
+            グループまたはユーザーに権限を付与します。
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4 py-4">
+          {/* 種別選択 */}
+          <div className="space-y-2">
+            <Label htmlFor="target-type">種別</Label>
+            <Select
+              value={targetType}
+              onValueChange={(value) => {
+                setTargetType(value as 'group' | 'user');
+                setTargetId(''); // 種別変更時にリセット
+              }}
+            >
+              <SelectTrigger id="target-type">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="group">グループ</SelectItem>
+                <SelectItem value="user">ユーザー</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+
+          {/* グループ/ユーザー選択 */}
+          <div className="space-y-2">
+            <Label htmlFor="target-id">
+              {targetType === 'group' ? 'グループ' : 'ユーザー'}
+            </Label>
+            <Select value={targetId} onValueChange={setTargetId}>
+              <SelectTrigger id="target-id">
+                <SelectValue
+                  placeholder={
+                    targetType === 'group' ? 'グループを選択' : 'ユーザーを選択'
+                  }
+                />
+              </SelectTrigger>
+              <SelectContent>
+                {targetType === 'group'
+                  ? groups.map((group) => (
+                      <SelectItem key={group.id} value={group.id}>
+                        {group.name}
+                      </SelectItem>
+                    ))
+                  : users.map((user) => (
+                      <SelectItem key={user.id} value={user.id}>
+                        {user.name || user.email}
+                      </SelectItem>
+                    ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          {/* 権限レベル選択 */}
+          <div className="grid gap-2">
+            <Label htmlFor="permission-level">権限レベル</Label>
+            <div className="flex items-center gap-3">
+              <Select
+                value={level}
+                onValueChange={(value) => setLevel(value as Permission)}
+              >
+                <SelectTrigger id="permission-level" className="w-[100px]">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {PERMISSION_LIST.map((permLevel) => (
+                    <SelectItem key={permLevel} value={permLevel}>
+                      {getPermissionLabel(permLevel)}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              <p className="text-xs text-muted-foreground flex-1">
+                {getPermissionDescription(level)}
+              </p>
+            </div>
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button
+            variant="outline"
+            onClick={() => {
+              setOpen(false);
+              resetForm();
+            }}
+            disabled={loading}
+          >
+            キャンセル
+          </Button>
+          <Button onClick={handleAdd} disabled={loading || !targetId}>
+            {loading ? '追加中...' : '追加'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/features/permission/components/delete-permission-button.tsx
+++ b/features/permission/components/delete-permission-button.tsx
@@ -1,0 +1,96 @@
+'use client';
+
+import { useState } from 'react';
+import { Trash2, AlertCircle } from 'lucide-react';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from '@/components/ui/alert-dialog';
+import { toast } from 'sonner';
+
+/**
+ * 権限削除ボタンのProps型
+ */
+type DeletePermissionButtonProps = {
+  permissionId: string;
+  targetName: string;
+  onDelete: (permissionId: string) => Promise<void>;
+};
+
+/**
+ * 権限削除ボタンコンポーネント
+ */
+export function DeletePermissionButton({
+  permissionId,
+  targetName,
+  onDelete,
+}: DeletePermissionButtonProps) {
+  const [open, setOpen] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
+
+  const handleDelete = async () => {
+    setIsDeleting(true);
+
+    try {
+      await onDelete(permissionId);
+      setOpen(false);
+      toast.success('権限を削除しました', {
+        description: `${targetName}の権限を削除しました`,
+      });
+    } catch (error) {
+      toast.error('削除に失敗しました', {
+        description:
+          error instanceof Error ? error.message : '削除に失敗しました',
+      });
+    } finally {
+      setIsDeleting(false);
+    }
+  };
+
+  return (
+    <AlertDialog open={open} onOpenChange={setOpen}>
+      <AlertDialogTrigger asChild>
+        <button
+          type="button"
+          className="text-muted-foreground hover:text-destructive transition-colors"
+        >
+          <Trash2 className="size-4" />
+        </button>
+      </AlertDialogTrigger>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <div className="flex items-center space-x-2">
+            <AlertCircle className="text-destructive" />
+            <AlertDialogTitle className="text-destructive">
+              {targetName}の権限を削除
+            </AlertDialogTitle>
+          </div>
+          <AlertDialogDescription>
+            削除した権限設定は復元できません。
+            <br />
+            本当に削除しますか？
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={isDeleting}>
+            キャンセル
+          </AlertDialogCancel>
+          <AlertDialogAction
+            onClick={handleDelete}
+            disabled={isDeleting}
+            className="bg-destructive text-white hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60 "
+          >
+            {isDeleting ? '削除中...' : '削除'}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/features/permission/components/index.ts
+++ b/features/permission/components/index.ts
@@ -1,0 +1,2 @@
+export * from './add-permission-dialog';
+export * from './delete-permission-button';

--- a/features/permission/constants/index.ts
+++ b/features/permission/constants/index.ts
@@ -1,0 +1,1 @@
+export * from './permission-config';

--- a/features/permission/constants/permission-config.ts
+++ b/features/permission/constants/permission-config.ts
@@ -1,0 +1,67 @@
+import type { Permission } from '@prisma/client';
+
+/**
+ * 権限レベルごとの設定
+ */
+export type PermissionConfig = {
+  label: string;
+  description: string;
+  color: string; // バッジやUIの色
+};
+
+/**
+ * 権限レベルの設定（Config-Driven UI）
+ */
+export const PERMISSION_CONFIGS: Record<Permission, PermissionConfig> = {
+  NONE: {
+    label: 'なし',
+    description: 'アクセス不可',
+    color: 'gray',
+  },
+  READ: {
+    label: '読取',
+    description: '閲覧のみ可能',
+    color: 'blue',
+  },
+  WRITE: {
+    label: '編集',
+    description: '閲覧・作成・編集が可能',
+    color: 'green',
+  },
+  ADMIN: {
+    label: '管理',
+    description: 'すべての操作が可能（削除・権限設定含む）',
+    color: 'purple',
+  },
+} as const;
+
+/**
+ * 権限レベルの配列（UI表示順）
+ */
+export const PERMISSION_LIST: Permission[] = [
+  'READ',
+  'WRITE',
+  'ADMIN',
+  'NONE',
+] as const;
+
+/**
+ * 権限レベルの表示名を取得
+ */
+export function getPermissionLabel(level: Permission): string {
+  return PERMISSION_CONFIGS[level].label;
+}
+
+/**
+ * 権限レベルの説明を取得
+ */
+export function getPermissionDescription(level: Permission): string {
+  return PERMISSION_CONFIGS[level].description;
+}
+
+/**
+ * 権限レベルの色を取得
+ */
+export function getPermissionColor(level: Permission): string {
+  return PERMISSION_CONFIGS[level].color;
+}

--- a/features/permission/constants/permission-config.ts
+++ b/features/permission/constants/permission-config.ts
@@ -14,36 +14,26 @@ export type PermissionConfig = {
  */
 export const PERMISSION_CONFIGS: Record<Permission, PermissionConfig> = {
   NONE: {
-    label: 'なし',
+    label: 'none',
     description: 'アクセス不可',
     color: 'gray',
   },
   READ: {
-    label: '読取',
+    label: 'read',
     description: '閲覧のみ可能',
     color: 'blue',
   },
   WRITE: {
-    label: '編集',
-    description: '閲覧・作成・編集が可能',
+    label: 'write',
+    description: '閲覧・作成・編集・削除が可能',
     color: 'green',
-  },
-  ADMIN: {
-    label: '管理',
-    description: 'すべての操作が可能（削除・権限設定含む）',
-    color: 'purple',
   },
 } as const;
 
 /**
  * 権限レベルの配列（UI表示順）
  */
-export const PERMISSION_LIST: Permission[] = [
-  'READ',
-  'WRITE',
-  'ADMIN',
-  'NONE',
-] as const;
+export const PERMISSION_LIST: Permission[] = ['READ', 'WRITE', 'NONE'] as const;
 
 /**
  * 権限レベルの表示名を取得

--- a/features/permission/types/index.ts
+++ b/features/permission/types/index.ts
@@ -1,0 +1,32 @@
+import type { Permission } from '@prisma/client';
+
+/**
+ * アイテム権限の型
+ */
+export type ItemPermission = {
+  id: string;
+  itemId: string;
+  userId: string | null;
+  groupId: string | null;
+  level: Permission;
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+/**
+ * 権限追加の入力型
+ */
+export type AddPermissionInput = {
+  itemId: string;
+  userId?: string;
+  groupId?: string;
+  level: Permission;
+};
+
+/**
+ * 権限更新の入力型
+ */
+export type UpdatePermissionInput = {
+  permissionId: string;
+  level: Permission;
+};

--- a/features/record/api/__tests__/create-record.test.ts
+++ b/features/record/api/__tests__/create-record.test.ts
@@ -29,6 +29,12 @@ jest.mock('@/lib/prisma', () => ({
     record: {
       create: jest.fn(),
     },
+    itemPermission: {
+      findUnique: jest.fn(),
+    },
+    groupMember: {
+      findMany: jest.fn(),
+    },
   },
 }));
 
@@ -56,8 +62,13 @@ describe('createRecord', () => {
 
   it('レコードを作成できる', async () => {
     mockGetUser.mockResolvedValue({ data: { user: mockUser } });
-    (prisma.user.findUnique as jest.Mock).mockResolvedValue(mockDbUser);
+    (prisma.user.findUnique as jest.Mock).mockResolvedValue({
+      ...mockDbUser,
+      role: 'ADMIN',
+    });
     (prisma.item.findUnique as jest.Mock).mockResolvedValue(mockTable);
+    (prisma.itemPermission.findUnique as jest.Mock).mockResolvedValue(null);
+    (prisma.groupMember.findMany as jest.Mock).mockResolvedValue([]);
     (prisma.record.create as jest.Mock).mockResolvedValue({
       id: 'record-1',
       tableId: 'table-1',
@@ -128,7 +139,10 @@ describe('createRecord', () => {
 
   it('テーブルが存在しない場合はエラーを返す', async () => {
     mockGetUser.mockResolvedValue({ data: { user: mockUser } });
-    (prisma.user.findUnique as jest.Mock).mockResolvedValue(mockDbUser);
+    (prisma.user.findUnique as jest.Mock).mockResolvedValue({
+      ...mockDbUser,
+      role: 'ADMIN',
+    });
     (prisma.item.findUnique as jest.Mock).mockResolvedValue(null);
 
     const formData = new FormData();
@@ -142,8 +156,13 @@ describe('createRecord', () => {
 
   it('dataが空の場合は空オブジェクトで作成される', async () => {
     mockGetUser.mockResolvedValue({ data: { user: mockUser } });
-    (prisma.user.findUnique as jest.Mock).mockResolvedValue(mockDbUser);
+    (prisma.user.findUnique as jest.Mock).mockResolvedValue({
+      ...mockDbUser,
+      role: 'ADMIN',
+    });
     (prisma.item.findUnique as jest.Mock).mockResolvedValue(mockTable);
+    (prisma.itemPermission.findUnique as jest.Mock).mockResolvedValue(null);
+    (prisma.groupMember.findMany as jest.Mock).mockResolvedValue([]);
     (prisma.record.create as jest.Mock).mockResolvedValue({
       id: 'record-1',
       tableId: 'table-1',
@@ -176,8 +195,13 @@ describe('createRecord', () => {
 
   it('データベースエラーが発生した場合はエラーを返す', async () => {
     mockGetUser.mockResolvedValue({ data: { user: mockUser } });
-    (prisma.user.findUnique as jest.Mock).mockResolvedValue(mockDbUser);
+    (prisma.user.findUnique as jest.Mock).mockResolvedValue({
+      ...mockDbUser,
+      role: 'ADMIN',
+    });
     (prisma.item.findUnique as jest.Mock).mockResolvedValue(mockTable);
+    (prisma.itemPermission.findUnique as jest.Mock).mockResolvedValue(null);
+    (prisma.groupMember.findMany as jest.Mock).mockResolvedValue([]);
     (prisma.record.create as jest.Mock).mockRejectedValue(
       new Error('Database error')
     );

--- a/features/record/api/__tests__/delete-record.test.ts
+++ b/features/record/api/__tests__/delete-record.test.ts
@@ -20,8 +20,21 @@ jest.mock('@/lib/supabase/server', () => ({
 // Prismaクライアントをモック化
 jest.mock('@/lib/prisma', () => ({
   prisma: {
+    user: {
+      findUnique: jest.fn(),
+    },
     record: {
+      findUnique: jest.fn(),
       delete: jest.fn(),
+    },
+    item: {
+      findUnique: jest.fn(),
+    },
+    itemPermission: {
+      findUnique: jest.fn(),
+    },
+    groupMember: {
+      findMany: jest.fn(),
     },
   },
 }));
@@ -40,6 +53,31 @@ describe('deleteRecord', () => {
 
   it('レコードを削除できる', async () => {
     mockGetUser.mockResolvedValue({ data: { user: mockUser } });
+
+    // getCurrentUser用のモック
+    (prisma.user.findUnique as jest.Mock).mockResolvedValue({
+      id: 'user-1',
+      email: 'test@example.com',
+      role: 'ADMIN',
+    });
+
+    // レコード取得のモック
+    (prisma.record.findUnique as jest.Mock).mockResolvedValue({
+      id: 'record-1',
+      tableId: 'table-1',
+      data: {},
+    });
+
+    // アイテム取得のモック
+    (prisma.item.findUnique as jest.Mock).mockResolvedValue({
+      id: 'table-1',
+      type: 'TABLE',
+    });
+
+    // 権限チェック用のモック（ADMIN権限なので不要だが念のため）
+    (prisma.itemPermission.findUnique as jest.Mock).mockResolvedValue(null);
+    (prisma.groupMember.findMany as jest.Mock).mockResolvedValue([]);
+
     (prisma.record.delete as jest.Mock).mockResolvedValue({
       tableId: 'table-1',
     });
@@ -49,7 +87,6 @@ describe('deleteRecord', () => {
     expect(result).toEqual({ success: true });
     expect(prisma.record.delete).toHaveBeenCalledWith({
       where: { id: 'record-1' },
-      select: { tableId: true },
     });
   });
 
@@ -64,6 +101,27 @@ describe('deleteRecord', () => {
 
   it('データベースエラーが発生した場合はエラーを返す', async () => {
     mockGetUser.mockResolvedValue({ data: { user: mockUser } });
+
+    (prisma.user.findUnique as jest.Mock).mockResolvedValue({
+      id: 'user-1',
+      email: 'test@example.com',
+      role: 'ADMIN',
+    });
+
+    (prisma.record.findUnique as jest.Mock).mockResolvedValue({
+      id: 'record-1',
+      tableId: 'table-1',
+      data: {},
+    });
+
+    (prisma.item.findUnique as jest.Mock).mockResolvedValue({
+      id: 'table-1',
+      type: 'TABLE',
+    });
+
+    (prisma.itemPermission.findUnique as jest.Mock).mockResolvedValue(null);
+    (prisma.groupMember.findMany as jest.Mock).mockResolvedValue([]);
+
     (prisma.record.delete as jest.Mock).mockRejectedValue(
       new Error('Database error')
     );
@@ -75,12 +133,17 @@ describe('deleteRecord', () => {
 
   it('存在しないレコードを削除しようとした場合はエラーを返す', async () => {
     mockGetUser.mockResolvedValue({ data: { user: mockUser } });
-    (prisma.record.delete as jest.Mock).mockRejectedValue(
-      new Error('Record not found')
-    );
+
+    (prisma.user.findUnique as jest.Mock).mockResolvedValue({
+      id: 'user-1',
+      email: 'test@example.com',
+      role: 'ADMIN',
+    });
+
+    (prisma.record.findUnique as jest.Mock).mockResolvedValue(null);
 
     const result = await deleteRecord('non-existent');
 
-    expect(result).toEqual({ error: 'レコードの削除に失敗しました' });
+    expect(result).toEqual({ error: 'レコードが見つかりません' });
   });
 });

--- a/features/record/api/__tests__/delete-record.test.ts
+++ b/features/record/api/__tests__/delete-record.test.ts
@@ -146,4 +146,36 @@ describe('deleteRecord', () => {
 
     expect(result).toEqual({ error: 'レコードが見つかりません' });
   });
+
+  it('WRITE権限がない場合はエラーを返す', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: mockUser } });
+
+    (prisma.user.findUnique as jest.Mock).mockResolvedValue({
+      id: 'user-1',
+      email: 'test@example.com',
+      role: 'MEMBER',
+    });
+
+    (prisma.record.findUnique as jest.Mock).mockResolvedValue({
+      id: 'record-1',
+      tableId: 'table-1',
+      data: {},
+    });
+
+    (prisma.item.findUnique as jest.Mock).mockResolvedValue({
+      id: 'table-1',
+      type: 'TABLE',
+    });
+
+    // READ権限のみ
+    (prisma.itemPermission.findUnique as jest.Mock).mockResolvedValue({
+      level: 'READ',
+    });
+    (prisma.groupMember.findMany as jest.Mock).mockResolvedValue([]);
+
+    const result = await deleteRecord('record-1');
+
+    expect(result).toEqual({ error: 'レコードを削除する権限がありません' });
+    expect(prisma.record.delete).not.toHaveBeenCalled();
+  });
 });

--- a/features/record/api/__tests__/update-record.test.ts
+++ b/features/record/api/__tests__/update-record.test.ts
@@ -154,6 +154,34 @@ describe('updateRecord', () => {
     expect(prisma.record.update).not.toHaveBeenCalled();
   });
 
+  it('WRITE権限がない場合はエラーを返す', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: mockUser } });
+
+    (prisma.user.findUnique as jest.Mock).mockResolvedValue({
+      id: 'user-1',
+      email: 'test@example.com',
+      role: 'MEMBER',
+    });
+
+    (prisma.record.findUnique as jest.Mock).mockResolvedValue(mockRecord);
+
+    (prisma.item.findUnique as jest.Mock).mockResolvedValue({
+      id: 'table-1',
+      type: 'TABLE',
+    });
+
+    // READ権限のみ
+    (prisma.itemPermission.findUnique as jest.Mock).mockResolvedValue({
+      level: 'READ',
+    });
+    (prisma.groupMember.findMany as jest.Mock).mockResolvedValue([]);
+
+    const result = await updateRecord('record-1', { name: '更新後' });
+
+    expect(result).toEqual({ error: 'レコードを更新する権限がありません' });
+    expect(prisma.record.update).not.toHaveBeenCalled();
+  });
+
   it('データベースエラーが発生した場合はエラーを返す', async () => {
     mockGetUser.mockResolvedValue({ data: { user: mockUser } });
 

--- a/features/record/api/__tests__/update-record.test.ts
+++ b/features/record/api/__tests__/update-record.test.ts
@@ -20,9 +20,21 @@ jest.mock('@/lib/supabase/server', () => ({
 // Prismaクライアントをモック化
 jest.mock('@/lib/prisma', () => ({
   prisma: {
+    user: {
+      findUnique: jest.fn(),
+    },
     record: {
       findUnique: jest.fn(),
       update: jest.fn(),
+    },
+    item: {
+      findUnique: jest.fn(),
+    },
+    itemPermission: {
+      findUnique: jest.fn(),
+    },
+    groupMember: {
+      findMany: jest.fn(),
     },
   },
 }));
@@ -49,7 +61,23 @@ describe('updateRecord', () => {
 
   it('レコードを更新できる', async () => {
     mockGetUser.mockResolvedValue({ data: { user: mockUser } });
+
+    (prisma.user.findUnique as jest.Mock).mockResolvedValue({
+      id: 'user-1',
+      email: 'test@example.com',
+      role: 'ADMIN',
+    });
+
     (prisma.record.findUnique as jest.Mock).mockResolvedValue(mockRecord);
+
+    (prisma.item.findUnique as jest.Mock).mockResolvedValue({
+      id: 'table-1',
+      type: 'TABLE',
+    });
+
+    (prisma.itemPermission.findUnique as jest.Mock).mockResolvedValue(null);
+    (prisma.groupMember.findMany as jest.Mock).mockResolvedValue([]);
+
     (prisma.record.update as jest.Mock).mockResolvedValue({
       ...mockRecord,
       data: { name: '更新後の名前', age: 20 },
@@ -66,7 +94,23 @@ describe('updateRecord', () => {
 
   it('既存のデータとマージされる', async () => {
     mockGetUser.mockResolvedValue({ data: { user: mockUser } });
+
+    (prisma.user.findUnique as jest.Mock).mockResolvedValue({
+      id: 'user-1',
+      email: 'test@example.com',
+      role: 'ADMIN',
+    });
+
     (prisma.record.findUnique as jest.Mock).mockResolvedValue(mockRecord);
+
+    (prisma.item.findUnique as jest.Mock).mockResolvedValue({
+      id: 'table-1',
+      type: 'TABLE',
+    });
+
+    (prisma.itemPermission.findUnique as jest.Mock).mockResolvedValue(null);
+    (prisma.groupMember.findMany as jest.Mock).mockResolvedValue([]);
+
     (prisma.record.update as jest.Mock).mockResolvedValue({
       ...mockRecord,
       data: { name: '元の名前', age: 25, email: 'new@example.com' },
@@ -95,6 +139,13 @@ describe('updateRecord', () => {
 
   it('レコードが存在しない場合はエラーを返す', async () => {
     mockGetUser.mockResolvedValue({ data: { user: mockUser } });
+
+    (prisma.user.findUnique as jest.Mock).mockResolvedValue({
+      id: 'user-1',
+      email: 'test@example.com',
+      role: 'ADMIN',
+    });
+
     (prisma.record.findUnique as jest.Mock).mockResolvedValue(null);
 
     const result = await updateRecord('non-existent', { name: '更新後' });
@@ -105,7 +156,23 @@ describe('updateRecord', () => {
 
   it('データベースエラーが発生した場合はエラーを返す', async () => {
     mockGetUser.mockResolvedValue({ data: { user: mockUser } });
+
+    (prisma.user.findUnique as jest.Mock).mockResolvedValue({
+      id: 'user-1',
+      email: 'test@example.com',
+      role: 'ADMIN',
+    });
+
     (prisma.record.findUnique as jest.Mock).mockResolvedValue(mockRecord);
+
+    (prisma.item.findUnique as jest.Mock).mockResolvedValue({
+      id: 'table-1',
+      type: 'TABLE',
+    });
+
+    (prisma.itemPermission.findUnique as jest.Mock).mockResolvedValue(null);
+    (prisma.groupMember.findMany as jest.Mock).mockResolvedValue([]);
+
     (prisma.record.update as jest.Mock).mockRejectedValue(
       new Error('Database error')
     );
@@ -121,9 +188,25 @@ describe('updateRecord', () => {
       data: null,
     };
     mockGetUser.mockResolvedValue({ data: { user: mockUser } });
+
+    (prisma.user.findUnique as jest.Mock).mockResolvedValue({
+      id: 'user-1',
+      email: 'test@example.com',
+      role: 'ADMIN',
+    });
+
     (prisma.record.findUnique as jest.Mock).mockResolvedValue(
       recordWithNullData
     );
+
+    (prisma.item.findUnique as jest.Mock).mockResolvedValue({
+      id: 'table-1',
+      type: 'TABLE',
+    });
+
+    (prisma.itemPermission.findUnique as jest.Mock).mockResolvedValue(null);
+    (prisma.groupMember.findMany as jest.Mock).mockResolvedValue([]);
+
     (prisma.record.update as jest.Mock).mockResolvedValue({
       ...recordWithNullData,
       data: { name: '新しい名前' },

--- a/features/record/api/create-record.ts
+++ b/features/record/api/create-record.ts
@@ -3,6 +3,8 @@
 import { revalidatePath } from 'next/cache';
 import { createClient } from '@/lib/supabase/server';
 import { prisma } from '@/lib/prisma';
+import { getCurrentUser } from '@/lib/auth';
+import { canAccessItem, hasPermission } from '@/lib/permissions';
 import type { InputJsonValue } from '@prisma/client/runtime/library';
 import type { Record as RecordType } from '../types';
 
@@ -32,13 +34,9 @@ export async function createRecord(
     return { error: '認証が必要です' };
   }
 
-  // DBからユーザーIDを取得
-  const dbUser = await prisma.user.findUnique({
-    where: { email: user.email! },
-    select: { id: true },
-  });
-
-  if (!dbUser) {
+  // DBからユーザー情報を取得
+  const currentUser = await getCurrentUser();
+  if (!currentUser) {
     return { error: 'ユーザー情報が取得できませんでした' };
   }
 
@@ -58,6 +56,17 @@ export async function createRecord(
     return { error: 'テーブルが見つかりません' };
   }
 
+  // 権限チェック（WRITE権限が必要）
+  const { canAccess, level } = await canAccessItem(
+    tableId,
+    currentUser.id,
+    currentUser.role
+  );
+
+  if (!canAccess || !hasPermission(level, 'WRITE')) {
+    return { error: 'レコードを作成する権限がありません' };
+  }
+
   try {
     // dataをパース（PrismaのJson型に対応）
     const data: InputJsonValue = dataString ? JSON.parse(dataString) : {};
@@ -66,7 +75,7 @@ export async function createRecord(
       data: {
         tableId,
         data,
-        createdById: dbUser.id,
+        createdById: currentUser.id,
       },
     });
 

--- a/features/record/api/delete-record.ts
+++ b/features/record/api/delete-record.ts
@@ -3,6 +3,8 @@
 import { revalidatePath } from 'next/cache';
 import { createClient } from '@/lib/supabase/server';
 import { prisma } from '@/lib/prisma';
+import { getCurrentUser } from '@/lib/auth';
+import { canAccessItem, hasPermission } from '@/lib/permissions';
 
 /**
  * レコード削除結果の型
@@ -28,11 +30,37 @@ export async function deleteRecord(
     return { error: '認証が必要です' };
   }
 
+  // DBからユーザー情報を取得
+  const currentUser = await getCurrentUser();
+  if (!currentUser) {
+    return { error: 'ユーザー情報が取得できませんでした' };
+  }
+
+  // レコードが存在するか確認
+  const record = await prisma.record.findUnique({
+    where: { id: recordId },
+    select: { tableId: true },
+  });
+
+  if (!record) {
+    return { error: 'レコードが見つかりません' };
+  }
+
+  // 権限チェック（WRITE権限が必要）
+  const { canAccess, level } = await canAccessItem(
+    record.tableId,
+    currentUser.id,
+    currentUser.role
+  );
+
+  if (!canAccess || !hasPermission(level, 'WRITE')) {
+    return { error: 'レコードを削除する権限がありません' };
+  }
+
   try {
-    // レコードを削除し、tableIdを取得
-    const record = await prisma.record.delete({
+    // レコードを削除
+    await prisma.record.delete({
       where: { id: recordId },
-      select: { tableId: true },
     });
 
     revalidatePath(`/${record.tableId}`);

--- a/features/record/api/update-record.ts
+++ b/features/record/api/update-record.ts
@@ -3,6 +3,8 @@
 import { revalidatePath } from 'next/cache';
 import { createClient } from '@/lib/supabase/server';
 import { prisma } from '@/lib/prisma';
+import { getCurrentUser } from '@/lib/auth';
+import { canAccessItem, hasPermission } from '@/lib/permissions';
 import type { InputJsonValue } from '@prisma/client/runtime/library';
 
 /**
@@ -30,6 +32,12 @@ export async function updateRecord(
     return { error: '認証が必要です' };
   }
 
+  // DBからユーザー情報を取得
+  const currentUser = await getCurrentUser();
+  if (!currentUser) {
+    return { error: 'ユーザー情報が取得できませんでした' };
+  }
+
   // レコードが存在するか確認
   const record = await prisma.record.findUnique({
     where: { id: recordId },
@@ -38,6 +46,17 @@ export async function updateRecord(
 
   if (!record) {
     return { error: 'レコードが見つかりません' };
+  }
+
+  // 権限チェック（WRITE権限が必要）
+  const { canAccess, level } = await canAccessItem(
+    record.tableId,
+    currentUser.id,
+    currentUser.role
+  );
+
+  if (!canAccess || !hasPermission(level, 'WRITE')) {
+    return { error: 'レコードを更新する権限がありません' };
   }
 
   try {

--- a/features/table/components/cells/checkbox-cell.tsx
+++ b/features/table/components/cells/checkbox-cell.tsx
@@ -9,6 +9,7 @@ type CheckboxCellProps = {
   displayStyle?: 'checkbox' | 'switch';
   checkedLabel?: string;
   uncheckedLabel?: string;
+  readOnly?: boolean;
 };
 
 /**
@@ -20,6 +21,7 @@ export function CheckboxCell({
   displayStyle = 'checkbox',
   checkedLabel,
   uncheckedLabel,
+  readOnly = false,
 }: CheckboxCellProps) {
   // ラベルを取得
   const label = value ? checkedLabel : uncheckedLabel;
@@ -27,11 +29,16 @@ export function CheckboxCell({
   return (
     <div className="min-h-[32px] px-2 py-1 flex items-center gap-2 w-full">
       {displayStyle === 'switch' ? (
-        <Switch checked={value} onCheckedChange={onChange} />
+        <Switch
+          checked={value}
+          onCheckedChange={onChange}
+          disabled={readOnly}
+        />
       ) : (
         <Checkbox
           checked={value}
           onCheckedChange={(checked) => onChange(checked === true)}
+          disabled={readOnly}
         />
       )}
       {label && <span className="text-sm">{label}</span>}

--- a/features/table/components/cells/date-cell.tsx
+++ b/features/table/components/cells/date-cell.tsx
@@ -20,6 +20,7 @@ type DateCellProps = {
   min?: string;
   max?: string;
   placeholder?: string;
+  readOnly?: boolean;
 };
 
 /**
@@ -61,6 +62,7 @@ export function DateCell({
   min,
   max,
   placeholder = '-',
+  readOnly = false,
 }: DateCellProps) {
   const [open, setOpen] = useState(false);
 
@@ -88,6 +90,16 @@ export function DateCell({
       return dateStr;
     }
   };
+
+  if (readOnly) {
+    return (
+      <div className="h-8 w-full px-2 flex items-center">
+        <span className={!value ? 'text-muted-foreground' : ''}>
+          {formatDisplayDate(value)}
+        </span>
+      </div>
+    );
+  }
 
   return (
     <Popover open={open} onOpenChange={setOpen}>

--- a/features/table/components/cells/multi-select-cell.tsx
+++ b/features/table/components/cells/multi-select-cell.tsx
@@ -8,6 +8,7 @@ type MultiSelectCellProps = {
   value: string[] | null;
   onChange: (value: string[] | null) => void;
   options: SelectOption[];
+  readOnly?: boolean;
 };
 
 /**
@@ -40,6 +41,7 @@ export function MultiSelectCell({
   value,
   onChange,
   options,
+  readOnly = false,
 }: MultiSelectCellProps) {
   const [isOpen, setIsOpen] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
@@ -83,6 +85,26 @@ export function MultiSelectCell({
       setIsOpen(false);
     }
   };
+
+  if (readOnly) {
+    return (
+      <div className="min-h-[32px] px-2 py-1 flex items-center flex-wrap gap-1 w-full">
+        {selectedOptions.length > 0 ? (
+          selectedOptions.map((option) => (
+            <span
+              key={option.id}
+              className="inline-flex items-center px-2 py-0.5 rounded text-sm"
+              style={getColorStyles(option.color)}
+            >
+              {option.label}
+            </span>
+          ))
+        ) : (
+          <span className="text-muted-foreground">-</span>
+        )}
+      </div>
+    );
+  }
 
   return (
     <div

--- a/features/table/components/cells/number-cell.tsx
+++ b/features/table/components/cells/number-cell.tsx
@@ -13,6 +13,7 @@ type NumberCellProps = {
   unit?: string;
   unitPosition?: 'prefix' | 'suffix';
   thousandSeparator?: boolean;
+  readOnly?: boolean;
 };
 
 /**
@@ -28,6 +29,7 @@ export function NumberCell({
   unit,
   unitPosition = 'suffix',
   thousandSeparator = false,
+  readOnly = false,
 }: NumberCellProps) {
   const [isEditing, setIsEditing] = useState(false);
   const [editValue, setEditValue] = useState('');
@@ -35,6 +37,7 @@ export function NumberCell({
 
   // 編集開始時にpropsの値をローカルステートにコピー
   const handleStartEdit = () => {
+    if (readOnly) return;
     setEditValue(value?.toString() ?? '');
     setIsEditing(true);
   };
@@ -108,7 +111,9 @@ export function NumberCell({
 
   return (
     <div
-      className="cursor-text min-h-[32px] px-2 py-1 hover:bg-muted/50 rounded flex items-center w-full"
+      className={`min-h-[32px] px-2 py-1 rounded flex items-center w-full ${
+        readOnly ? '' : 'cursor-text hover:bg-muted/50'
+      }`}
       onClick={handleStartEdit}
     >
       <span className={value != null ? '' : 'text-muted-foreground'}>

--- a/features/table/components/cells/select-cell.tsx
+++ b/features/table/components/cells/select-cell.tsx
@@ -7,6 +7,7 @@ type SelectCellProps = {
   value: string | null;
   onChange: (value: string | null) => void;
   options: SelectOption[];
+  readOnly?: boolean;
 };
 
 /**
@@ -35,7 +36,12 @@ function getColorStyles(color?: string): React.CSSProperties {
 /**
  * セレクトセルコンポーネント
  */
-export function SelectCell({ value, onChange, options }: SelectCellProps) {
+export function SelectCell({
+  value,
+  onChange,
+  options,
+  readOnly = false,
+}: SelectCellProps) {
   const [isOpen, setIsOpen] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
 
@@ -67,6 +73,23 @@ export function SelectCell({ value, onChange, options }: SelectCellProps) {
       setIsOpen(false);
     }
   };
+
+  if (readOnly) {
+    return (
+      <div className="min-h-[32px] px-2 py-1 flex items-center w-full">
+        {selectedOption ? (
+          <span
+            className="inline-flex items-center px-2 py-0.5 rounded text-sm"
+            style={getColorStyles(selectedOption.color)}
+          >
+            {selectedOption.label}
+          </span>
+        ) : (
+          <span className="text-muted-foreground">-</span>
+        )}
+      </div>
+    );
+  }
 
   return (
     <div

--- a/features/table/components/cells/text-cell.tsx
+++ b/features/table/components/cells/text-cell.tsx
@@ -7,18 +7,25 @@ type TextCellProps = {
   value: string;
   onChange: (value: string) => void;
   placeholder?: string;
+  readOnly?: boolean;
 };
 
 /**
  * テキストセルコンポーネント
  */
-export function TextCell({ value, onChange, placeholder }: TextCellProps) {
+export function TextCell({
+  value,
+  onChange,
+  placeholder,
+  readOnly = false,
+}: TextCellProps) {
   const [isEditing, setIsEditing] = useState(false);
   const [editValue, setEditValue] = useState('');
   const inputRef = useRef<HTMLInputElement>(null);
 
   // 編集開始時にpropsの値をローカルステートにコピー
   const handleStartEdit = () => {
+    if (readOnly) return;
     setEditValue(value);
     setIsEditing(true);
   };
@@ -62,7 +69,9 @@ export function TextCell({ value, onChange, placeholder }: TextCellProps) {
 
   return (
     <div
-      className="cursor-text min-h-[32px] px-2 py-1 hover:bg-muted/50 rounded flex items-center w-full"
+      className={`min-h-[32px] px-2 py-1 rounded flex items-center w-full ${
+        readOnly ? '' : 'cursor-text hover:bg-muted/50'
+      }`}
       onClick={handleStartEdit}
     >
       <span className={value ? '' : 'text-muted-foreground'}>

--- a/features/table/components/cells/textarea-cell.tsx
+++ b/features/table/components/cells/textarea-cell.tsx
@@ -7,6 +7,7 @@ type TextareaCellProps = {
   value: string;
   onChange: (value: string) => void;
   placeholder?: string;
+  readOnly?: boolean;
 };
 
 /**
@@ -16,6 +17,7 @@ export function TextareaCell({
   value,
   onChange,
   placeholder,
+  readOnly = false,
 }: TextareaCellProps) {
   const [isEditing, setIsEditing] = useState(false);
   const [editValue, setEditValue] = useState('');
@@ -23,6 +25,7 @@ export function TextareaCell({
 
   // 編集開始時にpropsの値をローカルステートにコピー
   const handleStartEdit = () => {
+    if (readOnly) return;
     setEditValue(value);
     setIsEditing(true);
   };
@@ -70,7 +73,9 @@ export function TextareaCell({
 
   return (
     <div
-      className="cursor-text min-h-[32px] px-2 py-1 hover:bg-muted/50 rounded flex items-center w-full"
+      className={`min-h-[32px] px-2 py-1 rounded flex items-center w-full ${
+        readOnly ? '' : 'cursor-text hover:bg-muted/50'
+      }`}
       onClick={handleStartEdit}
     >
       <span className={firstLine ? '' : 'text-muted-foreground'}>

--- a/features/table/components/columns.tsx
+++ b/features/table/components/columns.tsx
@@ -30,11 +30,111 @@ type CellChangeHandler = (
  */
 export const createColumns = (
   columns: Column[],
-  onCellChange: CellChangeHandler
+  onCellChange: CellChangeHandler,
+  readOnly = false
 ): ColumnDef<Record>[] => {
   // orderでソートされたカラム
   const sortedColumns = [...columns].sort((a, b) => a.order - b.order);
 
+  const dataColumns: ColumnDef<Record>[] = sortedColumns.map((column) => ({
+    id: column.id,
+    accessorFn: (row) => (row.data as RecordData)[column.id],
+    header: column.name,
+    cell: ({ row, getValue }) => {
+      const value = getValue();
+      const recordId = row.original.id;
+
+      const handleChange = (newValue: unknown) => {
+        onCellChange(recordId, column.id, newValue);
+      };
+
+      switch (column.type) {
+        case 'TEXT':
+          return (
+            <TextCell
+              value={(value as string) ?? ''}
+              onChange={handleChange}
+              placeholder={column.config?.placeholder}
+              readOnly={readOnly}
+            />
+          );
+        case 'TEXTAREA':
+          return (
+            <TextareaCell
+              value={(value as string) ?? ''}
+              onChange={handleChange}
+              placeholder={column.config?.placeholder}
+              readOnly={readOnly}
+            />
+          );
+        case 'NUMBER':
+          return (
+            <NumberCell
+              value={(value as number) ?? null}
+              onChange={handleChange}
+              min={column.config?.min}
+              max={column.config?.max}
+              step={column.config?.step}
+              placeholder={column.config?.placeholder}
+              unit={column.config?.unit}
+              unitPosition={column.config?.unitPosition}
+              thousandSeparator={column.config?.thousandSeparator}
+              readOnly={readOnly}
+            />
+          );
+        case 'DATE':
+          return (
+            <DateCell
+              value={(value as string) ?? null}
+              onChange={handleChange}
+              precision={column.config?.precision}
+              min={column.config?.min}
+              max={column.config?.max}
+              placeholder={column.config?.placeholder}
+              readOnly={readOnly}
+            />
+          );
+        case 'SELECT':
+          return (
+            <SelectCell
+              value={(value as string) ?? null}
+              onChange={handleChange}
+              options={(column as SelectColumn).config?.options ?? []}
+              readOnly={readOnly}
+            />
+          );
+        case 'MULTI_SELECT':
+          return (
+            <MultiSelectCell
+              value={(value as string[]) ?? null}
+              onChange={handleChange}
+              options={(column as MultiSelectColumn).config?.options ?? []}
+              readOnly={readOnly}
+            />
+          );
+        case 'CHECKBOX':
+          return (
+            <CheckboxCell
+              value={(value as boolean) ?? false}
+              onChange={handleChange}
+              displayStyle={column.config?.displayStyle}
+              checkedLabel={column.config?.checkedLabel}
+              uncheckedLabel={column.config?.uncheckedLabel}
+              readOnly={readOnly}
+            />
+          );
+        default:
+          return <span>{String(value ?? '-')}</span>;
+      }
+    },
+  }));
+
+  // READ権限の場合はチェックボックス列を含めない
+  if (readOnly) {
+    return dataColumns;
+  }
+
+  // WRITE権限がある場合はチェックボックス列を含める
   const selectColumn: ColumnDef<Record> = {
     id: 'select',
     header: ({ table }) => (
@@ -58,92 +158,6 @@ export const createColumns = (
     enableHiding: false,
     meta: { width: 'w-12' },
   };
-
-  const dataColumns: ColumnDef<Record>[] = sortedColumns.map((column) => ({
-    id: column.id,
-    accessorFn: (row) => (row.data as RecordData)[column.id],
-    header: column.name,
-    cell: ({ row, getValue }) => {
-      const value = getValue();
-      const recordId = row.original.id;
-
-      const handleChange = (newValue: unknown) => {
-        onCellChange(recordId, column.id, newValue);
-      };
-
-      switch (column.type) {
-        case 'TEXT':
-          return (
-            <TextCell
-              value={(value as string) ?? ''}
-              onChange={handleChange}
-              placeholder={column.config?.placeholder}
-            />
-          );
-        case 'TEXTAREA':
-          return (
-            <TextareaCell
-              value={(value as string) ?? ''}
-              onChange={handleChange}
-              placeholder={column.config?.placeholder}
-            />
-          );
-        case 'NUMBER':
-          return (
-            <NumberCell
-              value={(value as number) ?? null}
-              onChange={handleChange}
-              min={column.config?.min}
-              max={column.config?.max}
-              step={column.config?.step}
-              placeholder={column.config?.placeholder}
-              unit={column.config?.unit}
-              unitPosition={column.config?.unitPosition}
-              thousandSeparator={column.config?.thousandSeparator}
-            />
-          );
-        case 'DATE':
-          return (
-            <DateCell
-              value={(value as string) ?? null}
-              onChange={handleChange}
-              precision={column.config?.precision}
-              min={column.config?.min}
-              max={column.config?.max}
-              placeholder={column.config?.placeholder}
-            />
-          );
-        case 'SELECT':
-          return (
-            <SelectCell
-              value={(value as string) ?? null}
-              onChange={handleChange}
-              options={(column as SelectColumn).config?.options ?? []}
-            />
-          );
-        case 'MULTI_SELECT':
-          return (
-            <MultiSelectCell
-              value={(value as string[]) ?? null}
-              onChange={handleChange}
-              options={(column as MultiSelectColumn).config?.options ?? []}
-            />
-          );
-        case 'CHECKBOX':
-          return (
-            <CheckboxCell
-              value={(value as boolean) ?? false}
-              onChange={handleChange}
-              displayStyle={column.config?.displayStyle}
-              checkedLabel={column.config?.checkedLabel}
-              uncheckedLabel={column.config?.uncheckedLabel}
-            />
-          );
-        default:
-          return <span>{String(value ?? '-')}</span>;
-      }
-    },
-  }));
 
   return [selectColumn, ...dataColumns];
 };

--- a/features/table/components/data-table.tsx
+++ b/features/table/components/data-table.tsx
@@ -10,6 +10,7 @@ import {
   type VisibilityState,
 } from '@tanstack/react-table';
 import { ChevronDown, Plus } from 'lucide-react';
+import type { Permission } from '@prisma/client';
 import {
   DropdownMenu,
   DropdownMenuCheckboxItem,
@@ -31,6 +32,7 @@ import { Input } from '@/components/ui/input';
 import { updateRecord } from '@/features/record/api/update-record';
 import { createRecord } from '@/features/record/api/create-record';
 import { applyDefaultValues } from '@/features/column/utils';
+import { hasPermission } from '@/lib/permissions';
 import { createColumns } from './columns';
 import { BulkDeleteButton } from './bulk-delete-button';
 
@@ -41,6 +43,7 @@ type DataTableProps = {
   tableId: string;
   columns: Column[];
   initialRecords: Record[];
+  permissionLevel: Permission;
 };
 
 /**
@@ -50,12 +53,16 @@ export function DataTable({
   tableId,
   columns,
   initialRecords,
+  permissionLevel,
 }: DataTableProps) {
   const [records, setRecords] = useState<Record[]>(initialRecords);
   const [isPending, startTransition] = useTransition();
   const [searchValue, setSearchValue] = useState('');
   const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
   const [columnVisibility, setColumnVisibility] = useState<VisibilityState>({});
+
+  // WRITE権限があるかチェック
+  const canWrite = hasPermission(permissionLevel, 'WRITE');
 
   // セル値の更新ハンドラ
   const handleCellChange = useCallback(
@@ -145,8 +152,8 @@ export function DataTable({
 
   // TanStack Table用のカラム定義
   const tableColumns = useMemo(
-    () => createColumns(columns, handleCellChange),
-    [columns, handleCellChange]
+    () => createColumns(columns, handleCellChange, !canWrite),
+    [columns, handleCellChange, canWrite]
   );
 
   // eslint-disable-next-line react-hooks/incompatible-library
@@ -204,13 +211,15 @@ export function DataTable({
                 ))}
             </DropdownMenuContent>
           </DropdownMenu>
-          <Button
-            onClick={handleCreateRecord}
-            disabled={isPending || columns.length === 0}
-          >
-            <Plus />
-            レコード追加
-          </Button>
+          {canWrite && (
+            <Button
+              onClick={handleCreateRecord}
+              disabled={isPending || columns.length === 0}
+            >
+              <Plus />
+              レコード追加
+            </Button>
+          )}
         </div>
       </div>
 
@@ -274,7 +283,7 @@ export function DataTable({
 
       {/* ページネーション */}
       <div className="flex items-center justify-end space-x-2 py-4">
-        {selectedRows.length > 0 && (
+        {canWrite && selectedRows.length > 0 && (
           <div className="text-muted-foreground flex flex-1 items-center gap-2 text-sm">
             {selectedRows.length} / {table.getFilteredRowModel().rows.length}{' '}
             行を選択中

--- a/features/table/components/edit/access-content.tsx
+++ b/features/table/components/edit/access-content.tsx
@@ -1,0 +1,192 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import { Plus, Trash2 } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import { getPermissions, removePermission } from '@/features/permission/api';
+import {
+  PERMISSION_LIST,
+  getPermissionLabel,
+} from '@/features/permission/constants';
+import type { Permission } from '@prisma/client';
+
+/**
+ * AccessContentのProps型
+ */
+type AccessContentProps = {
+  itemId: string;
+};
+
+/**
+ * 権限情報の型
+ */
+type PermissionInfo = {
+  id: string;
+  itemId: string;
+  userId: string | null;
+  groupId: string | null;
+  level: Permission;
+  user?: {
+    id: string;
+    name: string | null;
+    email: string;
+  } | null;
+  group?: {
+    id: string;
+    name: string;
+    description: string | null;
+  } | null;
+};
+
+/**
+ * アクセス権限タブのコンテンツコンポーネント
+ */
+export function AccessContent({ itemId }: AccessContentProps) {
+  const [permissions, setPermissions] = useState<PermissionInfo[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  // 権限一覧を取得
+  const loadPermissions = useCallback(async () => {
+    setLoading(true);
+    const result = await getPermissions(itemId);
+    if ('success' in result && result.success) {
+      setPermissions(result.permissions as PermissionInfo[]);
+    }
+    setLoading(false);
+  }, [itemId]);
+
+  useEffect(() => {
+    let isMounted = true;
+
+    const fetchPermissions = async () => {
+      setLoading(true);
+      const result = await getPermissions(itemId);
+      if (isMounted && 'success' in result && result.success) {
+        setPermissions(result.permissions as PermissionInfo[]);
+      }
+      if (isMounted) {
+        setLoading(false);
+      }
+    };
+
+    fetchPermissions();
+
+    return () => {
+      isMounted = false;
+    };
+  }, [itemId]);
+
+  // 権限削除
+  const handleRemove = async (permissionId: string) => {
+    if (!confirm('この権限設定を削除しますか？')) {
+      return;
+    }
+
+    const result = await removePermission(permissionId);
+    if ('success' in result && result.success) {
+      await loadPermissions();
+    } else if ('error' in result) {
+      alert(result.error || '削除に失敗しました');
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h2 className="text-lg font-semibold mb-2">アクセス権限</h2>
+        <p className="text-sm text-muted-foreground mb-4">
+          このアイテムにアクセスできるユーザーとグループを管理します。
+          <br />
+          権限が設定されていない場合、すべてのユーザーがREAD権限でアクセスできます（パブリック）。
+        </p>
+      </div>
+
+      {/* 権限追加ボタン */}
+      <div className="flex justify-end">
+        <Button size="sm">
+          <Plus className="size-4 mr-2" />
+          権限を追加
+        </Button>
+      </div>
+
+      {/* 権限一覧 */}
+      {loading ? (
+        <p className="text-sm text-muted-foreground">読み込み中...</p>
+      ) : permissions.length === 0 ? (
+        <div className="rounded-lg border border-dashed p-8 text-center">
+          <p className="text-sm text-muted-foreground">
+            権限が設定されていません。
+          </p>
+          <p className="text-xs text-muted-foreground mt-2">
+            すべてのユーザーがREAD権限でアクセスできます。
+          </p>
+        </div>
+      ) : (
+        <div className="rounded-lg border">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>種別</TableHead>
+                <TableHead>名前</TableHead>
+                <TableHead>権限レベル</TableHead>
+                <TableHead className="w-[100px]">操作</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {permissions.map((permission) => (
+                <TableRow key={permission.id}>
+                  <TableCell>
+                    {permission.userId ? 'ユーザー' : 'グループ'}
+                  </TableCell>
+                  <TableCell>
+                    {permission.user
+                      ? permission.user.name || permission.user.email
+                      : permission.group?.name}
+                  </TableCell>
+                  <TableCell>
+                    <Select value={permission.level} disabled>
+                      <SelectTrigger className="w-[120px]">
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {PERMISSION_LIST.map((level) => (
+                          <SelectItem key={level} value={level}>
+                            {getPermissionLabel(level)}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </TableCell>
+                  <TableCell>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => handleRemove(permission.id)}
+                    >
+                      <Trash2 className="size-4" />
+                    </Button>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/features/table/components/edit/access-content.tsx
+++ b/features/table/components/edit/access-content.tsx
@@ -1,8 +1,6 @@
 'use client';
 
-import { useCallback, useEffect, useState } from 'react';
-import { Plus, Trash2 } from 'lucide-react';
-import { Button } from '@/components/ui/button';
+import { useEffect, useState } from 'react';
 import {
   Select,
   SelectContent,
@@ -18,11 +16,20 @@ import {
   TableHeader,
   TableRow,
 } from '@/components/ui/table';
-import { getPermissions, removePermission } from '@/features/permission/api';
+import {
+  getPermissions,
+  addPermission,
+  updatePermission,
+  removePermission,
+} from '@/features/permission/api';
 import {
   PERMISSION_LIST,
   getPermissionLabel,
 } from '@/features/permission/constants';
+import { AddPermissionDialog } from '@/features/permission/components/add-permission-dialog';
+import { DeletePermissionButton } from '@/features/permission/components/delete-permission-button';
+import { getUsers } from '@/features/user/api';
+import { getGroups } from '@/features/group/api';
 import type { Permission } from '@prisma/client';
 
 /**
@@ -59,49 +66,109 @@ type PermissionInfo = {
 export function AccessContent({ itemId }: AccessContentProps) {
   const [permissions, setPermissions] = useState<PermissionInfo[]>([]);
   const [loading, setLoading] = useState(true);
-
-  // 権限一覧を取得
-  const loadPermissions = useCallback(async () => {
-    setLoading(true);
-    const result = await getPermissions(itemId);
-    if ('success' in result && result.success) {
-      setPermissions(result.permissions as PermissionInfo[]);
-    }
-    setLoading(false);
-  }, [itemId]);
+  const [users, setUsers] = useState<
+    Array<{ id: string; name: string | null; email: string }>
+  >([]);
+  const [groups, setGroups] = useState<
+    Array<{ id: string; name: string; description: string | null }>
+  >([]);
 
   useEffect(() => {
     let isMounted = true;
 
-    const fetchPermissions = async () => {
+    const fetchData = async () => {
       setLoading(true);
-      const result = await getPermissions(itemId);
-      if (isMounted && 'success' in result && result.success) {
-        setPermissions(result.permissions as PermissionInfo[]);
-      }
+
+      // 並列で取得
+      const [permissionsResult, usersData, groupsData] = await Promise.all([
+        getPermissions(itemId),
+        getUsers(),
+        getGroups(),
+      ]);
+
       if (isMounted) {
+        // 権限一覧をセット
+        if ('success' in permissionsResult && permissionsResult.success) {
+          setPermissions(permissionsResult.permissions as PermissionInfo[]);
+        }
+
+        // ユーザー一覧をセット（簡略化された型に変換）
+        setUsers(
+          usersData.map((user) => ({
+            id: user.id,
+            name: user.name,
+            email: user.email,
+          }))
+        );
+
+        // グループ一覧をセット（簡略化された型に変換）
+        setGroups(
+          groupsData.map((group) => ({
+            id: group.id,
+            name: group.name,
+            description: group.description,
+          }))
+        );
+
         setLoading(false);
       }
     };
 
-    fetchPermissions();
+    fetchData();
 
     return () => {
       isMounted = false;
     };
   }, [itemId]);
 
-  // 権限削除
-  const handleRemove = async (permissionId: string) => {
-    if (!confirm('この権限設定を削除しますか？')) {
-      return;
-    }
-
-    const result = await removePermission(permissionId);
+  // 権限追加
+  const handleAdd = async (
+    targetType: 'group' | 'user',
+    targetId: string,
+    level: Permission
+  ) => {
+    const result = await addPermission(itemId, targetType, targetId, level);
     if ('success' in result && result.success) {
-      await loadPermissions();
+      // 成功時は権限一覧を再取得してUIを更新
+      const permissionsResult = await getPermissions(itemId);
+      if ('success' in permissionsResult && permissionsResult.success) {
+        setPermissions(permissionsResult.permissions as PermissionInfo[]);
+      }
     } else if ('error' in result) {
+      alert(result.error || '権限の追加に失敗しました');
+      throw new Error(result.error);
+    }
+  };
+
+  // 権限更新
+  const handleUpdate = async (permissionId: string, level: Permission) => {
+    // 楽観的更新：先にUIを更新
+    const previousPermissions = permissions;
+    setPermissions((prev) =>
+      prev.map((p) => (p.id === permissionId ? { ...p, level } : p))
+    );
+
+    // サーバーに保存
+    const result = await updatePermission(permissionId, level);
+    if ('error' in result) {
+      // エラー時はロールバック
+      alert(result.error || '権限の更新に失敗しました');
+      setPermissions(previousPermissions);
+    }
+  };
+
+  // 権限削除
+  const handleDelete = async (permissionId: string) => {
+    // 楽観的更新：先にUIから削除
+    const previousPermissions = permissions;
+    setPermissions((prev) => prev.filter((p) => p.id !== permissionId));
+
+    // サーバーで削除
+    const result = await removePermission(permissionId);
+    if ('error' in result) {
+      // エラー時はロールバック
       alert(result.error || '削除に失敗しました');
+      setPermissions(previousPermissions);
     }
   };
 
@@ -116,12 +183,9 @@ export function AccessContent({ itemId }: AccessContentProps) {
         </p>
       </div>
 
-      {/* 権限追加ボタン */}
+      {/* 権限追加ダイアログ */}
       <div className="flex justify-end">
-        <Button size="sm">
-          <Plus className="size-4 mr-2" />
-          権限を追加
-        </Button>
+        <AddPermissionDialog users={users} groups={groups} onAdd={handleAdd} />
       </div>
 
       {/* 権限一覧 */}
@@ -159,7 +223,12 @@ export function AccessContent({ itemId }: AccessContentProps) {
                       : permission.group?.name}
                   </TableCell>
                   <TableCell>
-                    <Select value={permission.level} disabled>
+                    <Select
+                      value={permission.level}
+                      onValueChange={(value) =>
+                        handleUpdate(permission.id, value as Permission)
+                      }
+                    >
                       <SelectTrigger className="w-[120px]">
                         <SelectValue />
                       </SelectTrigger>
@@ -173,13 +242,15 @@ export function AccessContent({ itemId }: AccessContentProps) {
                     </Select>
                   </TableCell>
                   <TableCell>
-                    <Button
-                      variant="ghost"
-                      size="sm"
-                      onClick={() => handleRemove(permission.id)}
-                    >
-                      <Trash2 className="size-4" />
-                    </Button>
+                    <DeletePermissionButton
+                      permissionId={permission.id}
+                      targetName={
+                        permission.user
+                          ? permission.user.name || permission.user.email
+                          : permission.group?.name || ''
+                      }
+                      onDelete={handleDelete}
+                    />
                   </TableCell>
                 </TableRow>
               ))}

--- a/features/table/components/edit/index.ts
+++ b/features/table/components/edit/index.ts
@@ -1,3 +1,4 @@
 export * from './table-edit-layout';
 export * from './columns-content';
 export * from './settings-content';
+export * from './access-content';

--- a/features/table/components/edit/table-edit-layout.tsx
+++ b/features/table/components/edit/table-edit-layout.tsx
@@ -6,6 +6,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import type { Column } from '@/features/column/types';
 import { ColumnsContent } from './columns-content';
 import { SettingsContent } from './settings-content';
+import { AccessContent } from './access-content';
 
 /**
  * TableEditLayoutのProps型
@@ -59,6 +60,9 @@ export function TableEditLayout({
         </TabsContent>
         <TabsContent value="columns" className="flex-1 mt-6">
           <ColumnsContent itemId={itemId} columns={columns} />
+        </TabsContent>
+        <TabsContent value="access" className="flex-1 mt-6">
+          <AccessContent itemId={itemId} />
         </TabsContent>
       </Tabs>
     </div>

--- a/features/table/components/table-layout.tsx
+++ b/features/table/components/table-layout.tsx
@@ -1,3 +1,4 @@
+import type { Permission } from '@prisma/client';
 import type { Column } from '@/features/column/types';
 import type { Record } from '@/features/record/types';
 import { DataTable } from './data-table';
@@ -10,6 +11,7 @@ type TableLayoutProps = {
   itemName: string;
   columns: Column[];
   records: Record[];
+  permissionLevel: Permission;
 };
 
 /**
@@ -20,6 +22,7 @@ export function TableLayout({
   itemName,
   columns,
   records,
+  permissionLevel,
 }: TableLayoutProps) {
   return (
     <div className="w-full p-6">
@@ -27,7 +30,12 @@ export function TableLayout({
         <h1 className="text-2xl font-bold">{itemName}</h1>
       </div>
 
-      <DataTable tableId={itemId} columns={columns} initialRecords={records} />
+      <DataTable
+        tableId={itemId}
+        columns={columns}
+        initialRecords={records}
+        permissionLevel={permissionLevel}
+      />
     </div>
   );
 }

--- a/lib/permissions.ts
+++ b/lib/permissions.ts
@@ -16,7 +16,6 @@ const ROLE_LEVELS: Record<UserRole, number> = {
  * 数値が大きいほど上位の権限
  */
 const PERMISSION_LEVELS: Record<Permission, number> = {
-  ADMIN: 4,
   WRITE: 3,
   READ: 2,
   NONE: 1,
@@ -92,9 +91,9 @@ export async function canAccessItem(
   userId: string,
   userRole: UserRole
 ): Promise<{ canAccess: boolean; level: Permission }> {
-  // 1. ADMIN roleは全アクセス可能
-  if (userRole === 'ADMIN') {
-    return { canAccess: true, level: 'ADMIN' };
+  // 1. ADMIN/DEVELOPER roleは全アクセス可能（WRITE権限）
+  if (userRole === 'ADMIN' || userRole === 'DEVELOPER') {
+    return { canAccess: true, level: 'WRITE' };
   }
 
   // 2. ユーザー個別の権限をチェック

--- a/lib/permissions.ts
+++ b/lib/permissions.ts
@@ -1,4 +1,5 @@
-import type { UserRole } from '@prisma/client';
+import type { UserRole, Permission } from '@prisma/client';
+import { prisma } from '@/lib/prisma';
 
 /**
  * ロールの階層レベル
@@ -8,6 +9,17 @@ const ROLE_LEVELS: Record<UserRole, number> = {
   ADMIN: 3,
   DEVELOPER: 2,
   MEMBER: 1,
+};
+
+/**
+ * 権限レベルの階層
+ * 数値が大きいほど上位の権限
+ */
+const PERMISSION_LEVELS: Record<Permission, number> = {
+  ADMIN: 4,
+  WRITE: 3,
+  READ: 2,
+  NONE: 1,
 };
 
 /**
@@ -66,4 +78,99 @@ export function canManageRecords(role: UserRole): boolean {
  */
 export function canView(role: UserRole): boolean {
   return hasRole(role, 'MEMBER');
+}
+
+/**
+ * アイテムへのアクセス権限をチェック
+ * @param itemId - アイテムID
+ * @param userId - ユーザーID
+ * @param userRole - ユーザーのロール
+ * @returns アクセス権限の有無と権限レベル
+ */
+export async function canAccessItem(
+  itemId: string,
+  userId: string,
+  userRole: UserRole
+): Promise<{ canAccess: boolean; level: Permission }> {
+  // 1. ADMIN roleは全アクセス可能
+  if (userRole === 'ADMIN') {
+    return { canAccess: true, level: 'ADMIN' };
+  }
+
+  // 2. ユーザー個別の権限をチェック
+  const userPermission = await prisma.itemPermission.findUnique({
+    where: {
+      itemId_userId: {
+        itemId,
+        userId,
+      },
+    },
+  });
+
+  if (userPermission) {
+    return {
+      canAccess: userPermission.level !== 'NONE',
+      level: userPermission.level,
+    };
+  }
+
+  // 3. グループ権限をチェック（ユーザーが所属するすべてのグループ）
+  const groupPermissions = await prisma.itemPermission.findMany({
+    where: {
+      itemId,
+      group: {
+        members: {
+          some: {
+            userId,
+          },
+        },
+      },
+    },
+  });
+
+  if (groupPermissions.length > 0) {
+    // 数値に変換して最大の権限レベルを取得
+    const highestPermission = groupPermissions.reduce((max, current) => {
+      return PERMISSION_LEVELS[current.level] > PERMISSION_LEVELS[max.level]
+        ? current
+        : max;
+    });
+
+    return {
+      canAccess: highestPermission.level !== 'NONE',
+      level: highestPermission.level,
+    };
+  }
+
+  // 4. デフォルト: パブリックアクセス（READ権限）
+  return { canAccess: true, level: 'READ' };
+}
+
+/**
+ * アイテムの権限レベルを取得
+ * @param itemId - アイテムID
+ * @param userId - ユーザーID
+ * @param userRole - ユーザーのロール
+ * @returns 権限レベル
+ */
+export async function getItemPermissionLevel(
+  itemId: string,
+  userId: string,
+  userRole: UserRole
+): Promise<Permission> {
+  const { level } = await canAccessItem(itemId, userId, userRole);
+  return level;
+}
+
+/**
+ * 指定された権限レベルがあるかチェック
+ * @param currentLevel - 現在の権限レベル
+ * @param requiredLevel - 必要な権限レベル
+ * @returns 権限があればtrue
+ */
+export function hasPermission(
+  currentLevel: Permission,
+  requiredLevel: Permission
+): boolean {
+  return PERMISSION_LEVELS[currentLevel] >= PERMISSION_LEVELS[requiredLevel];
 }

--- a/prisma/migrations/20251202221919_add_item_permission/migration.sql
+++ b/prisma/migrations/20251202221919_add_item_permission/migration.sql
@@ -1,0 +1,39 @@
+-- CreateEnum
+CREATE TYPE "Permission" AS ENUM ('NONE', 'READ', 'WRITE', 'ADMIN');
+
+-- CreateTable
+CREATE TABLE "ItemPermission" (
+    "id" TEXT NOT NULL,
+    "itemId" TEXT NOT NULL,
+    "userId" TEXT,
+    "groupId" TEXT,
+    "level" "Permission" NOT NULL DEFAULT 'READ',
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "ItemPermission_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "ItemPermission_itemId_idx" ON "ItemPermission"("itemId");
+
+-- CreateIndex
+CREATE INDEX "ItemPermission_userId_idx" ON "ItemPermission"("userId");
+
+-- CreateIndex
+CREATE INDEX "ItemPermission_groupId_idx" ON "ItemPermission"("groupId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ItemPermission_itemId_userId_key" ON "ItemPermission"("itemId", "userId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ItemPermission_itemId_groupId_key" ON "ItemPermission"("itemId", "groupId");
+
+-- AddForeignKey
+ALTER TABLE "ItemPermission" ADD CONSTRAINT "ItemPermission_itemId_fkey" FOREIGN KEY ("itemId") REFERENCES "Item"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ItemPermission" ADD CONSTRAINT "ItemPermission_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ItemPermission" ADD CONSTRAINT "ItemPermission_groupId_fkey" FOREIGN KEY ("groupId") REFERENCES "Group"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/migrations/20251204001159_remove_admin_permission/migration.sql
+++ b/prisma/migrations/20251204001159_remove_admin_permission/migration.sql
@@ -1,0 +1,16 @@
+-- 既存のADMIN権限をWRITEに変換
+UPDATE "ItemPermission" SET "level" = 'WRITE' WHERE "level" = 'ADMIN';
+
+-- Permission enumからADMINを削除
+-- PostgreSQLではenum値の削除は直接できないため、enumを再作成
+-- 1. 一時的な新しいenumを作成
+CREATE TYPE "Permission_new" AS ENUM ('NONE', 'READ', 'WRITE');
+
+-- 2. 既存のカラムを新しいenumに変換
+ALTER TABLE "ItemPermission" ALTER COLUMN "level" TYPE "Permission_new" USING ("level"::text::"Permission_new");
+
+-- 3. 古いenumを削除
+DROP TYPE "Permission";
+
+-- 4. 新しいenumを元の名前にリネーム
+ALTER TYPE "Permission_new" RENAME TO "Permission";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -16,7 +16,8 @@ model User {
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
-  groupMembers GroupMember[]
+  groupMembers    GroupMember[]
+  itemPermissions ItemPermission[]
 }
 
 model Group {
@@ -27,9 +28,10 @@ model Group {
   createdAt   DateTime @default(now())
   updatedAt   DateTime @updatedAt
 
-  parent   Group?        @relation("GroupHierarchy", fields: [parentId], references: [id], onDelete: Restrict)
-  children Group[]       @relation("GroupHierarchy")
-  members  GroupMember[]
+  parent          Group?             @relation("GroupHierarchy", fields: [parentId], references: [id], onDelete: Restrict)
+  children        Group[]            @relation("GroupHierarchy")
+  members         GroupMember[]
+  itemPermissions ItemPermission[]
 
   @@index([parentId])
 }
@@ -59,9 +61,10 @@ model Item {
   createdAt   DateTime @default(now())
   updatedAt   DateTime @updatedAt
 
-  parent   Item?    @relation("ItemHierarchy", fields: [parentId], references: [id], onDelete: Cascade)
-  children Item[]   @relation("ItemHierarchy")
-  records  Record[]
+  parent      Item?              @relation("ItemHierarchy", fields: [parentId], references: [id], onDelete: Cascade)
+  children    Item[]             @relation("ItemHierarchy")
+  records     Record[]
+  permissions ItemPermission[]
 
   @@index([parentId])
   @@index([createdById])
@@ -83,6 +86,26 @@ model Record {
   @@index([createdById])
 }
 
+model ItemPermission {
+  id        String     @id @default(uuid())
+  itemId    String
+  userId    String?
+  groupId   String?
+  level     Permission @default(READ)
+  createdAt DateTime   @default(now())
+  updatedAt DateTime   @updatedAt
+
+  item  Item   @relation(fields: [itemId], references: [id], onDelete: Cascade)
+  user  User?  @relation(fields: [userId], references: [id], onDelete: Cascade)
+  group Group? @relation(fields: [groupId], references: [id], onDelete: Cascade)
+
+  @@unique([itemId, userId])
+  @@unique([itemId, groupId])
+  @@index([itemId])
+  @@index([userId])
+  @@index([groupId])
+}
+
 enum UserRole {
   ADMIN
   DEVELOPER
@@ -92,4 +115,11 @@ enum UserRole {
 enum ItemType {
   FOLDER
   TABLE
+}
+
+enum Permission {
+  NONE
+  READ
+  WRITE
+  ADMIN
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -121,5 +121,4 @@ enum Permission {
   NONE
   READ
   WRITE
-  ADMIN
 }


### PR DESCRIPTION
## 概要

アイテム（フォルダ・テーブル）に対する権限管理機能を実装しました。ユーザーやグループごとに、個別のアイテムに対するアクセス権限（READ/WRITE/NONE）を設定できるようになります。

## 実装内容

### 1. データベーススキーマ

- **ItemPermissionモデルの追加**
  - `itemId`: 対象アイテム
  - `userId` / `groupId`: 権限対象（ユーザーまたはグループ）
  - `level`: 権限レベル（READ/WRITE/NONE）
  - ユニーク制約: `itemId + userId` および `itemId + groupId`

### 2. 権限管理API（Server Actions）

- **[add-permission.ts](features/permission/api/add-permission.ts)**: ユーザー/グループに権限を追加
- **[update-permission.ts](features/permission/api/update-permission.ts)**: 権限レベルを更新
- **[remove-permission.ts](features/permission/api/remove-permission.ts)**: 権限を削除
- **[get-permissions.ts](features/permission/api/get-permissions.ts)**: アイテムの権限一覧を取得

すべてのAPIで以下を実装：
- 認証チェック（`getCurrentUser`）
- 構造管理権限チェック（DEVELOPER以上が必要）
- 楽観的更新パターンに対応（`revalidatePath`なし）

### 3. 権限チェックロジック

**[lib/permissions.ts](lib/permissions.ts)** に以下の関数を追加：

- `canAccessItem()`: アイテムへのアクセス権限を確認
  - ADMIN/DEVELOPER: すべてのアイテムにWRITEアクセス
  - MEMBER: 個別権限 > グループ権限 > デフォルト（READ）の優先順位

- `hasPermission()`: 必要な権限レベルをチェック

### 4. UI実装

**[access-content.tsx](features/table/components/edit/access-content.tsx)**:
- 権限一覧の表示（Table形式）
- 権限レベルの変更（Selectコンポーネント）
- 権限の追加（AddPermissionDialog）
- 権限の削除（DeletePermissionButton with AlertDialog）
- 楽観的更新による即座のUI反映
- エラー時の自動ロールバック

**[delete-permission-button.tsx](features/permission/components/delete-permission-button.tsx)**:
- AlertDialogによる削除確認
- Toast通知（成功/エラー）
- アイコンボタンスタイル（`Trash2`）

### 5. 既存機能への統合

以下のAPIに権限チェックを追加：
- **レコード操作**: `create-record.ts`, `update-record.ts`, `delete-record.ts`
- **アイテム取得**: `get-items.ts`（権限のないアイテムを自動フィルタ）

### 6. テスト

**権限管理APIのテスト（100%カバレッジ）**:
- [add-permission.test.ts](features/permission/api/__tests__/add-permission.test.ts) - 11テスト
- [update-permission.test.ts](features/permission/api/__tests__/update-permission.test.ts) - 5テスト
- [remove-permission.test.ts](features/permission/api/__tests__/remove-permission.test.ts) - 5テスト
- [get-permissions.test.ts](features/permission/api/__tests__/get-permissions.test.ts) - 6テスト

**既存テストの修正**:
- `delete-record.test.ts`, `update-record.test.ts`, `create-record.test.ts`, `get-items.test.ts`
- 権限チェック用のモック（`itemPermission`, `groupMember`）を追加

**テスト結果**:
- 全38テストスイート、234テストすべて成功 

## 権限の優先順位

ADMIN/DEVELOPER権限 (WRITE) ↓ ユーザー個別権限 ↓ グループ権限（複数グループの場合は最も高い権限） ↓ デフォルト権限 (READ)

## 動作確認

- [x] 権限の追加（ユーザー/グループ）
- [x] 権限レベルの変更（READ/WRITE/NONE）
- [x] 権限の削除（AlertDialog確認）
- [x] 楽観的更新によるUI即時反映
- [x] エラー時の自動ロールバック
- [x] 権限に応じたレコード操作制限
- [x] すべてのテストが成功

## 関連Issue

Closes #52  