### PR TITLE
SELECTとMULTI_SELECTを統一型に変更

### DIFF
--- a/components/ui/radio-group.tsx
+++ b/components/ui/radio-group.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import * as React from 'react';
+import * as RadioGroupPrimitive from '@radix-ui/react-radio-group';
+import { CircleIcon } from 'lucide-react';
+
+import { cn } from '@/lib/utils';
+
+function RadioGroup({
+  className,
+  ...props
+}: React.ComponentProps<typeof RadioGroupPrimitive.Root>) {
+  return (
+    <RadioGroupPrimitive.Root
+      data-slot="radio-group"
+      className={cn('grid gap-3', className)}
+      {...props}
+    />
+  );
+}
+
+function RadioGroupItem({
+  className,
+  ...props
+}: React.ComponentProps<typeof RadioGroupPrimitive.Item>) {
+  return (
+    <RadioGroupPrimitive.Item
+      data-slot="radio-group-item"
+      className={cn(
+        'border-input text-primary focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 aspect-square size-4 shrink-0 rounded-full border shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50',
+        className
+      )}
+      {...props}
+    >
+      <RadioGroupPrimitive.Indicator
+        data-slot="radio-group-indicator"
+        className="relative flex items-center justify-center"
+      >
+        <CircleIcon className="fill-primary absolute top-1/2 left-1/2 size-2 -translate-x-1/2 -translate-y-1/2" />
+      </RadioGroupPrimitive.Indicator>
+    </RadioGroupPrimitive.Item>
+  );
+}
+
+export { RadioGroup, RadioGroupItem };

