### PR TITLE
テーブル管理画面のアクセス権限読み込み最適化

### DIFF
--- a/app/(protected)/[itemId]/edit/page.tsx
+++ b/app/(protected)/[itemId]/edit/page.tsx
@@ -3,6 +3,9 @@ import { getCurrentUser } from '@/lib/auth';
 import { canManageStructure } from '@/lib/permissions';
 import { getItemById, getTables } from '@/features/item/api';
 import { getColumnSchema } from '@/features/column/types/schema';
+import { getPermissions } from '@/features/permission/api';
+import { getUsers } from '@/features/user/api';
+import { getGroups } from '@/features/group/api';
 import { TableEditLayout } from '@/features/table/components/edit';
 import { FolderEditLayout } from '@/features/folder/components/edit';
 
@@ -38,7 +41,20 @@ export default async function ItemEditPage({ params }: ItemEditPageProps) {
   if (item.type === 'TABLE') {
     const columnSchema = getColumnSchema(item.meta);
     const columns = columnSchema?.columns || [];
-    const tables = await getTables();
+
+    // データを並列取得
+    const [tables, permissionsResult, users, groups] = await Promise.all([
+      getTables(),
+      getPermissions(itemId),
+      getUsers(),
+      getGroups(),
+    ]);
+
+    // 権限データの展開
+    const permissions =
+      'success' in permissionsResult && permissionsResult.success
+        ? permissionsResult.permissions
+        : [];
 
     return (
       <TableEditLayout
@@ -46,13 +62,36 @@ export default async function ItemEditPage({ params }: ItemEditPageProps) {
         itemName={item.name}
         columns={columns}
         tables={tables}
+        initialPermissions={permissions}
+        users={users}
+        groups={groups}
       />
     );
   }
 
   // FOLDER型の場合
   if (item.type === 'FOLDER') {
-    return <FolderEditLayout folder={item} />;
+    // データを並列取得
+    const [permissionsResult, users, groups] = await Promise.all([
+      getPermissions(itemId),
+      getUsers(),
+      getGroups(),
+    ]);
+
+    // 権限データの展開
+    const permissions =
+      'success' in permissionsResult && permissionsResult.success
+        ? permissionsResult.permissions
+        : [];
+
+    return (
+      <FolderEditLayout
+        folder={item}
+        initialPermissions={permissions}
+        users={users}
+        groups={groups}
+      />
+    );
   }
 
   // 未対応の型

--- a/features/folder/components/edit/folder-edit-layout.tsx
+++ b/features/folder/components/edit/folder-edit-layout.tsx
@@ -4,20 +4,53 @@ import Link from 'next/link';
 import { ArrowLeft } from 'lucide-react';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import type { Item } from '@/features/item/types';
+import type { User } from '@/features/user/types';
+import type { Group } from '@/features/group/types';
+import type { Prisma } from '@prisma/client';
 import { SettingsContent } from './settings-content';
 import { AccessContent } from '@/features/table/components/edit/access-content';
+
+/**
+ * 権限情報の型（userとgroupをincludeした状態）
+ */
+type PermissionWithRelations = Prisma.ItemPermissionGetPayload<{
+  include: {
+    user: {
+      select: {
+        id: true;
+        name: true;
+        email: true;
+      };
+    };
+    group: {
+      select: {
+        id: true;
+        name: true;
+        description: true;
+      };
+    };
+  };
+}>;
 
 /**
  * FolderEditLayoutのProps型
  */
 type FolderEditLayoutProps = {
   folder: Item & { type: 'FOLDER' };
+  initialPermissions: PermissionWithRelations[];
+  users: User[];
+  groups: Group[];
 };
 
 /**
  * フォルダ編集画面のレイアウトコンポーネント
  */
-export function FolderEditLayout({ folder }: FolderEditLayoutProps) {
+export function FolderEditLayout({
+  folder,
+  initialPermissions,
+  users,
+  groups,
+}: FolderEditLayoutProps) {
   return (
     <div className="w-full p-6">
       {/* ヘッダー */}
@@ -45,7 +78,12 @@ export function FolderEditLayout({ folder }: FolderEditLayoutProps) {
           <SettingsContent folderId={folder.id} folderName={folder.name} />
         </TabsContent>
         <TabsContent value="access" className="flex-1 mt-6">
-          <AccessContent itemId={folder.id} />
+          <AccessContent
+            itemId={folder.id}
+            initialPermissions={initialPermissions}
+            users={users}
+            groups={groups}
+          />
         </TabsContent>
       </Tabs>
     </div>

--- a/features/folder/components/edit/folder-edit-layout.tsx
+++ b/features/folder/components/edit/folder-edit-layout.tsx
@@ -6,31 +6,9 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import type { Item } from '@/features/item/types';
 import type { User } from '@/features/user/types';
 import type { Group } from '@/features/group/types';
-import type { Prisma } from '@prisma/client';
+import type { PermissionWithRelations } from '@/features/permission/types';
 import { SettingsContent } from './settings-content';
 import { AccessContent } from '@/features/table/components/edit/access-content';
-
-/**
- * 権限情報の型（userとgroupをincludeした状態）
- */
-type PermissionWithRelations = Prisma.ItemPermissionGetPayload<{
-  include: {
-    user: {
-      select: {
-        id: true;
-        name: true;
-        email: true;
-      };
-    };
-    group: {
-      select: {
-        id: true;
-        name: true;
-        description: true;
-      };
-    };
-  };
-}>;
 
 /**
  * FolderEditLayoutのProps型

--- a/features/permission/api/get-permissions.ts
+++ b/features/permission/api/get-permissions.ts
@@ -3,29 +3,7 @@
 import { prisma } from '@/lib/prisma';
 import { getCurrentUser } from '@/lib/auth';
 import { canManageStructure } from '@/lib/permissions';
-import type { Prisma } from '@prisma/client';
-
-/**
- * 権限情報の型（userとgroupをincludeした状態）
- */
-type PermissionWithRelations = Prisma.ItemPermissionGetPayload<{
-  include: {
-    user: {
-      select: {
-        id: true;
-        name: true;
-        email: true;
-      };
-    };
-    group: {
-      select: {
-        id: true;
-        name: true;
-        description: true;
-      };
-    };
-  };
-}>;
+import type { PermissionWithRelations } from '@/features/permission/types';
 
 /**
  * アイテムの権限一覧を取得

--- a/features/permission/components/add-permission-button.tsx
+++ b/features/permission/components/add-permission-button.tsx
@@ -28,9 +28,9 @@ import {
 import type { Permission } from '@prisma/client';
 
 /**
- * 権限追加ダイアログのProps型
+ * 権限追加ボタンのProps型
  */
-type AddPermissionDialogProps = {
+type AddPermissionButtonProps = {
   users: Array<{ id: string; name: string | null; email: string }>;
   groups: Array<{ id: string; name: string; description: string | null }>;
   onAdd: (
@@ -41,13 +41,13 @@ type AddPermissionDialogProps = {
 };
 
 /**
- * 権限追加ダイアログコンポーネント
+ * 権限追加ボタンコンポーネント
  */
-export function AddPermissionDialog({
+export function AddPermissionButton({
   users,
   groups,
   onAdd,
-}: AddPermissionDialogProps) {
+}: AddPermissionButtonProps) {
   const [open, setOpen] = useState(false);
   const [targetType, setTargetType] = useState<'group' | 'user'>('group');
   const [targetId, setTargetId] = useState('');
@@ -83,9 +83,9 @@ export function AddPermissionDialog({
   return (
     <Dialog open={open} onOpenChange={setOpen}>
       <DialogTrigger asChild>
-        <Button size="sm" variant="outline">
-          <Plus className="size-4 mr-2" />
-          権限を追加
+        <Button size="sm" variant="default">
+          <Plus />
+          権限追加
         </Button>
       </DialogTrigger>
       <DialogContent className="sm:max-w-[500px]">

--- a/features/permission/components/index.ts
+++ b/features/permission/components/index.ts
@@ -1,2 +1,2 @@
-export * from './add-permission-dialog';
+export * from './add-permission-button';
 export * from './delete-permission-button';

--- a/features/permission/types/index.ts
+++ b/features/permission/types/index.ts
@@ -1,4 +1,4 @@
-import type { Permission } from '@prisma/client';
+import type { Permission, Prisma } from '@prisma/client';
 
 /**
  * アイテム権限の型
@@ -12,6 +12,28 @@ export type ItemPermission = {
   createdAt: Date;
   updatedAt: Date;
 };
+
+/**
+ * 権限情報の型（userとgroupをincludeした状態）
+ */
+export type PermissionWithRelations = Prisma.ItemPermissionGetPayload<{
+  include: {
+    user: {
+      select: {
+        id: true;
+        name: true;
+        email: true;
+      };
+    };
+    group: {
+      select: {
+        id: true;
+        name: true;
+        description: true;
+      };
+    };
+  };
+}>;
 
 /**
  * 権限追加の入力型

--- a/features/table/components/edit/access-content.tsx
+++ b/features/table/components/edit/access-content.tsx
@@ -29,38 +29,17 @@ import {
 } from '@/features/permission/constants';
 import { AddPermissionButton } from '@/features/permission/components/add-permission-button';
 import { DeletePermissionButton } from '@/features/permission/components/delete-permission-button';
-import type { Permission, Prisma } from '@prisma/client';
+import type { Permission } from '@prisma/client';
 import type { User } from '@/features/user/types';
 import type { Group } from '@/features/group/types';
-
-/**
- * 権限情報の型（userとgroupをincludeした状態）
- */
-type PermissionInfo = Prisma.ItemPermissionGetPayload<{
-  include: {
-    user: {
-      select: {
-        id: true;
-        name: true;
-        email: true;
-      };
-    };
-    group: {
-      select: {
-        id: true;
-        name: true;
-        description: true;
-      };
-    };
-  };
-}>;
+import type { PermissionWithRelations } from '@/features/permission/types';
 
 /**
  * AccessContentのProps型
  */
 type AccessContentProps = {
   itemId: string;
-  initialPermissions: PermissionInfo[];
+  initialPermissions: PermissionWithRelations[];
   users: User[];
   groups: Group[];
 };
@@ -75,7 +54,7 @@ export function AccessContent({
   groups,
 }: AccessContentProps) {
   const [permissions, setPermissions] =
-    useState<PermissionInfo[]>(initialPermissions);
+    useState<PermissionWithRelations[]>(initialPermissions);
   const [pendingChanges, setPendingChanges] = useState<{
     updates: Map<string, Permission>;
     deletes: Set<string>;
@@ -101,7 +80,7 @@ export function AccessContent({
       // 成功時は権限一覧を再取得してUIを更新
       const permissionsResult = await getPermissions(itemId);
       if ('success' in permissionsResult && permissionsResult.success) {
-        setPermissions(permissionsResult.permissions as PermissionInfo[]);
+        setPermissions(permissionsResult.permissions);
         // 保留中の変更をクリア
         setPendingChanges({ updates: new Map(), deletes: new Set() });
       }
@@ -154,7 +133,7 @@ export function AccessContent({
           // エラー時は権限一覧を再取得して正しい状態に戻す
           const permissionsResult = await getPermissions(itemId);
           if ('success' in permissionsResult && permissionsResult.success) {
-            setPermissions(permissionsResult.permissions as PermissionInfo[]);
+            setPermissions(permissionsResult.permissions);
           }
           // 保留中の変更もクリアして整合性を保つ
           setPendingChanges({ updates: new Map(), deletes: new Set() });
@@ -170,7 +149,7 @@ export function AccessContent({
           // エラー時は権限一覧を再取得して正しい状態に戻す
           const permissionsResult = await getPermissions(itemId);
           if ('success' in permissionsResult && permissionsResult.success) {
-            setPermissions(permissionsResult.permissions as PermissionInfo[]);
+            setPermissions(permissionsResult.permissions);
           }
           // 保留中の変更もクリアして整合性を保つ
           setPendingChanges({ updates: new Map(), deletes: new Set() });

--- a/features/table/components/edit/access-content.tsx
+++ b/features/table/components/edit/access-content.tsx
@@ -156,6 +156,8 @@ export function AccessContent({
           if ('success' in permissionsResult && permissionsResult.success) {
             setPermissions(permissionsResult.permissions as PermissionInfo[]);
           }
+          // 保留中の変更もクリアして整合性を保つ
+          setPendingChanges({ updates: new Map(), deletes: new Set() });
           return;
         }
       }
@@ -170,6 +172,8 @@ export function AccessContent({
           if ('success' in permissionsResult && permissionsResult.success) {
             setPermissions(permissionsResult.permissions as PermissionInfo[]);
           }
+          // 保留中の変更もクリアして整合性を保つ
+          setPendingChanges({ updates: new Map(), deletes: new Set() });
           return;
         }
       }

--- a/features/table/components/edit/access-content.tsx
+++ b/features/table/components/edit/access-content.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useState, useMemo } from 'react';
 import {
   Select,
   SelectContent,
@@ -16,6 +16,7 @@ import {
   TableHeader,
   TableRow,
 } from '@/components/ui/table';
+import { Button } from '@/components/ui/button';
 import {
   getPermissions,
   addPermission,
@@ -26,102 +27,70 @@ import {
   PERMISSION_LIST,
   getPermissionLabel,
 } from '@/features/permission/constants';
-import { AddPermissionDialog } from '@/features/permission/components/add-permission-dialog';
+import { AddPermissionButton } from '@/features/permission/components/add-permission-button';
 import { DeletePermissionButton } from '@/features/permission/components/delete-permission-button';
-import { getUsers } from '@/features/user/api';
-import { getGroups } from '@/features/group/api';
-import type { Permission } from '@prisma/client';
+import type { Permission, Prisma } from '@prisma/client';
+import type { User } from '@/features/user/types';
+import type { Group } from '@/features/group/types';
+
+/**
+ * 権限情報の型（userとgroupをincludeした状態）
+ */
+type PermissionInfo = Prisma.ItemPermissionGetPayload<{
+  include: {
+    user: {
+      select: {
+        id: true;
+        name: true;
+        email: true;
+      };
+    };
+    group: {
+      select: {
+        id: true;
+        name: true;
+        description: true;
+      };
+    };
+  };
+}>;
 
 /**
  * AccessContentのProps型
  */
 type AccessContentProps = {
   itemId: string;
-};
-
-/**
- * 権限情報の型
- */
-type PermissionInfo = {
-  id: string;
-  itemId: string;
-  userId: string | null;
-  groupId: string | null;
-  level: Permission;
-  user?: {
-    id: string;
-    name: string | null;
-    email: string;
-  } | null;
-  group?: {
-    id: string;
-    name: string;
-    description: string | null;
-  } | null;
+  initialPermissions: PermissionInfo[];
+  users: User[];
+  groups: Group[];
 };
 
 /**
  * アクセス権限タブのコンテンツコンポーネント
  */
-export function AccessContent({ itemId }: AccessContentProps) {
-  const [permissions, setPermissions] = useState<PermissionInfo[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [users, setUsers] = useState<
-    Array<{ id: string; name: string | null; email: string }>
-  >([]);
-  const [groups, setGroups] = useState<
-    Array<{ id: string; name: string; description: string | null }>
-  >([]);
+export function AccessContent({
+  itemId,
+  initialPermissions,
+  users,
+  groups,
+}: AccessContentProps) {
+  const [permissions, setPermissions] =
+    useState<PermissionInfo[]>(initialPermissions);
+  const [pendingChanges, setPendingChanges] = useState<{
+    updates: Map<string, Permission>;
+    deletes: Set<string>;
+  }>({
+    updates: new Map(),
+    deletes: new Set(),
+  });
+  const [isSaving, setIsSaving] = useState(false);
 
-  useEffect(() => {
-    let isMounted = true;
+  // 変更があるかどうかを判定
+  const hasChanges = useMemo(() => {
+    return pendingChanges.updates.size > 0 || pendingChanges.deletes.size > 0;
+  }, [pendingChanges]);
 
-    const fetchData = async () => {
-      setLoading(true);
-
-      // 並列で取得
-      const [permissionsResult, usersData, groupsData] = await Promise.all([
-        getPermissions(itemId),
-        getUsers(),
-        getGroups(),
-      ]);
-
-      if (isMounted) {
-        // 権限一覧をセット
-        if ('success' in permissionsResult && permissionsResult.success) {
-          setPermissions(permissionsResult.permissions as PermissionInfo[]);
-        }
-
-        // ユーザー一覧をセット（簡略化された型に変換）
-        setUsers(
-          usersData.map((user) => ({
-            id: user.id,
-            name: user.name,
-            email: user.email,
-          }))
-        );
-
-        // グループ一覧をセット（簡略化された型に変換）
-        setGroups(
-          groupsData.map((group) => ({
-            id: group.id,
-            name: group.name,
-            description: group.description,
-          }))
-        );
-
-        setLoading(false);
-      }
-    };
-
-    fetchData();
-
-    return () => {
-      isMounted = false;
-    };
-  }, [itemId]);
-
-  // 権限追加
+  // 権限追加（即座に保存）
   const handleAdd = async (
     targetType: 'group' | 'user',
     targetId: string,
@@ -133,6 +102,8 @@ export function AccessContent({ itemId }: AccessContentProps) {
       const permissionsResult = await getPermissions(itemId);
       if ('success' in permissionsResult && permissionsResult.success) {
         setPermissions(permissionsResult.permissions as PermissionInfo[]);
+        // 保留中の変更をクリア
+        setPendingChanges({ updates: new Map(), deletes: new Set() });
       }
     } else if ('error' in result) {
       alert(result.error || '権限の追加に失敗しました');
@@ -140,58 +111,105 @@ export function AccessContent({ itemId }: AccessContentProps) {
     }
   };
 
-  // 権限更新
-  const handleUpdate = async (permissionId: string, level: Permission) => {
-    // 楽観的更新：先にUIを更新
-    const previousPermissions = permissions;
+  // 権限更新（保留）
+  const handleUpdate = (permissionId: string, level: Permission) => {
+    // UIを即座に更新
     setPermissions((prev) =>
       prev.map((p) => (p.id === permissionId ? { ...p, level } : p))
     );
 
-    // サーバーに保存
-    const result = await updatePermission(permissionId, level);
-    if ('error' in result) {
-      // エラー時はロールバック
-      alert(result.error || '権限の更新に失敗しました');
-      setPermissions(previousPermissions);
+    // 更新を保留リストに追加
+    setPendingChanges((prev) => {
+      const newUpdates = new Map(prev.updates);
+      newUpdates.set(permissionId, level);
+      return { ...prev, updates: newUpdates };
+    });
+  };
+
+  // 権限削除（保留）
+  const handleDelete = (permissionId: string) => {
+    // UIから即座に削除
+    setPermissions((prev) => prev.filter((p) => p.id !== permissionId));
+
+    // 削除を保留リストに追加
+    setPendingChanges((prev) => {
+      const newDeletes = new Set(prev.deletes);
+      newDeletes.add(permissionId);
+      // 更新リストからも削除（削除する権限の更新は不要）
+      const newUpdates = new Map(prev.updates);
+      newUpdates.delete(permissionId);
+      return { updates: newUpdates, deletes: newDeletes };
+    });
+  };
+
+  // 保存
+  const handleSave = async () => {
+    setIsSaving(true);
+    try {
+      // 更新を実行
+      for (const [permissionId, level] of pendingChanges.updates) {
+        const result = await updatePermission(permissionId, level);
+        if ('error' in result) {
+          alert(result.error || '権限の更新に失敗しました');
+          // エラー時は権限一覧を再取得して正しい状態に戻す
+          const permissionsResult = await getPermissions(itemId);
+          if ('success' in permissionsResult && permissionsResult.success) {
+            setPermissions(permissionsResult.permissions as PermissionInfo[]);
+          }
+          return;
+        }
+      }
+
+      // 削除を実行
+      for (const permissionId of pendingChanges.deletes) {
+        const result = await removePermission(permissionId);
+        if ('error' in result) {
+          alert(result.error || '削除に失敗しました');
+          // エラー時は権限一覧を再取得して正しい状態に戻す
+          const permissionsResult = await getPermissions(itemId);
+          if ('success' in permissionsResult && permissionsResult.success) {
+            setPermissions(permissionsResult.permissions as PermissionInfo[]);
+          }
+          return;
+        }
+      }
+
+      // 成功したら保留中の変更をクリア
+      setPendingChanges({ updates: new Map(), deletes: new Set() });
+    } finally {
+      setIsSaving(false);
     }
   };
 
-  // 権限削除
-  const handleDelete = async (permissionId: string) => {
-    // 楽観的更新：先にUIから削除
-    const previousPermissions = permissions;
-    setPermissions((prev) => prev.filter((p) => p.id !== permissionId));
-
-    // サーバーで削除
-    const result = await removePermission(permissionId);
-    if ('error' in result) {
-      // エラー時はロールバック
-      alert(result.error || '削除に失敗しました');
-      setPermissions(previousPermissions);
-    }
+  // キャンセル
+  const handleCancel = () => {
+    // 元の状態に戻す
+    setPermissions(initialPermissions);
+    setPendingChanges({ updates: new Map(), deletes: new Set() });
   };
 
   return (
     <div className="space-y-6">
-      <div>
-        <h2 className="text-lg font-semibold mb-2">アクセス権限</h2>
-        <p className="text-sm text-muted-foreground mb-4">
-          このアイテムにアクセスできるユーザーとグループを管理します。
-          <br />
-          権限が設定されていない場合、すべてのユーザーがREAD権限でアクセスできます（パブリック）。
-        </p>
-      </div>
-
-      {/* 権限追加ダイアログ */}
-      <div className="flex justify-end">
-        <AddPermissionDialog users={users} groups={groups} onAdd={handleAdd} />
+      <div className="flex items-end justify-between gap-4">
+        <div className="flex-1">
+          <h2 className="text-lg font-semibold mb-2">アクセス権限</h2>
+          <p className="text-sm text-muted-foreground">
+            このアイテムにアクセスできるユーザーとグループを管理します。
+            <br />
+            権限が設定されていない場合、すべてのユーザーがREAD権限でアクセスできます。
+          </p>
+        </div>
+        <div>
+          <AddPermissionButton
+            users={users}
+            groups={groups}
+            onAdd={handleAdd}
+          />
+        </div>
       </div>
 
       {/* 権限一覧 */}
-      {loading ? (
-        <p className="text-sm text-muted-foreground">読み込み中...</p>
-      ) : permissions.length === 0 ? (
+      {permissions.length === 0 ? (
         <div className="rounded-lg border border-dashed p-8 text-center">
           <p className="text-sm text-muted-foreground">
             権限が設定されていません。
@@ -249,13 +267,25 @@ export function AccessContent({ itemId }: AccessContentProps) {
                           ? permission.user.name || permission.user.email
                           : permission.group?.name || ''
                       }
-                      onDelete={handleDelete}
+                      onDelete={async (id) => handleDelete(id)}
                     />
                   </TableCell>
                 </TableRow>
               ))}
             </TableBody>
           </Table>
+        </div>
+      )}
+
+      {/* 保存・キャンセルボタン */}
+      {hasChanges && (
+        <div className="flex justify-end gap-2 mt-4">
+          <Button variant="outline" onClick={handleCancel} disabled={isSaving}>
+            キャンセル
+          </Button>
+          <Button onClick={handleSave} disabled={isSaving}>
+            {isSaving ? '保存中...' : '変更を保存'}
+          </Button>
         </div>
       )}
     </div>

--- a/features/table/components/edit/table-edit-layout.tsx
+++ b/features/table/components/edit/table-edit-layout.tsx
@@ -5,9 +5,34 @@ import { ArrowLeft } from 'lucide-react';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import type { Column } from '@/features/column/types';
 import type { Item } from '@/features/item/types';
+import type { User } from '@/features/user/types';
+import type { Group } from '@/features/group/types';
+import type { Prisma } from '@prisma/client';
 import { ColumnsContent } from './columns-content';
 import { SettingsContent } from './settings-content';
 import { AccessContent } from './access-content';
+
+/**
+ * 権限情報の型（userとgroupをincludeした状態）
+ */
+type PermissionWithRelations = Prisma.ItemPermissionGetPayload<{
+  include: {
+    user: {
+      select: {
+        id: true;
+        name: true;
+        email: true;
+      };
+    };
+    group: {
+      select: {
+        id: true;
+        name: true;
+        description: true;
+      };
+    };
+  };
+}>;
 
 /**
  * TableEditLayoutのProps型
@@ -17,6 +42,9 @@ type TableEditLayoutProps = {
   itemName: string;
   columns: Column[];
   tables: Item[];
+  initialPermissions: PermissionWithRelations[];
+  users: User[];
+  groups: Group[];
 };
 
 /**
@@ -27,6 +55,9 @@ export function TableEditLayout({
   itemName,
   columns,
   tables,
+  initialPermissions,
+  users,
+  groups,
 }: TableEditLayoutProps) {
   return (
     <div className="w-full p-6">
@@ -65,7 +96,12 @@ export function TableEditLayout({
           <ColumnsContent itemId={itemId} columns={columns} tables={tables} />
         </TabsContent>
         <TabsContent value="access" className="flex-1 mt-6">
-          <AccessContent itemId={itemId} />
+          <AccessContent
+            itemId={itemId}
+            initialPermissions={initialPermissions}
+            users={users}
+            groups={groups}
+          />
         </TabsContent>
       </Tabs>
     </div>

--- a/features/table/components/edit/table-edit-layout.tsx
+++ b/features/table/components/edit/table-edit-layout.tsx
@@ -7,32 +7,10 @@ import type { Column } from '@/features/column/types';
 import type { Item } from '@/features/item/types';
 import type { User } from '@/features/user/types';
 import type { Group } from '@/features/group/types';
-import type { Prisma } from '@prisma/client';
+import type { PermissionWithRelations } from '@/features/permission/types';
 import { ColumnsContent } from './columns-content';
 import { SettingsContent } from './settings-content';
 import { AccessContent } from './access-content';
-
-/**
- * 権限情報の型（userとgroupをincludeした状態）
- */
-type PermissionWithRelations = Prisma.ItemPermissionGetPayload<{
-  include: {
-    user: {
-      select: {
-        id: true;
-        name: true;
-        email: true;
-      };
-    };
-    group: {
-      select: {
-        id: true;
-        name: true;
-        description: true;
-      };
-    };
-  };
-}>;
 
 /**
  * TableEditLayoutのProps型


### PR DESCRIPTION
## 概要

テーブル/フォルダ編集画面の「権限」タブにおいて、データの読み込み最適化とバッチ保存機能を実装しました。

## 変更内容

### 1. データプリフェッチによる読み込み最適化

**before**: Client Componentの`useEffect`で権限データを取得（タブを開くたびに通信発生）
**after**: Server Componentで事前取得してpropsで渡す（即座に表示）

**変更ファイル**:
- `app/(protected)/[itemId]/edit/page.tsx` - TABLE型・FOLDER型両方でデータを並列取得
- `features/table/components/edit/table-edit-layout.tsx` - propsを追加してAccessContentに渡す
- `features/folder/components/edit/folder-edit-layout.tsx` - 同上（FOLDER型対応）
- `features/table/components/edit/access-content.tsx` - useEffectでのデータ取得を削除、propsで受け取る

**効果**:
- タブを開いた瞬間にデータ表示（待機時間ゼロ）
- Next.jsのServer Componentキャッシュが有効に機能
- users/groupsデータを全タブで共有可能

### 2. バッチ保存機能の実装

**before**: 権限の変更（更新・削除）を即座にサーバーに保存
**after**: 変更を保留し、「変更を保存」ボタンで一括保存

**実装内容**:
- 権限の更新・削除はUIのみ即座に反映（楽観的更新）
- 保留中の変更を`pendingChanges`（Map/Set）で管理
- テーブル下部に「キャンセル」「変更を保存」ボタンを表示（変更がある時のみ）
- 保存ボタンクリック時に全ての変更を一括でサーバーに送信
- キャンセルボタンで変更を破棄して元の状態に戻す
- 権限の追加は従来通り即座に保存

**効果**:
- 誤操作時に取り消しが可能
- 複数の変更をまとめて保存できる
- UX向上

### 3. UI改善

- 権限追加ボタンをヘッダー右側に配置（視認性向上）
- ボタンを説明文のベースラインに下寄せ

## テスト

- [x] テーブル編集画面で権限タブを開いた際、即座にデータが表示されることを確認
- [x] フォルダ編集画面でも同様に動作することを確認
- [x] 権限の更新・削除時に保存ボタンが表示されることを確認
- [x] 保存ボタンクリックで変更が保存されることを確認
- [x] キャンセルボタンで変更が破棄されることを確認
- [x] 権限の追加が即座に反映されることを確認


## 関連Issue

Closes #69

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **新機能**
  * フォルダとテーブルのアクセス権限画面で、ユーザー・グループ情報と既存権限を読み込み、保存／キャンセルで一括反映できるようになりました。

* **リファクタリング**
  * 権限まわりのデータ取得を並列化して表示を高速化。
  * 権限追加UIをダイアログからよりシンプルなボタン操作に変更。

* **改善**
  * 追加・更新・削除は一時保留して楽観的に反映、保存失敗時は状態を復元。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->