### PR TITLE
既存のget系APIを `Prisma.GetPayload` を使った型定義に統一する

### DIFF
--- a/features/group/api/get-groups.ts
+++ b/features/group/api/get-groups.ts
@@ -39,5 +39,5 @@ export async function getGroups(): Promise<Group[]> {
     },
   });
 
-  return groups as Group[];
+  return groups;
 }

--- a/features/group/types/group.ts
+++ b/features/group/types/group.ts
@@ -1,16 +1,30 @@
-import type { Group as PrismaGroup, GroupMember, User } from '@prisma/client';
+import type { Prisma } from '@prisma/client';
 
 /**
- * グループ型（PrismaGroupを拡張）
+ * グループ型（Prisma.GroupGetPayloadを使用）
  */
-export type Group = PrismaGroup & {
-  parent?: {
-    name: string;
-  } | null;
-  members?: (GroupMember & {
-    user: Pick<User, 'id' | 'email' | 'name'>;
-  })[];
-  _count?: {
-    members: number;
+export type Group = Prisma.GroupGetPayload<{
+  include: {
+    parent: {
+      select: {
+        name: true;
+      };
+    };
+    members: {
+      include: {
+        user: {
+          select: {
+            id: true;
+            email: true;
+            name: true;
+          };
+        };
+      };
+    };
+    _count: {
+      select: {
+        members: true;
+      };
+    };
   };
-};
+}>;

--- a/features/item/api/get-items.ts
+++ b/features/item/api/get-items.ts
@@ -52,6 +52,8 @@ async function getItemWithChildren(
     );
   }
 
+  // 再帰的な構造のため、型アサーションが必要
+  // Prisma型からItem型（Discriminated Union）への変換
   return item as Item;
 }
 

--- a/features/item/types/item.ts
+++ b/features/item/types/item.ts
@@ -1,14 +1,23 @@
-import type { Item as PrismaItem } from '@prisma/client';
+import type { Prisma } from '@prisma/client';
+
+/**
+ * Itemのクエリペイロード型（get-items.tsのクエリ構造に対応）
+ */
+type ItemPayload = Prisma.ItemGetPayload<{
+  include: {
+    children: true;
+    _count: {
+      select: {
+        children: true;
+      };
+    };
+  };
+}>;
 
 /**
  * 基本型（共通プロパティ）
  */
-type BaseItem = Omit<PrismaItem, 'type' | 'meta'> & {
-  order: number;
-  _count?: {
-    children: number;
-  };
-};
+type BaseItem = Omit<ItemPayload, 'type' | 'meta' | 'children'>;
 
 /**
  * Folder専用型

--- a/features/record/api/get-records.ts
+++ b/features/record/api/get-records.ts
@@ -12,5 +12,7 @@ export async function getRecords(tableId: string): Promise<Record[]> {
     orderBy: { createdAt: 'asc' },
   });
 
+  // Prismaの`data: Json`フィールドは、カスタム型の`data: RecordData`と互換
+  // 型キャストで意図を明示
   return records as Record[];
 }

--- a/features/user/api/get-users.ts
+++ b/features/user/api/get-users.ts
@@ -13,5 +13,5 @@ export async function getUsers(): Promise<User[]> {
     },
   });
 
-  return users as User[];
+  return users;
 }

--- a/features/user/types/user.ts
+++ b/features/user/types/user.ts
@@ -1,11 +1,22 @@
-import type { User as PrismaUser, GroupMember } from '@prisma/client';
+import type { User as PrismaUser, Prisma } from '@prisma/client';
 
 /**
- * ユーザー型（PrismaUserを拡張）
+ * ユーザー型（基本型）
+ * get-users.tsのクエリ構造に対応（includeなし）
  */
-export type User = PrismaUser & {
-  groupMembers?: GroupMember[];
-  _count?: {
-    groupMembers: number;
+export type User = PrismaUser;
+
+/**
+ * ユーザー型（グループメンバー情報を含む）
+ * 将来的にグループメンバー情報が必要な場合に使用
+ */
+export type UserWithGroupMembers = Prisma.UserGetPayload<{
+  include: {
+    groupMembers: true;
+    _count: {
+      select: {
+        groupMembers: true;
+      };
+    };
   };
-};
+}>;


### PR DESCRIPTION
## 概要

既存のget系APIの型定義を`Prisma.GetPayload`を使った自動生成型に統一し、型の正確性とメンテナンス性を向上させました。

## 実装内容

- **Group**: 手動型定義から`Prisma.GroupGetPayload`に変更し、型キャストを削除
- **Item**: `Prisma.ItemGetPayload`をベースに使用、`orderBy`と手動`_count`オーバーライドを削除
- **User**: 基本型は`PrismaUser`に、拡張型は`GetPayload`で定義

## 動作確認

- [x] ビルドが成功することを確認
- [x] 全テストが通過することを確認
- [x] 他のget系APIに同様の改善が必要ないか調査済み

Closes #53