--- a/features/column/components/add-column-dialog.tsx
+++ b/features/column/components/add-column-dialog.tsx
@@ -62,9 +62,12 @@ export function AddColumnDialog({
   const [isRequired, setIsRequired] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
 
-  // SELECT/MULTI_SELECT用の状態
+  // SELECT用の状態
   const [selectOptions, setSelectOptions] = useState<SelectOption[]>([]);
-  const [defaultValue, setDefaultValue] = useState<string | string[]>('');
+  const [selectDefaultValue, setSelectDefaultValue] = useState<
+    string | string[]
+  >('');
+  const [selectAllowMultiple, setSelectAllowMultiple] = useState(false);
 
   // TEXT用の状態
   const [textConfig, setTextConfig] = useState<{
@@ -126,7 +129,8 @@ export function AddColumnDialog({
       setColumnName('');
       setIsRequired(false);
       setSelectOptions([]);
-      setDefaultValue('');
+      setSelectDefaultValue('');
+      setSelectAllowMultiple(false);
       setTextConfig({});
       setTextareaConfig({});
       setNumberConfig({});
@@ -143,18 +147,15 @@ export function AddColumnDialog({
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
 
-    // SELECT/MULTI_SELECTの場合、選択肢が必須
-    if (
-      (columnType === 'SELECT' || columnType === 'MULTI_SELECT') &&
-      selectOptions.length === 0
-    ) {
+    // SELECTの場合、選択肢が必須
+    if (columnType === 'SELECT' && selectOptions.length === 0) {
       toast.error('選択肢を少なくとも1つ追加してください');
       return;
     }
 
     // 空ラベルのチェック
     if (
-      (columnType === 'SELECT' || columnType === 'MULTI_SELECT') &&
+      columnType === 'SELECT' &&
       selectOptions.some((opt) => !opt.label.trim())
     ) {
       toast.error('すべての選択肢にラベルを入力してください');
@@ -188,12 +189,8 @@ export function AddColumnDialog({
       } else if (columnType === 'SELECT') {
         config = {
           options: selectOptions,
-          defaultValue: defaultValue as string,
-        };
-      } else if (columnType === 'MULTI_SELECT') {
-        config = {
-          options: selectOptions,
-          defaultValue: defaultValue as string[],
+          allowMultiple: selectAllowMultiple,
+          defaultValue: selectDefaultValue,
         };
       } else if (
         columnType === 'NUMBER' &&
@@ -306,17 +303,18 @@ export function AddColumnDialog({
                 />
               )}
 
-              {/* SELECT/MULTI_SELECT用の選択肢設定 */}
-              {(columnType === 'SELECT' || columnType === 'MULTI_SELECT') && (
+              {/* SELECT用の選択肢設定 */}
+              {columnType === 'SELECT' && (
                 <SelectConfigEditor
                   options={selectOptions}
-                  defaultValue={defaultValue}
-                  isMultiSelect={columnType === 'MULTI_SELECT'}
-                  onChange={(options, defValue) => {
+                  defaultValue={selectDefaultValue}
+                  allowMultiple={selectAllowMultiple}
+                  onChange={(options, defValue, allowMultiple) => {
                     setSelectOptions(options);
-                    setDefaultValue(
-                      defValue || (columnType === 'MULTI_SELECT' ? [] : '')
-                    );
+                    setSelectDefaultValue(defValue || '');
+                    if (allowMultiple !== undefined) {
+                      setSelectAllowMultiple(allowMultiple);
+                    }
                   }}
                 />
               )}
@@ -359,8 +357,8 @@ export function AddColumnDialog({
                 />
               )}
 
-              {/* CHECKBOXとRELATIONは必須項目設定が不要 */}
-              {columnType !== 'CHECKBOX' && columnType !== 'RELATION' && (
+              {/* CHECKBOXは必須項目設定が不要 */}
+              {columnType !== 'CHECKBOX' && (
                 <div className="flex items-center space-x-2">
                   <Checkbox
                     id="required"

--- a/features/column/components/config/select-config-editor.tsx
+++ b/features/column/components/config/select-config-editor.tsx
@@ -36,8 +36,12 @@ import type { SelectOption } from '../../types';
 type SelectConfigEditorProps = {
   options: SelectOption[];
   defaultValue?: string | string[];
-  isMultiSelect?: boolean;
-  onChange: (options: SelectOption[], defaultValue?: string | string[]) => void;
+  allowMultiple?: boolean;
+  onChange: (
+    options: SelectOption[],
+    defaultValue?: string | string[],
+    allowMultiple?: boolean
+  ) => void;
 };
 
 /**
@@ -166,18 +170,20 @@ function OptionItem({
 }
 
 /**
- * SELECT/MULTI_SELECT型カラムの設定エディタコンポーネント
+ * SELECT型カラムの設定エディタコンポーネント
  */
 export function SelectConfigEditor({
   options,
   defaultValue,
-  isMultiSelect = false,
+  allowMultiple = false,
   onChange,
 }: SelectConfigEditorProps) {
   const [localOptions, setLocalOptions] = useState<SelectOption[]>(options);
   const [localDefaultValue, setLocalDefaultValue] = useState<string | string[]>(
-    defaultValue || (isMultiSelect ? [] : '')
+    defaultValue || (allowMultiple ? [] : '')
   );
+  const [localAllowMultiple, setLocalAllowMultiple] =
+    useState<boolean>(allowMultiple);
 
   // 親から受け取ったpropsが変更されたらローカルステートを更新
   useEffect(() => {
@@ -185,8 +191,12 @@ export function SelectConfigEditor({
   }, [options]);
 
   useEffect(() => {
-    setLocalDefaultValue(defaultValue || (isMultiSelect ? [] : ''));
-  }, [defaultValue, isMultiSelect]);
+    setLocalDefaultValue(defaultValue || (allowMultiple ? [] : ''));
+  }, [defaultValue, allowMultiple]);
+
+  useEffect(() => {
+    setLocalAllowMultiple(allowMultiple);
+  }, [allowMultiple]);
 
   // DnDセンサーの設定
   const sensors = useSensors(
@@ -205,7 +215,7 @@ export function SelectConfigEditor({
     };
     const newOptions = [...localOptions, newOption];
     setLocalOptions(newOptions);
-    onChange(newOptions, localDefaultValue);
+    onChange(newOptions, localDefaultValue, localAllowMultiple);
   };
 
   // ラベル変更
@@ -214,7 +224,7 @@ export function SelectConfigEditor({
       opt.id === id ? { ...opt, label } : opt
     );
     setLocalOptions(newOptions);
-    onChange(newOptions, localDefaultValue);
+    onChange(newOptions, localDefaultValue, localAllowMultiple);
   };
 
   // カラー変更
@@ -223,7 +233,7 @@ export function SelectConfigEditor({
       opt.id === id ? { ...opt, color } : opt
     );
     setLocalOptions(newOptions);
-    onChange(newOptions, localDefaultValue);
+    onChange(newOptions, localDefaultValue, localAllowMultiple);
   };
 
   // 選択肢削除
@@ -233,19 +243,19 @@ export function SelectConfigEditor({
 
     // デフォルト値から削除
     let newDefaultValue = localDefaultValue;
-    if (isMultiSelect && Array.isArray(localDefaultValue)) {
+    if (localAllowMultiple && Array.isArray(localDefaultValue)) {
       newDefaultValue = localDefaultValue.filter((val) => val !== id);
     } else if (localDefaultValue === id) {
       newDefaultValue = '';
     }
     setLocalDefaultValue(newDefaultValue);
-    onChange(newOptions, newDefaultValue);
+    onChange(newOptions, newDefaultValue, localAllowMultiple);
   };
 
   // デフォルト値のトグル
   const handleToggleDefault = (id: string) => {
     let newDefaultValue: string | string[];
-    if (isMultiSelect) {
+    if (localAllowMultiple) {
       const current = (localDefaultValue as string[]) || [];
       if (current.includes(id)) {
         newDefaultValue = current.filter((val) => val !== id);
@@ -256,7 +266,21 @@ export function SelectConfigEditor({
       newDefaultValue = localDefaultValue === id ? '' : id;
     }
     setLocalDefaultValue(newDefaultValue);
-    onChange(localOptions, newDefaultValue);
+    onChange(localOptions, newDefaultValue, localAllowMultiple);
+  };
+
+  // 複数選択許可フラグ変更
+  const handleAllowMultipleChange = (checked: boolean) => {
+    setLocalAllowMultiple(checked);
+    // 単一→複数に切り替えた場合、デフォルト値を配列に変換
+    // 複数→単一に切り替えた場合、デフォルト値を空文字にリセット
+    const newDefaultValue = checked
+      ? typeof localDefaultValue === 'string' && localDefaultValue
+        ? [localDefaultValue]
+        : []
+      : '';
+    setLocalDefaultValue(newDefaultValue);
+    onChange(localOptions, newDefaultValue, checked);
   };
 
   // ドラッグ終了時のハンドラ
@@ -271,12 +295,13 @@ export function SelectConfigEditor({
       const [movedOption] = newOptions.splice(oldIndex, 1);
       newOptions.splice(newIndex, 0, movedOption);
       setLocalOptions(newOptions);
-      onChange(newOptions, localDefaultValue);
+      onChange(newOptions, localDefaultValue, localAllowMultiple);
     }
   };
 
   return (
-    <div>
+    <div className="space-y-4">
+      {/* 選択肢 */}
       <div>
         <Label className="mb-3">選択肢</Label>
         <DndContext
@@ -294,12 +319,12 @@ export function SelectConfigEditor({
                   key={option.id}
                   option={option}
                   isDefault={
-                    isMultiSelect
+                    localAllowMultiple
                       ? (localDefaultValue as string[])?.includes(option.id) ||
                         false
                       : localDefaultValue === option.id
                   }
-                  isMultiSelect={isMultiSelect}
+                  isMultiSelect={localAllowMultiple}
                   onLabelChange={handleLabelChange}
                   onColorChange={handleColorChange}
                   onDelete={handleDelete}
@@ -318,6 +343,21 @@ export function SelectConfigEditor({
             </div>
           </SortableContext>
         </DndContext>
+      </div>
+
+      {/* 複数選択許可 */}
+      <div className="flex items-center space-x-2">
+        <Checkbox
+          id="allow-multiple"
+          checked={localAllowMultiple}
+          onCheckedChange={handleAllowMultipleChange}
+        />
+        <Label
+          htmlFor="allow-multiple"
+          className="text-sm font-normal cursor-pointer"
+        >
+          複数選択を許可する
+        </Label>
       </div>
     </div>
   );

--- a/features/column/components/config/select-config-editor.tsx
+++ b/features/column/components/config/select-config-editor.tsx
@@ -22,6 +22,7 @@ import { CSS } from '@dnd-kit/utilities';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Checkbox } from '@/components/ui/checkbox';
+import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group';
 import {
   Popover,
   PopoverContent,
@@ -54,7 +55,7 @@ type OptionItemProps = {
   onLabelChange: (id: string, label: string) => void;
   onColorChange: (id: string, color: string) => void;
   onDelete: (id: string) => void;
-  onToggleDefault: (id: string) => void;
+  onToggleDefault?: (id: string) => void;
 };
 
 /**
@@ -141,20 +142,15 @@ function OptionItem({
       {isMultiSelect ? (
         <Checkbox
           checked={isDefault}
-          onCheckedChange={() => onToggleDefault(option.id)}
+          onCheckedChange={() => onToggleDefault?.(option.id)}
           title="デフォルト値に設定"
         />
       ) : (
-        <button
-          type="button"
-          onClick={() => onToggleDefault(option.id)}
-          className={`size-5 rounded-full border-2 ${
-            isDefault ? 'border-primary bg-primary' : 'border-muted-foreground'
-          }`}
+        <RadioGroupItem
+          value={option.id}
+          id={`default-${option.id}`}
           title="デフォルト値に設定"
-        >
-          {isDefault && <Check className="size-3 text-white m-auto" />}
-        </button>
+        />
       )}
 
       {/* 削除ボタン */}
@@ -313,34 +309,65 @@ export function SelectConfigEditor({
             items={localOptions.map((opt) => opt.id)}
             strategy={verticalListSortingStrategy}
           >
-            <div className="space-y-2">
-              {localOptions.map((option) => (
-                <OptionItem
-                  key={option.id}
-                  option={option}
-                  isDefault={
-                    localAllowMultiple
-                      ? (localDefaultValue as string[])?.includes(option.id) ||
-                        false
-                      : localDefaultValue === option.id
-                  }
-                  isMultiSelect={localAllowMultiple}
-                  onLabelChange={handleLabelChange}
-                  onColorChange={handleColorChange}
-                  onDelete={handleDelete}
-                  onToggleDefault={handleToggleDefault}
-                />
-              ))}
-              {/* 選択肢を追加ボタン */}
-              <button
-                type="button"
-                onClick={handleAddOption}
-                className="flex items-center gap-2 w-full p-3 border border-dashed rounded-lg text-muted-foreground hover:bg-accent/50 hover:text-foreground transition-colors"
+            {localAllowMultiple ? (
+              <div className="space-y-2">
+                {localOptions.map((option) => (
+                  <OptionItem
+                    key={option.id}
+                    option={option}
+                    isDefault={
+                      (localDefaultValue as string[])?.includes(option.id) ||
+                      false
+                    }
+                    isMultiSelect={localAllowMultiple}
+                    onLabelChange={handleLabelChange}
+                    onColorChange={handleColorChange}
+                    onDelete={handleDelete}
+                    onToggleDefault={handleToggleDefault}
+                  />
+                ))}
+                {/* 選択肢を追加ボタン */}
+                <button
+                  type="button"
+                  onClick={handleAddOption}
+                  className="flex items-center gap-2 w-full p-3 border border-dashed rounded-lg text-muted-foreground hover:bg-accent/50 hover:text-foreground transition-colors"
+                >
+                  <Plus className="size-4" />
+                  <span className="text-sm">選択肢を追加</span>
+                </button>
+              </div>
+            ) : (
+              <RadioGroup
+                value={localDefaultValue as string}
+                onValueChange={(value) => {
+                  setLocalDefaultValue(value);
+                  onChange(localOptions, value, localAllowMultiple);
+                }}
               >
-                <Plus className="size-4" />
-                <span className="text-sm">選択肢を追加</span>
-              </button>
-            </div>
+                <div className="space-y-2">
+                  {localOptions.map((option) => (
+                    <OptionItem
+                      key={option.id}
+                      option={option}
+                      isDefault={localDefaultValue === option.id}
+                      isMultiSelect={localAllowMultiple}
+                      onLabelChange={handleLabelChange}
+                      onColorChange={handleColorChange}
+                      onDelete={handleDelete}
+                    />
+                  ))}
+                  {/* 選択肢を追加ボタン */}
+                  <button
+                    type="button"
+                    onClick={handleAddOption}
+                    className="flex items-center gap-2 w-full p-3 border border-dashed rounded-lg text-muted-foreground hover:bg-accent/50 hover:text-foreground transition-colors"
+                  >
+                    <Plus className="size-4" />
+                    <span className="text-sm">選択肢を追加</span>
+                  </button>
+                </div>
+              </RadioGroup>
+            )}
           </SortableContext>
         </DndContext>
       </div>

--- a/features/column/components/edit-column-item.tsx
+++ b/features/column/components/edit-column-item.tsx
@@ -61,9 +61,12 @@ export function EditColumnItem({
   );
   const [isSubmitting, setIsSubmitting] = useState(false);
 
-  // SELECT/MULTI_SELECT用の状態
+  // SELECT用の状態
   const [selectOptions, setSelectOptions] = useState<SelectOption[]>([]);
-  const [defaultValue, setDefaultValue] = useState<string | string[]>('');
+  const [selectDefaultValue, setSelectDefaultValue] = useState<
+    string | string[]
+  >('');
+  const [selectAllowMultiple, setSelectAllowMultiple] = useState(false);
 
   // TEXT用の状態
   const [textConfig, setTextConfig] = useState<{
@@ -136,13 +139,12 @@ export function EditColumnItem({
         setTextareaConfig(config || {});
       }
 
-      // SELECT/MULTI_SELECTの場合、configから値を取得
-      if (column.type === 'SELECT' || column.type === 'MULTI_SELECT') {
+      // SELECTの場合、configから値を取得
+      if (column.type === 'SELECT') {
         const config = column.config;
         setSelectOptions(config?.options || []);
-        setDefaultValue(
-          config?.defaultValue || (column.type === 'MULTI_SELECT' ? [] : '')
-        );
+        setSelectDefaultValue(config?.defaultValue || '');
+        setSelectAllowMultiple(config?.allowMultiple || false);
       }
 
       // NUMBERの場合、configから値を取得
@@ -180,18 +182,15 @@ export function EditColumnItem({
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
 
-    // SELECT/MULTI_SELECTの場合、選択肢が必須
-    if (
-      (column.type === 'SELECT' || column.type === 'MULTI_SELECT') &&
-      selectOptions.length === 0
-    ) {
+    // SELECTの場合、選択肢が必須
+    if (column.type === 'SELECT' && selectOptions.length === 0) {
       toast.error('選択肢を少なくとも1つ追加してください');
       return;
     }
 
     // 空ラベルのチェック
     if (
-      (column.type === 'SELECT' || column.type === 'MULTI_SELECT') &&
+      column.type === 'SELECT' &&
       selectOptions.some((opt) => !opt.label.trim())
     ) {
       toast.error('すべての選択肢にラベルを入力してください');
@@ -225,12 +224,8 @@ export function EditColumnItem({
       } else if (column.type === 'SELECT') {
         config = {
           options: selectOptions,
-          defaultValue: defaultValue as string,
-        };
-      } else if (column.type === 'MULTI_SELECT') {
-        config = {
-          options: selectOptions,
-          defaultValue: defaultValue as string[],
+          allowMultiple: selectAllowMultiple,
+          defaultValue: selectDefaultValue,
         };
       } else if (
         column.type === 'NUMBER' &&
@@ -326,17 +321,18 @@ export function EditColumnItem({
                 />
               )}
 
-              {/* SELECT/MULTI_SELECT用の選択肢設定 */}
-              {(column.type === 'SELECT' || column.type === 'MULTI_SELECT') && (
+              {/* SELECT用の選択肢設定 */}
+              {column.type === 'SELECT' && (
                 <SelectConfigEditor
                   options={selectOptions}
-                  defaultValue={defaultValue}
-                  isMultiSelect={column.type === 'MULTI_SELECT'}
-                  onChange={(options, defValue) => {
+                  defaultValue={selectDefaultValue}
+                  allowMultiple={selectAllowMultiple}
+                  onChange={(options, defValue, allowMultiple) => {
                     setSelectOptions(options);
-                    setDefaultValue(
-                      defValue || (column.type === 'MULTI_SELECT' ? [] : '')
-                    );
+                    setSelectDefaultValue(defValue || '');
+                    if (allowMultiple !== undefined) {
+                      setSelectAllowMultiple(allowMultiple);
+                    }
                   }}
                 />
               )}
@@ -379,8 +375,8 @@ export function EditColumnItem({
                 />
               )}
 
-              {/* CHECKBOXとRELATIONは必須項目設定が不要 */}
-              {column.type !== 'CHECKBOX' && column.type !== 'RELATION' && (
+              {/* CHECKBOXは必須項目設定が不要 */}
+              {column.type !== 'CHECKBOX' && (
                 <div className="flex items-center space-x-2">
                   <Checkbox
                     id="edit-required"

--- a/features/column/constants/column-config.ts
+++ b/features/column/constants/column-config.ts
@@ -4,7 +4,6 @@ import {
   Hash,
   Calendar,
   List,
-  Tags,
   CheckSquare,
   Link,
 } from 'lucide-react';
@@ -69,21 +68,11 @@ export const COLUMN_CONFIGS: Record<ColumnType, ColumnConfig> = {
   SELECT: {
     icon: List,
     label: 'セレクト',
-    description: 'ドロップダウンから選択できます',
+    description: 'ドロップダウンから選択できます（単一/複数選択対応）',
     hasConfig: true,
     defaultConfig: {
       options: [],
-      allowCustom: false,
-    },
-  },
-  MULTI_SELECT: {
-    icon: Tags,
-    label: 'マルチセレクト',
-    description: '複数の選択肢から複数選択できます',
-    hasConfig: true,
-    defaultConfig: {
-      options: [],
-      allowCustom: false,
+      allowMultiple: false,
     },
   },
   CHECKBOX: {
@@ -117,7 +106,6 @@ export const COLUMN_TYPE_LIST: ColumnType[] = [
   'NUMBER',
   'DATE',
   'SELECT',
-  'MULTI_SELECT',
   'CHECKBOX',
   'RELATION',
 ] as const;

--- a/features/column/types/column.ts
+++ b/features/column/types/column.ts
@@ -7,7 +7,6 @@ export const COLUMN_TYPES = {
   NUMBER: 'NUMBER',
   DATE: 'DATE',
   SELECT: 'SELECT',
-  MULTI_SELECT: 'MULTI_SELECT',
   CHECKBOX: 'CHECKBOX',
   RELATION: 'RELATION',
 } as const;
@@ -79,11 +78,8 @@ export type ColumnTypeConfig = {
   };
   SELECT: {
     options: SelectOption[];
-    defaultValue?: string; // デフォルト値（選択肢のID）
-  };
-  MULTI_SELECT: {
-    options: SelectOption[];
-    defaultValue?: string[]; // デフォルト値（選択肢のIDの配列）
+    allowMultiple?: boolean; // 複数選択を許可（デフォルト: false）
+    defaultValue?: string | string[]; // デフォルト値（選択肢のIDまたはIDの配列）
   };
   CHECKBOX: {
     checkedLabel?: string; // チェック時のラベル（例: 「完了」）
@@ -147,11 +143,6 @@ export type SelectColumn = BaseColumn & {
   config: ColumnTypeConfig['SELECT']; // SELECT型はoptionsが必須
 };
 
-export type MultiSelectColumn = BaseColumn & {
-  type: 'MULTI_SELECT';
-  config: ColumnTypeConfig['MULTI_SELECT']; // MULTI_SELECT型はoptionsが必須
-};
-
 export type CheckboxColumn = BaseColumn & {
   type: 'CHECKBOX';
   config?: ColumnTypeConfig['CHECKBOX'];
@@ -171,7 +162,6 @@ export type Column =
   | NumberColumn
   | DateColumn
   | SelectColumn
-  | MultiSelectColumn
   | CheckboxColumn
   | RelationColumn;
 

--- a/features/column/utils/__tests__/apply-default-values.test.ts
+++ b/features/column/utils/__tests__/apply-default-values.test.ts
@@ -1,7 +1,6 @@
 import { applyDefaultValues } from '../apply-default-values';
 import type {
   SelectColumn,
-  MultiSelectColumn,
   TextColumn,
   NumberColumn,
 } from '../../types/column';
@@ -33,18 +32,19 @@ describe('applyDefaultValues', () => {
     });
   });
 
-  it('MULTI_SELECT型のデフォルト値を適用する', () => {
-    const columns: MultiSelectColumn[] = [
+  it('SELECT型（複数選択）のデフォルト値を適用する', () => {
+    const columns: SelectColumn[] = [
       {
         id: 'col-1',
         name: 'タグ',
-        type: 'MULTI_SELECT',
+        type: 'SELECT',
         order: 0,
         config: {
           options: [
             { id: 'opt-1', label: 'タグ1' },
             { id: 'opt-2', label: 'タグ2' },
           ],
+          allowMultiple: true,
           defaultValue: ['opt-1', 'opt-2'],
         },
         createdAt: new Date(),
@@ -127,13 +127,14 @@ describe('applyDefaultValues', () => {
       {
         id: 'col-3',
         name: 'タグ',
-        type: 'MULTI_SELECT' as const,
+        type: 'SELECT' as const,
         order: 2,
         config: {
           options: [
             { id: 'tag-1', label: 'タグ1' },
             { id: 'tag-2', label: 'タグ2' },
           ],
+          allowMultiple: true,
           defaultValue: ['tag-1'],
         },
         createdAt: new Date(),

--- a/features/column/utils/__tests__/validate-column-value.test.ts
+++ b/features/column/utils/__tests__/validate-column-value.test.ts
@@ -1,7 +1,6 @@
 import { validateColumnValue } from '../validate-column-value';
 import type {
   SelectColumn,
-  MultiSelectColumn,
   TextColumn,
   NumberColumn,
 } from '../../types/column';
@@ -61,11 +60,11 @@ describe('validateColumnValue', () => {
     });
   });
 
-  describe('MULTI_SELECT型のバリデーション', () => {
-    const multiSelectColumn: MultiSelectColumn = {
+  describe('SELECT型（複数選択）のバリデーション', () => {
+    const multiSelectColumn: SelectColumn = {
       id: 'col-1',
       name: 'タグ',
-      type: 'MULTI_SELECT',
+      type: 'SELECT',
       order: 0,
       config: {
         options: [
@@ -73,6 +72,7 @@ describe('validateColumnValue', () => {
           { id: 'opt-2', label: 'タグ2' },
           { id: 'opt-3', label: 'タグ3' },
         ],
+        allowMultiple: true,
       },
       createdAt: new Date(),
       updatedAt: new Date(),
@@ -101,7 +101,7 @@ describe('validateColumnValue', () => {
     });
 
     it('required=trueで空配列の場合はエラーを返す', () => {
-      const requiredColumn: MultiSelectColumn = {
+      const requiredColumn: SelectColumn = {
         ...multiSelectColumn,
         validation: { required: true },
       };

--- a/features/column/utils/apply-default-values.ts
+++ b/features/column/utils/apply-default-values.ts
@@ -16,8 +16,6 @@ export function applyDefaultValues(columns: Column[]): RecordData {
       data[column.id] = column.config.defaultValue;
     } else if (column.type === 'SELECT' && column.config?.defaultValue) {
       data[column.id] = column.config.defaultValue;
-    } else if (column.type === 'MULTI_SELECT' && column.config?.defaultValue) {
-      data[column.id] = column.config.defaultValue;
     } else if (
       column.type === 'CHECKBOX' &&
       column.config?.defaultValue !== undefined

--- a/features/column/utils/validate-column-value.ts
+++ b/features/column/utils/validate-column-value.ts
@@ -2,7 +2,6 @@ import type {
   Column,
   CheckboxColumn,
   DateColumn,
-  MultiSelectColumn,
   NumberColumn,
   SelectColumn,
   TextColumn,
@@ -44,8 +43,6 @@ export function validateColumnValue(
       return validateDateValue(value, column);
     case 'SELECT':
       return validateSelectValue(value, column);
-    case 'MULTI_SELECT':
-      return validateMultiSelectValue(value, column);
     case 'CHECKBOX':
       return validateCheckboxValue(value, column);
     case 'RELATION':
@@ -222,35 +219,33 @@ function validateSelectValue(
   value: unknown,
   column: SelectColumn
 ): ValidationError | null {
-  if (typeof value !== 'string') {
-    return {
-      columnId: column.id,
-      columnName: column.name,
-      message: `${column.name}は文字列である必要があります`,
-    };
+  const allowMultiple = column.config.allowMultiple || false;
+
+  // 単一選択の場合
+  if (!allowMultiple) {
+    if (typeof value !== 'string') {
+      return {
+        columnId: column.id,
+        columnName: column.name,
+        message: `${column.name}は文字列である必要があります`,
+      };
+    }
+
+    const validOptionIds = column.config.options.map((opt) => opt.id);
+
+    // 選択肢のIDにマッチしない場合はエラー
+    if (!validOptionIds.includes(value)) {
+      return {
+        columnId: column.id,
+        columnName: column.name,
+        message: `${column.name}は有効な選択肢から選んでください`,
+      };
+    }
+
+    return null;
   }
 
-  const validOptionIds = column.config.options.map((opt) => opt.id);
-
-  // 選択肢のIDにマッチしない場合はエラー
-  if (!validOptionIds.includes(value)) {
-    return {
-      columnId: column.id,
-      columnName: column.name,
-      message: `${column.name}は有効な選択肢から選んでください`,
-    };
-  }
-
-  return null;
-}
-
-/**
- * MULTI_SELECT型のバリデーション
- */
-function validateMultiSelectValue(
-  value: unknown,
-  column: MultiSelectColumn
-): ValidationError | null {
+  // 複数選択の場合
   if (!Array.isArray(value)) {
     return {
       columnId: column.id,

--- a/features/table/components/cells/select-cell.tsx
+++ b/features/table/components/cells/select-cell.tsx
@@ -1,12 +1,15 @@
 'use client';
 
 import { useState, useRef, useEffect } from 'react';
+import { X } from 'lucide-react';
+import { Checkbox } from '@/components/ui/checkbox';
 import type { SelectOption } from '@/features/column/types';
 
 type SelectCellProps = {
-  value: string | null;
-  onChange: (value: string | null) => void;
+  value: string | string[] | null;
+  onChange: (value: string | string[] | null) => void;
   options: SelectOption[];
+  allowMultiple?: boolean;
   readOnly?: boolean;
 };
 
@@ -40,6 +43,7 @@ export function SelectCell({
   value,
   onChange,
   options,
+  allowMultiple = false,
   readOnly = false,
 }: SelectCellProps) {
   const [isOpen, setIsOpen] = useState(false);
@@ -61,11 +65,38 @@ export function SelectCell({
     return () => document.removeEventListener('mousedown', handleClickOutside);
   }, [isOpen]);
 
-  const selectedOption = options.find((opt) => opt.id === value);
+  // 選択中のオプションを取得
+  const selectedOptions = (() => {
+    if (!value) return [];
+    const ids = Array.isArray(value) ? value : [value];
+    return ids
+      .map((id) => options.find((opt) => opt.id === id))
+      .filter((opt) => opt !== undefined);
+  })();
 
-  const handleSelect = (optionId: string | null) => {
+  // 単一選択時の処理
+  const handleSelectSingle = (optionId: string | null) => {
     onChange(optionId);
     setIsOpen(false);
+  };
+
+  // 複数選択時の処理
+  const handleToggleMultiple = (optionId: string) => {
+    const currentIds = Array.isArray(value) ? value : value ? [value] : [];
+    if (currentIds.includes(optionId)) {
+      const newIds = currentIds.filter((id) => id !== optionId);
+      onChange(newIds.length > 0 ? newIds : null);
+    } else {
+      onChange([...currentIds, optionId]);
+    }
+  };
+
+  // 個別削除（複数選択時）
+  const handleRemove = (optionId: string) => {
+    if (allowMultiple && Array.isArray(value)) {
+      const newIds = value.filter((id) => id !== optionId);
+      onChange(newIds.length > 0 ? newIds : null);
+    }
   };
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
@@ -76,14 +107,17 @@ export function SelectCell({
 
   if (readOnly) {
     return (
-      <div className="min-h-[32px] px-2 py-1 flex items-center w-full">
-        {selectedOption ? (
-          <span
-            className="inline-flex items-center px-2 py-0.5 rounded text-sm"
-            style={getColorStyles(selectedOption.color)}
-          >
-            {selectedOption.label}
-          </span>
+      <div className="min-h-[32px] px-2 py-1 flex items-center gap-1.5 flex-wrap w-full">
+        {selectedOptions.length > 0 ? (
+          selectedOptions.map((option) => (
+            <span
+              key={option.id}
+              className="inline-flex items-center px-2 py-0.5 rounded text-sm"
+              style={getColorStyles(option.color)}
+            >
+              {option.label}
+            </span>
+          ))
         ) : (
           <span className="text-muted-foreground">-</span>
         )}
@@ -98,16 +132,31 @@ export function SelectCell({
       onKeyDown={handleKeyDown}
     >
       <div
-        className="cursor-pointer min-h-[32px] px-2 py-1 hover:bg-muted/50 rounded flex items-center w-full"
+        className="cursor-pointer min-h-[32px] px-2 py-1 hover:bg-muted/50 rounded flex items-center gap-1.5 flex-wrap w-full"
         onClick={() => setIsOpen(!isOpen)}
       >
-        {selectedOption ? (
-          <span
-            className="inline-flex items-center px-2 py-0.5 rounded text-sm"
-            style={getColorStyles(selectedOption.color)}
-          >
-            {selectedOption.label}
-          </span>
+        {selectedOptions.length > 0 ? (
+          selectedOptions.map((option) => (
+            <span
+              key={option.id}
+              className="inline-flex items-center gap-1 px-2 py-0.5 rounded text-sm group/option"
+              style={getColorStyles(option.color)}
+            >
+              {option.label}
+              {allowMultiple && (
+                <button
+                  type="button"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    handleRemove(option.id);
+                  }}
+                  className="opacity-70 hover:opacity-100"
+                >
+                  <X className="size-3" />
+                </button>
+              )}
+            </span>
+          ))
         ) : (
           <span className="text-muted-foreground">-</span>
         )}
@@ -116,26 +165,51 @@ export function SelectCell({
       {isOpen && (
         <div className="absolute top-full left-0 mt-1 min-w-[150px] bg-popover border rounded-md shadow-lg z-50">
           <div className="py-1">
-            <div
-              className="px-3 py-1.5 hover:bg-muted cursor-pointer text-sm text-muted-foreground"
-              onClick={() => handleSelect(null)}
-            >
-              選択なし
-            </div>
-            {options.map((option) => (
+            {!allowMultiple && (
               <div
-                key={option.id}
-                className="px-3 py-1.5 hover:bg-muted cursor-pointer"
-                onClick={() => handleSelect(option.id)}
+                className="px-3 py-1.5 hover:bg-muted cursor-pointer text-sm text-muted-foreground"
+                onClick={() => handleSelectSingle(null)}
               >
-                <span
-                  className="inline-flex items-center px-2 py-0.5 rounded text-sm"
-                  style={getColorStyles(option.color)}
-                >
-                  {option.label}
-                </span>
+                選択なし
               </div>
-            ))}
+            )}
+            {options.map((option) => {
+              const isSelected =
+                Array.isArray(value) && value.includes(option.id);
+
+              if (allowMultiple) {
+                return (
+                  <div
+                    key={option.id}
+                    className="px-3 py-1.5 hover:bg-muted cursor-pointer flex items-center gap-2"
+                    onClick={() => handleToggleMultiple(option.id)}
+                  >
+                    <Checkbox checked={isSelected} />
+                    <span
+                      className="inline-flex items-center px-2 py-0.5 rounded text-sm"
+                      style={getColorStyles(option.color)}
+                    >
+                      {option.label}
+                    </span>
+                  </div>
+                );
+              }
+
+              return (
+                <div
+                  key={option.id}
+                  className="px-3 py-1.5 hover:bg-muted cursor-pointer"
+                  onClick={() => handleSelectSingle(option.id)}
+                >
+                  <span
+                    className="inline-flex items-center px-2 py-0.5 rounded text-sm"
+                    style={getColorStyles(option.color)}
+                  >
+                    {option.label}
+                  </span>
+                </div>
+              );
+            })}
           </div>
         </div>
       )}

--- a/features/table/components/columns.tsx
+++ b/features/table/components/columns.tsx
@@ -5,7 +5,6 @@ import { Checkbox } from '@/components/ui/checkbox';
 import type {
   Column,
   SelectColumn,
-  MultiSelectColumn,
   RelationColumn,
   RelationRecord,
 } from '@/features/column/types';
@@ -13,7 +12,6 @@ import type { Record, RecordData } from '@/features/record/types';
 import { TextCell } from './cells/text-cell';
 import { NumberCell } from './cells/number-cell';
 import { SelectCell } from './cells/select-cell';
-import { MultiSelectCell } from './cells/multi-select-cell';
 import { CheckboxCell } from './cells/checkbox-cell';
 import { DateCell } from './cells/date-cell';
 import { TextareaCell } from './cells/textarea-cell';
@@ -101,18 +99,10 @@ export const createColumns = (
         case 'SELECT':
           return (
             <SelectCell
-              value={(value as string) ?? null}
+              value={(value as string | string[]) ?? null}
               onChange={handleChange}
               options={(column as SelectColumn).config?.options ?? []}
-              readOnly={readOnly}
-            />
-          );
-        case 'MULTI_SELECT':
-          return (
-            <MultiSelectCell
-              value={(value as string[]) ?? null}
-              onChange={handleChange}
-              options={(column as MultiSelectColumn).config?.options ?? []}
+              allowMultiple={(column as SelectColumn).config?.allowMultiple}
               readOnly={readOnly}
             />
           );

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "@radix-ui/react-dropdown-menu": "^2.1.16",
         "@radix-ui/react-label": "^2.1.7",
         "@radix-ui/react-popover": "^1.1.15",
+        "@radix-ui/react-radio-group": "^1.3.8",
         "@radix-ui/react-scroll-area": "^1.2.10",
         "@radix-ui/react-select": "^2.2.6",
         "@radix-ui/react-separator": "^1.1.7",
@@ -3054,6 +3055,38 @@
       },
       "peerDependenciesMeta": {
         "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-radio-group": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-radio-group/-/react-radio-group-1.3.8.tgz",
+      "integrity": "sha512-VBKYIYImA5zsxACdisNQ3BjCBfmbGH3kQlnFVqlWU4tXwjy7cGX8ta80BcrO+WJXIn5iBylEH3K6ZTlee//lgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-roving-focus": "1.1.11",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-previous": "1.1.1",
+        "@radix-ui/react-use-size": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
           "optional": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@radix-ui/react-dropdown-menu": "^2.1.16",
     "@radix-ui/react-label": "^2.1.7",
     "@radix-ui/react-popover": "^1.1.15",
+    "@radix-ui/react-radio-group": "^1.3.8",
     "@radix-ui/react-scroll-area": "^1.2.10",
     "@radix-ui/react-select": "^2.2.6",
     "@radix-ui/react-separator": "^1.1.7",


### PR DESCRIPTION
## 概要

`SELECT` と `MULTI_SELECT` カラムタイプを単一の `SELECT` タイプに統合し、`allowMultiple` フラグで単一選択/複数選択を制御できるようにしました。
また、デフォルト値設定 UI を shadcn/ui の `RadioGroup` コンポーネントで統一し、デザインの一貫性を向上させました。

## 実装内容

### 1. カラムタイプの統合
- **`MULTI_SELECT` タイプを削除**し、`SELECT` タイプに統合
- `SELECT` の設定に `allowMultiple?: boolean` フラグを追加（デフォルト: `false`）
- `defaultValue` の型を `string | string[]` に変更し、単一/複数選択両方に対応

### 2. バリデーションロジックの更新
- `validateSelectValue` 関数を更新し、`allowMultiple` に応じて単一選択/複数選択を検証
- 単一選択: 文字列のみ受け付け
- 複数選択: 文字列の配列を受け付け

### 3. UI コンポーネントの改善
- **`SelectCell`**: 単一/複数選択を動的に切り替え
  - 複数選択時: チェックボックスと個別削除ボタンを表示
  - 単一選択時: シンプルな選択UI
- **`SelectConfigEditor`**: 
  - 「複数選択を許可する」チェックボックスをオプションリストの下に配置
  - デフォルト値設定 UI を統一（単一選択: `RadioGroup`、複数選択: `Checkbox`）

### 4. デフォルト値設定 UI の統一
- **単一選択時**: shadcn/ui の `RadioGroup` コンポーネントを使用
- **複数選択時**: shadcn/ui の `Checkbox` コンポーネントを使用
- カスタムボタンを削除し、デザインシステムに準拠

### 5. RELATION カラムの必須項目設定を有効化
- 必須項目チェックボックスの表示条件を `CHECKBOX` のみ除外に変更
- `RELATION` でも必須項目設定が可能に

### 6. テストの更新
- `MULTI_SELECT` を使用していたテストを `SELECT` + `allowMultiple: true` に変更
- すべてのテスト (256/256) が成功

## 動作確認

- [x] ビルドが成功することを確認
- [x] TypeScript コンパイルエラーがないことを確認
- [x] 単一選択カラムの作成・編集が正常に動作することを確認
- [x] 複数選択カラムの作成・編集が正常に動作することを確認
- [x] デフォルト値設定 UI が統一されていることを確認

## 関連 Issue

Closes #57