### PR TITLE
レコードエクスポート機能の実装

### DIFF
--- a/app/(protected)/[itemId]/page.tsx
+++ b/app/(protected)/[itemId]/page.tsx
@@ -6,6 +6,10 @@ import { FolderLayout } from '@/features/folder/components';
 import { notFound } from 'next/navigation';
 import { getCurrentUser } from '@/lib/auth';
 import { canAccessItem } from '@/lib/permissions';
+import type {
+  ExportColumnFilter,
+  ExportSorting,
+} from '@/features/table/types/export';
 
 export const dynamic = 'force-dynamic';
 
@@ -70,20 +74,29 @@ export default async function ItemPage({
     const filtersParam = resolvedSearchParams.filters;
     const sortingParam = resolvedSearchParams.sorting;
 
-    const filters = filtersParam
-      ? JSON.parse(
+    let filters: ExportColumnFilter[] = [];
+    let sorting: ExportSorting[] = [];
+
+    try {
+      if (filtersParam) {
+        const parsed = JSON.parse(
           typeof filtersParam === 'string'
             ? filtersParam
             : filtersParam[0] || '[]'
-        )
-      : [];
-    const sorting = sortingParam
-      ? JSON.parse(
+        );
+        if (Array.isArray(parsed)) filters = parsed;
+      }
+      if (sortingParam) {
+        const parsed = JSON.parse(
           typeof sortingParam === 'string'
             ? sortingParam
             : sortingParam[0] || '[]'
-        )
-      : [];
+        );
+        if (Array.isArray(parsed)) sorting = parsed;
+      }
+    } catch {
+      // 不正なパラメータは無視してデフォルト値を使用
+    }
 
     // レコードとリレーション用データを並列取得
     const [records, relationRecords] = await Promise.all([

--- a/app/(protected)/[itemId]/page.tsx
+++ b/app/(protected)/[itemId]/page.tsx
@@ -100,7 +100,7 @@ export default async function ItemPage({
 
     // レコードとリレーション用データを並列取得
     const [records, relationRecords] = await Promise.all([
-      getRecords(itemId, { filters, sorting }),
+      getRecords(itemId, { filters }),
       getRelationRecords(columns),
     ]);
 

--- a/app/(protected)/[itemId]/page.tsx
+++ b/app/(protected)/[itemId]/page.tsx
@@ -6,10 +6,7 @@ import { FolderLayout } from '@/features/folder/components';
 import { notFound } from 'next/navigation';
 import { getCurrentUser } from '@/lib/auth';
 import { canAccessItem } from '@/lib/permissions';
-import type {
-  ExportColumnFilter,
-  ExportSorting,
-} from '@/features/table/types/export';
+import type { ExportColumnFilter } from '@/features/table/types/export';
 
 export const dynamic = 'force-dynamic';
 
@@ -70,12 +67,10 @@ export default async function ItemPage({
     const columnSchema = getColumnSchema(item.meta);
     const columns = columnSchema?.columns || [];
 
-    // searchParamsからフィルタとソート条件を抽出
+    // searchParamsからフィルタ条件を抽出
     const filtersParam = resolvedSearchParams.filters;
-    const sortingParam = resolvedSearchParams.sorting;
 
     let filters: ExportColumnFilter[] = [];
-    let sorting: ExportSorting[] = [];
 
     try {
       if (filtersParam) {
@@ -85,14 +80,6 @@ export default async function ItemPage({
             : filtersParam[0] || '[]'
         );
         if (Array.isArray(parsed)) filters = parsed;
-      }
-      if (sortingParam) {
-        const parsed = JSON.parse(
-          typeof sortingParam === 'string'
-            ? sortingParam
-            : sortingParam[0] || '[]'
-        );
-        if (Array.isArray(parsed)) sorting = parsed;
       }
     } catch {
       // 不正なパラメータは無視してデフォルト値を使用
@@ -113,7 +100,6 @@ export default async function ItemPage({
         relationRecords={relationRecords}
         permissionLevel={level}
         initialFilters={filters}
-        initialSorting={sorting}
       />
     );
   }

--- a/app/(protected)/[itemId]/page.tsx
+++ b/app/(protected)/[itemId]/page.tsx
@@ -14,13 +14,18 @@ export const dynamic = 'force-dynamic';
  */
 type ItemPageProps = {
   params: Promise<{ itemId: string }>;
+  searchParams: Promise<{ [key: string]: string | string[] | undefined }>;
 };
 
 /**
  * アイテム詳細ページ（フォルダ/テーブル）
  */
-export default async function ItemPage({ params }: ItemPageProps) {
+export default async function ItemPage({
+  params,
+  searchParams,
+}: ItemPageProps) {
   const { itemId } = await params;
+  const resolvedSearchParams = await searchParams;
 
   // 認証チェック
   const currentUser = await getCurrentUser();
@@ -61,9 +66,28 @@ export default async function ItemPage({ params }: ItemPageProps) {
     const columnSchema = getColumnSchema(item.meta);
     const columns = columnSchema?.columns || [];
 
+    // searchParamsからフィルタとソート条件を抽出
+    const filtersParam = resolvedSearchParams.filters;
+    const sortingParam = resolvedSearchParams.sorting;
+
+    const filters = filtersParam
+      ? JSON.parse(
+          typeof filtersParam === 'string'
+            ? filtersParam
+            : filtersParam[0] || '[]'
+        )
+      : [];
+    const sorting = sortingParam
+      ? JSON.parse(
+          typeof sortingParam === 'string'
+            ? sortingParam
+            : sortingParam[0] || '[]'
+        )
+      : [];
+
     // レコードとリレーション用データを並列取得
     const [records, relationRecords] = await Promise.all([
-      getRecords(itemId),
+      getRecords(itemId, { filters, sorting }),
       getRelationRecords(columns),
     ]);
 
@@ -75,6 +99,8 @@ export default async function ItemPage({ params }: ItemPageProps) {
         records={records}
         relationRecords={relationRecords}
         permissionLevel={level}
+        initialFilters={filters}
+        initialSorting={sorting}
       />
     );
   }

--- a/app/(protected)/groups/page.tsx
+++ b/app/(protected)/groups/page.tsx
@@ -41,13 +41,17 @@ export default async function GroupsPage({ searchParams }: GroupsPageProps) {
   try {
     if (filtersParam) {
       const parsed = JSON.parse(
-        typeof filtersParam === 'string' ? filtersParam : filtersParam[0] || '[]'
+        typeof filtersParam === 'string'
+          ? filtersParam
+          : filtersParam[0] || '[]'
       );
       if (Array.isArray(parsed)) filters = parsed;
     }
     if (sortingParam) {
       const parsed = JSON.parse(
-        typeof sortingParam === 'string' ? sortingParam : sortingParam[0] || '[]'
+        typeof sortingParam === 'string'
+          ? sortingParam
+          : sortingParam[0] || '[]'
       );
       if (Array.isArray(parsed)) sorting = parsed;
     }

--- a/app/(protected)/groups/page.tsx
+++ b/app/(protected)/groups/page.tsx
@@ -3,7 +3,7 @@ import { getCurrentUser } from '@/lib/auth';
 import { canManageGroups } from '@/lib/permissions';
 import { getGroups } from '@/features/group/api';
 import { getUsers } from '@/features/user/api';
-import { GroupTable } from '@/features/group/components';
+import { GroupsLayout } from '@/features/group/components';
 
 export const dynamic = 'force-dynamic';
 
@@ -20,15 +20,5 @@ export default async function GroupsPage() {
 
   const [groups, users] = await Promise.all([getGroups(), getUsers()]);
 
-  return (
-    <div className="flex flex-col gap-6 p-6">
-      <div className="flex items-center justify-between">
-        <div>
-          <h1 className="text-2xl font-bold">グループ管理</h1>
-        </div>
-      </div>
-
-      <GroupTable groups={groups} users={users} />
-    </div>
-  );
+  return <GroupsLayout groups={groups} users={users} />;
 }

--- a/app/(protected)/groups/page.tsx
+++ b/app/(protected)/groups/page.tsx
@@ -8,17 +8,52 @@ import { GroupsLayout } from '@/features/group/components';
 export const dynamic = 'force-dynamic';
 
 /**
+ * グループ管理ページのProps型
+ */
+type GroupsPageProps = {
+  searchParams: Promise<{ [key: string]: string | string[] | undefined }>;
+};
+
+/**
  * グループ管理ページ
  * ADMINロールのみアクセス可能
  */
-export default async function GroupsPage() {
+export default async function GroupsPage({ searchParams }: GroupsPageProps) {
   // 権限チェック
   const currentUser = await getCurrentUser();
   if (!currentUser || !canManageGroups(currentUser.role)) {
     redirect('/');
   }
 
+  const resolvedSearchParams = await searchParams;
+
+  // URLからフィルタとソート条件を抽出
+  const filtersParam = resolvedSearchParams.filters;
+  const sortingParam = resolvedSearchParams.sorting;
+
+  const filters = filtersParam
+    ? JSON.parse(
+        typeof filtersParam === 'string'
+          ? filtersParam
+          : filtersParam[0] || '[]'
+      )
+    : [];
+  const sorting = sortingParam
+    ? JSON.parse(
+        typeof sortingParam === 'string'
+          ? sortingParam
+          : sortingParam[0] || '[]'
+      )
+    : [];
+
   const [groups, users] = await Promise.all([getGroups(), getUsers()]);
 
-  return <GroupsLayout groups={groups} users={users} />;
+  return (
+    <GroupsLayout
+      groups={groups}
+      users={users}
+      initialFilters={filters}
+      initialSorting={sorting}
+    />
+  );
 }

--- a/app/(protected)/groups/page.tsx
+++ b/app/(protected)/groups/page.tsx
@@ -4,6 +4,10 @@ import { canManageGroups } from '@/lib/permissions';
 import { getGroups } from '@/features/group/api';
 import { getUsers } from '@/features/user/api';
 import { GroupsLayout } from '@/features/group/components';
+import type {
+  ExportColumnFilter,
+  ExportSorting,
+} from '@/features/table/types/export';
 
 export const dynamic = 'force-dynamic';
 
@@ -31,20 +35,25 @@ export default async function GroupsPage({ searchParams }: GroupsPageProps) {
   const filtersParam = resolvedSearchParams.filters;
   const sortingParam = resolvedSearchParams.sorting;
 
-  const filters = filtersParam
-    ? JSON.parse(
-        typeof filtersParam === 'string'
-          ? filtersParam
-          : filtersParam[0] || '[]'
-      )
-    : [];
-  const sorting = sortingParam
-    ? JSON.parse(
-        typeof sortingParam === 'string'
-          ? sortingParam
-          : sortingParam[0] || '[]'
-      )
-    : [];
+  let filters: ExportColumnFilter[] = [];
+  let sorting: ExportSorting[] = [];
+
+  try {
+    if (filtersParam) {
+      const parsed = JSON.parse(
+        typeof filtersParam === 'string' ? filtersParam : filtersParam[0] || '[]'
+      );
+      if (Array.isArray(parsed)) filters = parsed;
+    }
+    if (sortingParam) {
+      const parsed = JSON.parse(
+        typeof sortingParam === 'string' ? sortingParam : sortingParam[0] || '[]'
+      );
+      if (Array.isArray(parsed)) sorting = parsed;
+    }
+  } catch {
+    // 不正なパラメータは無視してデフォルト値を使用
+  }
 
   const [groups, users] = await Promise.all([getGroups(), getUsers()]);
 

--- a/app/(protected)/layout.tsx
+++ b/app/(protected)/layout.tsx
@@ -5,7 +5,6 @@ import { Separator } from '@/components/ui/separator';
 import { AppSidebar } from '@/features/layout/components/app-sidebar';
 import { BreadcrumbContainer } from '@/features/layout/components/breadcrumb/container';
 import { ItemOptionsButtonContainer } from '@/features/layout/components/item-options-button/container';
-import { ExportProvider } from '@/features/layout/providers/export-provider';
 
 /**
  * 保護されたレイアウトコンポーネント（認証必須）
@@ -24,21 +23,19 @@ export default async function ProtectedLayout({
   return (
     <SidebarProvider>
       <AppSidebar userName={userName} userRole={userRole} />
-      <ExportProvider>
-        <main className="w-full overflow-hidden">
-          <div className="relative flex items-center m-4">
-            <div className="flex items-center gap-2">
-              <SidebarTrigger />
-              <Separator orientation="vertical" className="h-4" />
-              <BreadcrumbContainer />
-            </div>
-            <div className="absolute right-0">
-              <ItemOptionsButtonContainer />
-            </div>
+      <main className="w-full overflow-hidden">
+        <div className="relative flex items-center m-4">
+          <div className="flex items-center gap-2">
+            <SidebarTrigger />
+            <Separator orientation="vertical" className="h-4" />
+            <BreadcrumbContainer />
           </div>
-          {children}
-        </main>
-      </ExportProvider>
+          <div className="absolute right-0">
+            <ItemOptionsButtonContainer />
+          </div>
+        </div>
+        {children}
+      </main>
     </SidebarProvider>
   );
 }

--- a/app/(protected)/layout.tsx
+++ b/app/(protected)/layout.tsx
@@ -5,6 +5,7 @@ import { Separator } from '@/components/ui/separator';
 import { AppSidebar } from '@/features/layout/components/app-sidebar';
 import { BreadcrumbContainer } from '@/features/layout/components/breadcrumb/container';
 import { ItemOptionsButtonContainer } from '@/features/layout/components/item-options-button/container';
+import { ExportProvider } from '@/features/layout/providers/export-provider';
 
 /**
  * 保護されたレイアウトコンポーネント（認証必須）
@@ -23,19 +24,21 @@ export default async function ProtectedLayout({
   return (
     <SidebarProvider>
       <AppSidebar userName={userName} userRole={userRole} />
-      <main className="w-full overflow-hidden">
-        <div className="relative flex items-center m-4">
-          <div className="flex items-center gap-2">
-            <SidebarTrigger />
-            <Separator orientation="vertical" className="h-4" />
-            <BreadcrumbContainer />
+      <ExportProvider>
+        <main className="w-full overflow-hidden">
+          <div className="relative flex items-center m-4">
+            <div className="flex items-center gap-2">
+              <SidebarTrigger />
+              <Separator orientation="vertical" className="h-4" />
+              <BreadcrumbContainer />
+            </div>
+            <div className="absolute right-0">
+              <ItemOptionsButtonContainer />
+            </div>
           </div>
-          <div className="absolute right-0">
-            <ItemOptionsButtonContainer />
-          </div>
-        </div>
-        {children}
-      </main>
+          {children}
+        </main>
+      </ExportProvider>
     </SidebarProvider>
   );
 }

--- a/app/(protected)/layout.tsx
+++ b/app/(protected)/layout.tsx
@@ -4,6 +4,7 @@ import { SidebarProvider, SidebarTrigger } from '@/components/ui/sidebar';
 import { Separator } from '@/components/ui/separator';
 import { AppSidebar } from '@/features/layout/components/app-sidebar';
 import { BreadcrumbContainer } from '@/features/layout/components/breadcrumb/container';
+import { ItemOptionsButtonContainer } from '@/features/layout/components/item-options-button/container';
 
 /**
  * 保護されたレイアウトコンポーネント（認証必須）
@@ -23,10 +24,15 @@ export default async function ProtectedLayout({
     <SidebarProvider>
       <AppSidebar userName={userName} userRole={userRole} />
       <main className="w-full overflow-hidden">
-        <div className="flex items-center gap-2 m-4">
-          <SidebarTrigger />
-          <Separator orientation="vertical" className="h-4" />
-          <BreadcrumbContainer />
+        <div className="relative flex items-center m-4">
+          <div className="flex items-center gap-2">
+            <SidebarTrigger />
+            <Separator orientation="vertical" className="h-4" />
+            <BreadcrumbContainer />
+          </div>
+          <div className="absolute right-0">
+            <ItemOptionsButtonContainer />
+          </div>
         </div>
         {children}
       </main>

--- a/app/(protected)/users/page.tsx
+++ b/app/(protected)/users/page.tsx
@@ -40,13 +40,17 @@ export default async function UsersPage({ searchParams }: UsersPageProps) {
   try {
     if (filtersParam) {
       const parsed = JSON.parse(
-        typeof filtersParam === 'string' ? filtersParam : filtersParam[0] || '[]'
+        typeof filtersParam === 'string'
+          ? filtersParam
+          : filtersParam[0] || '[]'
       );
       if (Array.isArray(parsed)) filters = parsed;
     }
     if (sortingParam) {
       const parsed = JSON.parse(
-        typeof sortingParam === 'string' ? sortingParam : sortingParam[0] || '[]'
+        typeof sortingParam === 'string'
+          ? sortingParam
+          : sortingParam[0] || '[]'
       );
       if (Array.isArray(parsed)) sorting = parsed;
     }

--- a/app/(protected)/users/page.tsx
+++ b/app/(protected)/users/page.tsx
@@ -7,17 +7,51 @@ import { UsersLayout } from '@/features/user/components';
 export const dynamic = 'force-dynamic';
 
 /**
+ * ユーザー管理ページのProps型
+ */
+type UsersPageProps = {
+  searchParams: Promise<{ [key: string]: string | string[] | undefined }>;
+};
+
+/**
  * ユーザー管理ページ
  * ADMINロールのみアクセス可能
  */
-export default async function UsersPage() {
+export default async function UsersPage({ searchParams }: UsersPageProps) {
   // 権限チェック
   const currentUser = await getCurrentUser();
   if (!currentUser || !canManageUsers(currentUser.role)) {
     redirect('/');
   }
 
+  const resolvedSearchParams = await searchParams;
+
+  // URLからフィルタとソート条件を抽出
+  const filtersParam = resolvedSearchParams.filters;
+  const sortingParam = resolvedSearchParams.sorting;
+
+  const filters = filtersParam
+    ? JSON.parse(
+        typeof filtersParam === 'string'
+          ? filtersParam
+          : filtersParam[0] || '[]'
+      )
+    : [];
+  const sorting = sortingParam
+    ? JSON.parse(
+        typeof sortingParam === 'string'
+          ? sortingParam
+          : sortingParam[0] || '[]'
+      )
+    : [];
+
   const users = await getUsers();
 
-  return <UsersLayout users={users} />;
+  return (
+    <UsersLayout
+      users={users}
+      initialFilters={filters}
+      initialSorting={sorting}
+    />
+  );
 }

--- a/app/(protected)/users/page.tsx
+++ b/app/(protected)/users/page.tsx
@@ -3,6 +3,10 @@ import { getCurrentUser } from '@/lib/auth';
 import { canManageUsers } from '@/lib/permissions';
 import { getUsers } from '@/features/user/api';
 import { UsersLayout } from '@/features/user/components';
+import type {
+  ExportColumnFilter,
+  ExportSorting,
+} from '@/features/table/types/export';
 
 export const dynamic = 'force-dynamic';
 
@@ -30,20 +34,25 @@ export default async function UsersPage({ searchParams }: UsersPageProps) {
   const filtersParam = resolvedSearchParams.filters;
   const sortingParam = resolvedSearchParams.sorting;
 
-  const filters = filtersParam
-    ? JSON.parse(
-        typeof filtersParam === 'string'
-          ? filtersParam
-          : filtersParam[0] || '[]'
-      )
-    : [];
-  const sorting = sortingParam
-    ? JSON.parse(
-        typeof sortingParam === 'string'
-          ? sortingParam
-          : sortingParam[0] || '[]'
-      )
-    : [];
+  let filters: ExportColumnFilter[] = [];
+  let sorting: ExportSorting[] = [];
+
+  try {
+    if (filtersParam) {
+      const parsed = JSON.parse(
+        typeof filtersParam === 'string' ? filtersParam : filtersParam[0] || '[]'
+      );
+      if (Array.isArray(parsed)) filters = parsed;
+    }
+    if (sortingParam) {
+      const parsed = JSON.parse(
+        typeof sortingParam === 'string' ? sortingParam : sortingParam[0] || '[]'
+      );
+      if (Array.isArray(parsed)) sorting = parsed;
+    }
+  } catch {
+    // 不正なパラメータは無視してデフォルト値を使用
+  }
 
   const users = await getUsers();
 

--- a/app/(protected)/users/page.tsx
+++ b/app/(protected)/users/page.tsx
@@ -2,7 +2,7 @@ import { redirect } from 'next/navigation';
 import { getCurrentUser } from '@/lib/auth';
 import { canManageUsers } from '@/lib/permissions';
 import { getUsers } from '@/features/user/api';
-import { UserTable } from '@/features/user/components';
+import { UsersLayout } from '@/features/user/components';
 
 export const dynamic = 'force-dynamic';
 
@@ -19,15 +19,5 @@ export default async function UsersPage() {
 
   const users = await getUsers();
 
-  return (
-    <div className="flex flex-col gap-6 p-6">
-      <div className="flex items-center justify-between">
-        <div>
-          <h1 className="text-2xl font-bold">ユーザー管理</h1>
-        </div>
-      </div>
-
-      <UserTable users={users} />
-    </div>
-  );
+  return <UsersLayout users={users} />;
 }

--- a/features/group/actions/export-groups.ts
+++ b/features/group/actions/export-groups.ts
@@ -1,0 +1,89 @@
+'use server';
+
+import { prisma } from '@/lib/prisma';
+import { convertToCSV } from '@/lib/csv';
+import type {
+  ExportColumnFilter,
+  ExportSorting,
+} from '@/features/table/types/export';
+
+/**
+ * グループデータをCSVエクスポートするServer Action
+ */
+export async function exportGroupsAction(
+  filters: ExportColumnFilter[],
+  sorting: ExportSorting[]
+) {
+  // フィルタ条件を構築
+  const where: {
+    name?: { contains: string; mode: 'insensitive' };
+    description?: { contains: string; mode: 'insensitive' };
+  } = {};
+
+  filters.forEach((filter) => {
+    const { id, value } = filter;
+    if (typeof value === 'string' && value.trim() !== '') {
+      if (id === 'name') {
+        where.name = { contains: value, mode: 'insensitive' };
+      } else if (id === 'description') {
+        where.description = { contains: value, mode: 'insensitive' };
+      }
+    }
+  });
+
+  // ソート条件を構築
+  const orderBy: Record<string, 'asc' | 'desc'>[] = [];
+  sorting.forEach((sort) => {
+    const { id, desc } = sort;
+    if (id === 'name' || id === 'description' || id === 'createdAt') {
+      orderBy.push({ [id]: desc ? 'desc' : 'asc' });
+    }
+  });
+
+  // グループデータを取得
+  const groups = await prisma.group.findMany({
+    where,
+    orderBy: orderBy.length > 0 ? orderBy : { createdAt: 'desc' },
+    select: {
+      id: true,
+      name: true,
+      description: true,
+      createdAt: true,
+      _count: {
+        select: {
+          members: true,
+        },
+      },
+    },
+  });
+
+  // ヘッダー行を作成
+  const headers = ['ID', 'グループ名', '説明', 'メンバー数', '作成日'];
+
+  // データ行を作成
+  const rows = groups.map((group) => [
+    group.id,
+    group.name,
+    group.description || '',
+    group._count.members.toString(),
+    group.createdAt.toISOString().split('T')[0], // YYYY-MM-DD
+  ]);
+
+  // CSV変換
+  const csv = convertToCSV(headers, rows);
+
+  // タイムスタンプ付きファイル名を生成
+  const timestamp = new Date()
+    .toLocaleString('ja-JP', {
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+      hour: '2-digit',
+      minute: '2-digit',
+      second: '2-digit',
+    })
+    .replace(/[/:\s]/g, '-');
+  const filename = `グループ管理_${timestamp}.csv`;
+
+  return { csv, filename };
+}

--- a/features/group/actions/export-groups.ts
+++ b/features/group/actions/export-groups.ts
@@ -2,18 +2,12 @@
 
 import { prisma } from '@/lib/prisma';
 import { convertToCSV } from '@/lib/csv';
-import type {
-  ExportColumnFilter,
-  ExportSorting,
-} from '@/features/table/types/export';
+import type { ExportColumnFilter } from '@/features/table/types/export';
 
 /**
  * グループデータをCSVエクスポートするServer Action
  */
-export async function exportGroupsAction(
-  filters: ExportColumnFilter[],
-  sorting: ExportSorting[]
-) {
+export async function exportGroupsAction(filters: ExportColumnFilter[]) {
   // フィルタ条件を構築
   const where: {
     name?: { contains: string; mode: 'insensitive' };
@@ -31,19 +25,11 @@ export async function exportGroupsAction(
     }
   });
 
-  // ソート条件を構築
-  const orderBy: Record<string, 'asc' | 'desc'>[] = [];
-  sorting.forEach((sort) => {
-    const { id, desc } = sort;
-    if (id === 'name' || id === 'description' || id === 'createdAt') {
-      orderBy.push({ [id]: desc ? 'desc' : 'asc' });
-    }
-  });
-
   // グループデータを取得
+  // 注: ソートはクライアントサイド（TanStack Table）で処理済み
   const groups = await prisma.group.findMany({
     where,
-    orderBy: orderBy.length > 0 ? orderBy : { createdAt: 'desc' },
+    orderBy: { createdAt: 'desc' },
     select: {
       id: true,
       name: true,

--- a/features/group/components/group-table.tsx
+++ b/features/group/components/group-table.tsx
@@ -14,6 +14,7 @@ import {
 } from '@tanstack/react-table';
 import { Button } from '@/components/ui/button';
 import { useLocalStorage } from '@/hooks/use-local-storage';
+import { exportTableToCSV } from '@/lib/table-export';
 import { CreateGroupButton } from './create-group-button';
 import { BulkDeleteButton } from './bulk-delete-button';
 import { createColumns } from './columns';
@@ -44,12 +45,13 @@ type User = {
 type GroupTableProps = {
   groups: Group[];
   users: User[];
+  onExportCSV?: (exportFn: () => void) => void;
 };
 
 /**
  * グループテーブルコンポーネント
  */
-export function GroupTable({ groups, users }: GroupTableProps) {
+export function GroupTable({ groups, users, onExportCSV }: GroupTableProps) {
   const columns = createColumns(groups, users);
   const [rowSelection, setRowSelection] = React.useState({});
 
@@ -91,6 +93,16 @@ export function GroupTable({ groups, users }: GroupTableProps) {
   const handleDeleteComplete = () => {
     table.resetRowSelection();
   };
+
+  // CSV エクスポート関数
+  const handleExportCSV = React.useCallback(() => {
+    exportTableToCSV(table, 'グループ管理');
+  }, [table]);
+
+  // エクスポート関数を親コンポーネントに登録
+  React.useEffect(() => {
+    onExportCSV?.(() => handleExportCSV);
+  }, [onExportCSV, handleExportCSV]);
 
   return (
     <div className="w-full">

--- a/features/group/components/group-table.tsx
+++ b/features/group/components/group-table.tsx
@@ -14,7 +14,6 @@ import {
 } from '@tanstack/react-table';
 import { Button } from '@/components/ui/button';
 import { useLocalStorage } from '@/hooks/use-local-storage';
-import { exportTableToCSV } from '@/lib/table-export';
 import { CreateGroupButton } from './create-group-button';
 import { BulkDeleteButton } from './bulk-delete-button';
 import { createColumns } from './columns';
@@ -45,27 +44,30 @@ type User = {
 type GroupTableProps = {
   groups: Group[];
   users: User[];
-  onExportCSV?: (exportFn: () => void) => void;
+  initialFilters?: ColumnFiltersState;
+  initialSorting?: SortingState;
 };
 
 /**
  * グループテーブルコンポーネント
  */
-export function GroupTable({ groups, users, onExportCSV }: GroupTableProps) {
+export function GroupTable({
+  groups,
+  users,
+  initialFilters = [],
+  initialSorting = [],
+}: GroupTableProps) {
   const columns = createColumns(groups, users);
   const [rowSelection, setRowSelection] = React.useState({});
 
   // localStorageに保存するテーブル状態
   const [columnVisibility, setColumnVisibility] =
     useLocalStorage<VisibilityState>('group-table-column-visibility', {});
-  const [sorting, setSorting] = useLocalStorage<SortingState>(
-    'group-table-sorting',
-    []
-  );
-  const [columnFilters, setColumnFilters] = useLocalStorage<ColumnFiltersState>(
-    'group-table-filters',
-    []
-  );
+
+  // フィルタとソートの状態をクライアント側で管理（即座に反映）
+  const [sorting, setSorting] = React.useState<SortingState>(initialSorting);
+  const [columnFilters, setColumnFilters] =
+    React.useState<ColumnFiltersState>(initialFilters);
 
   // eslint-disable-next-line react-hooks/incompatible-library
   const table = useReactTable({
@@ -79,6 +81,7 @@ export function GroupTable({ groups, users, onExportCSV }: GroupTableProps) {
     getFilteredRowModel: getFilteredRowModel(),
     onColumnVisibilityChange: setColumnVisibility,
     onRowSelectionChange: setRowSelection,
+    enableSortingRemoval: true,
     state: {
       sorting,
       columnFilters,
@@ -93,16 +96,6 @@ export function GroupTable({ groups, users, onExportCSV }: GroupTableProps) {
   const handleDeleteComplete = () => {
     table.resetRowSelection();
   };
-
-  // CSV エクスポート関数
-  const handleExportCSV = React.useCallback(() => {
-    exportTableToCSV(table, 'グループ管理');
-  }, [table]);
-
-  // エクスポート関数を親コンポーネントに登録
-  React.useEffect(() => {
-    onExportCSV?.(() => handleExportCSV);
-  }, [onExportCSV, handleExportCSV]);
 
   return (
     <div className="w-full">

--- a/features/group/components/groups-layout.tsx
+++ b/features/group/components/groups-layout.tsx
@@ -1,0 +1,35 @@
+'use client';
+
+import { useExport } from '@/features/layout/providers/export-provider';
+import { GroupTable } from '@/features/group/components';
+import type { Group } from '@/features/group/types';
+
+type User = {
+  id: string;
+  email: string;
+  name: string | null;
+};
+
+type GroupsLayoutProps = {
+  groups: Group[];
+  users: User[];
+};
+
+/**
+ * グループ管理ページのレイアウトコンポーネント
+ */
+export function GroupsLayout({ groups, users }: GroupsLayoutProps) {
+  const { setExportFn } = useExport();
+
+  return (
+    <div className="flex flex-col gap-6 p-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold">グループ管理</h1>
+        </div>
+      </div>
+
+      <GroupTable groups={groups} users={users} onExportCSV={setExportFn} />
+    </div>
+  );
+}

--- a/features/group/components/groups-layout.tsx
+++ b/features/group/components/groups-layout.tsx
@@ -1,8 +1,8 @@
 'use client';
 
-import { useExport } from '@/features/layout/providers/export-provider';
 import { GroupTable } from '@/features/group/components';
 import type { Group } from '@/features/group/types';
+import type { ColumnFiltersState, SortingState } from '@tanstack/react-table';
 
 type User = {
   id: string;
@@ -13,14 +13,19 @@ type User = {
 type GroupsLayoutProps = {
   groups: Group[];
   users: User[];
+  initialFilters?: ColumnFiltersState;
+  initialSorting?: SortingState;
 };
 
 /**
  * グループ管理ページのレイアウトコンポーネント
  */
-export function GroupsLayout({ groups, users }: GroupsLayoutProps) {
-  const { setExportFn } = useExport();
-
+export function GroupsLayout({
+  groups,
+  users,
+  initialFilters = [],
+  initialSorting = [],
+}: GroupsLayoutProps) {
   return (
     <div className="flex flex-col gap-6 p-6">
       <div className="flex items-center justify-between">
@@ -29,7 +34,12 @@ export function GroupsLayout({ groups, users }: GroupsLayoutProps) {
         </div>
       </div>
 
-      <GroupTable groups={groups} users={users} onExportCSV={setExportFn} />
+      <GroupTable
+        groups={groups}
+        users={users}
+        initialFilters={initialFilters}
+        initialSorting={initialSorting}
+      />
     </div>
   );
 }

--- a/features/group/components/index.ts
+++ b/features/group/components/index.ts
@@ -6,3 +6,4 @@ export * from './delete-group-item';
 export * from './bulk-delete-button';
 export * from './member-list';
 export * from './manage-members-item';
+export * from './groups-layout';

--- a/features/layout/components/item-options-button/container.tsx
+++ b/features/layout/components/item-options-button/container.tsx
@@ -1,0 +1,37 @@
+'use client';
+
+import { useParams } from 'next/navigation';
+import { useEffect, useState } from 'react';
+import type { ItemType } from '@prisma/client';
+import { getItemById } from '@/features/item/api';
+import { ItemOptionsButton } from './index';
+
+/**
+ * ItemOptionsButtonのコンテナコンポーネント
+ * ルートパラメータからitemIdを取得し、アイテム情報を取得してボタンを表示
+ */
+export function ItemOptionsButtonContainer() {
+  const params = useParams();
+  const itemId = params?.itemId as string | undefined;
+  const [itemType, setItemType] = useState<ItemType | null>(null);
+
+  useEffect(() => {
+    if (!itemId) {
+      return;
+    }
+
+    const fetchItemType = async () => {
+      const item = await getItemById(itemId);
+      setItemType(item?.type ?? null);
+    };
+
+    fetchItemType();
+  }, [itemId]);
+
+  // itemIdがない、またはitemTypeがない場合はnullを返す
+  if (!itemId || !itemType) {
+    return null;
+  }
+
+  return <ItemOptionsButton itemType={itemType} />;
+}

--- a/features/layout/components/item-options-button/container.tsx
+++ b/features/layout/components/item-options-button/container.tsx
@@ -47,12 +47,31 @@ export function ItemOptionsButtonContainer() {
       return;
     }
 
+    // 競合状態を防ぐためのフラグ
+    let cancelled = false;
+
     const fetchItemType = async () => {
-      const item = await getItemById(itemId);
-      setItemType(item?.type ?? null);
+      try {
+        const item = await getItemById(itemId);
+        // コンポーネントがアンマウントされた、または新しいitemIdでリクエストが開始された場合は状態更新しない
+        if (!cancelled) {
+          setItemType(item?.type ?? null);
+        }
+      } catch (error) {
+        // エラー時も競合状態チェック
+        if (!cancelled) {
+          console.error('Failed to fetch item type:', error);
+          setItemType(null);
+        }
+      }
     };
 
     fetchItemType();
+
+    // クリーンアップ: 新しいitemIdでリクエストが開始されたら古いリクエストの結果を無視
+    return () => {
+      cancelled = true;
+    };
   }, [itemId, pathname]);
 
   if (!pageType) {

--- a/features/layout/components/item-options-button/container.tsx
+++ b/features/layout/components/item-options-button/container.tsx
@@ -59,5 +59,5 @@ export function ItemOptionsButtonContainer() {
     return null;
   }
 
-  return <ItemOptionsButton pageType={pageType} />;
+  return <ItemOptionsButton pageType={pageType} itemId={itemId} />;
 }

--- a/features/layout/components/item-options-button/container.tsx
+++ b/features/layout/components/item-options-button/container.tsx
@@ -1,21 +1,48 @@
 'use client';
 
-import { useParams } from 'next/navigation';
-import { useEffect, useState } from 'react';
+import { useParams, usePathname } from 'next/navigation';
+import { useEffect, useState, useMemo } from 'react';
 import type { ItemType } from '@prisma/client';
 import { getItemById } from '@/features/item/api';
 import { ItemOptionsButton } from './index';
 
 /**
+ * ページタイプ（Itemタイプまたは特定のページ）
+ */
+export type PageType = ItemType | 'USERS' | 'GROUPS';
+
+/**
  * ItemOptionsButtonのコンテナコンポーネント
- * ルートパラメータからitemIdを取得し、アイテム情報を取得してボタンを表示
+ * パスまたはルートパラメータからページタイプを判定してボタンを表示
  */
 export function ItemOptionsButtonContainer() {
   const params = useParams();
+  const pathname = usePathname();
   const itemId = params?.itemId as string | undefined;
   const [itemType, setItemType] = useState<ItemType | null>(null);
 
+  // パスベースでページタイプを判定
+  const pageType = useMemo<PageType | null>(() => {
+    if (pathname === '/users') {
+      return 'USERS';
+    }
+    if (pathname === '/groups') {
+      return 'GROUPS';
+    }
+    // itemIdがある場合のみitemTypeを返す（TABLE/FOLDERなど）
+    if (itemId && itemType) {
+      return itemType;
+    }
+    return null;
+  }, [pathname, itemId, itemType]);
+
   useEffect(() => {
+    // パスベースのページの場合はアイテムタイプ取得不要
+    if (pathname === '/users' || pathname === '/groups') {
+      return;
+    }
+
+    // itemIdがない場合は何もしない（stateはnullのまま）
     if (!itemId) {
       return;
     }
@@ -26,12 +53,11 @@ export function ItemOptionsButtonContainer() {
     };
 
     fetchItemType();
-  }, [itemId]);
+  }, [itemId, pathname]);
 
-  // itemIdがない、またはitemTypeがない場合はnullを返す
-  if (!itemId || !itemType) {
+  if (!pageType) {
     return null;
   }
 
-  return <ItemOptionsButton itemType={itemType} />;
+  return <ItemOptionsButton pageType={pageType} />;
 }

--- a/features/layout/components/item-options-button/index.tsx
+++ b/features/layout/components/item-options-button/index.tsx
@@ -3,6 +3,10 @@
 import { useSearchParams } from 'next/navigation';
 import { Ellipsis, FileOutput, FileInput } from 'lucide-react';
 import type { PageType } from './container';
+import type {
+  ExportColumnFilter,
+  ExportSorting,
+} from '@/features/table/types/export';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -45,8 +49,22 @@ export function ItemOptionsButton({
     const filtersParam = searchParams.get('filters');
     const sortingParam = searchParams.get('sorting');
 
-    const filters = filtersParam ? JSON.parse(filtersParam) : [];
-    const sorting = sortingParam ? JSON.parse(sortingParam) : [];
+    let filters: ExportColumnFilter[] = [];
+    let sorting: ExportSorting[] = [];
+
+    try {
+      if (filtersParam) {
+        const parsed = JSON.parse(filtersParam);
+        if (Array.isArray(parsed)) filters = parsed;
+      }
+      if (sortingParam) {
+        const parsed = JSON.parse(sortingParam);
+        if (Array.isArray(parsed)) sorting = parsed;
+      }
+    } catch {
+      // 不正なパラメータは無視してデフォルト値を使用
+      console.error('Failed to parse filters or sorting from URL');
+    }
 
     let result: { csv?: string; filename?: string; error?: string };
 

--- a/features/layout/components/item-options-button/index.tsx
+++ b/features/layout/components/item-options-button/index.tsx
@@ -1,0 +1,50 @@
+'use client';
+
+import { Ellipsis, FileOutput, FileInput } from 'lucide-react';
+import type { ItemType } from '@prisma/client';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import { Button } from '@/components/ui/button';
+
+/**
+ * アイテムオプションボタンのProps型
+ */
+type ItemOptionsButtonProps = {
+  itemType: ItemType;
+};
+
+/**
+ * アイテムオプションボタンコンポーネント
+ * アイテムタイプに応じてインポート/エクスポートオプションを表示
+ */
+export function ItemOptionsButton({ itemType }: ItemOptionsButtonProps) {
+  // TABLEのみボタンを表示
+  if (itemType !== 'TABLE') {
+    return null;
+  }
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button variant="ghost" size="icon">
+          <Ellipsis />
+          <span className="sr-only">オプション</span>
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        <DropdownMenuItem>
+          <FileInput />
+          インポート
+        </DropdownMenuItem>
+        <DropdownMenuItem>
+          <FileOutput />
+          エクスポート
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/features/layout/components/item-options-button/index.tsx
+++ b/features/layout/components/item-options-button/index.tsx
@@ -3,10 +3,7 @@
 import { useSearchParams } from 'next/navigation';
 import { Ellipsis, FileOutput, FileInput } from 'lucide-react';
 import type { PageType } from './container';
-import type {
-  ExportColumnFilter,
-  ExportSorting,
-} from '@/features/table/types/export';
+import type { ExportColumnFilter } from '@/features/table/types/export';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -45,36 +42,30 @@ export function ItemOptionsButton({
   }
 
   const handleExport = async () => {
-    // URLからフィルタ・ソート条件を取得
+    // URLからフィルタ条件を取得
     const filtersParam = searchParams.get('filters');
-    const sortingParam = searchParams.get('sorting');
 
     let filters: ExportColumnFilter[] = [];
-    let sorting: ExportSorting[] = [];
 
     try {
       if (filtersParam) {
         const parsed = JSON.parse(filtersParam);
         if (Array.isArray(parsed)) filters = parsed;
       }
-      if (sortingParam) {
-        const parsed = JSON.parse(sortingParam);
-        if (Array.isArray(parsed)) sorting = parsed;
-      }
     } catch {
       // 不正なパラメータは無視してデフォルト値を使用
-      console.error('Failed to parse filters or sorting from URL');
+      console.error('Failed to parse filters from URL');
     }
 
     let result: { csv?: string; filename?: string; error?: string };
 
     // ページタイプに応じてServer Actionを呼び出し
     if (pageType === 'TABLE' && itemId) {
-      result = await exportTableAction(itemId, filters, sorting);
+      result = await exportTableAction(itemId, filters);
     } else if (pageType === 'USERS') {
-      result = await exportUsersAction(filters, sorting);
+      result = await exportUsersAction(filters);
     } else if (pageType === 'GROUPS') {
-      result = await exportGroupsAction(filters, sorting);
+      result = await exportGroupsAction(filters);
     } else {
       console.error('Unknown page type:', pageType);
       return;

--- a/features/layout/components/item-options-button/index.tsx
+++ b/features/layout/components/item-options-button/index.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useSearchParams } from 'next/navigation';
 import { Ellipsis, FileOutput, FileInput } from 'lucide-react';
 import type { PageType } from './container';
 import {
@@ -9,21 +10,28 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import { Button } from '@/components/ui/button';
-import { useExport } from '@/features/layout/providers/export-provider';
+import { exportTableAction } from '@/features/table/actions/export-table';
+import { exportUsersAction } from '@/features/user/actions/export-users';
+import { exportGroupsAction } from '@/features/group/actions/export-groups';
+import { downloadCSV } from '@/lib/csv';
 
 /**
  * アイテムオプションボタンのProps型
  */
 type ItemOptionsButtonProps = {
   pageType: PageType;
+  itemId?: string;
 };
 
 /**
  * アイテムオプションボタンコンポーネント
  * ページタイプに応じてインポート/エクスポートオプションを表示
  */
-export function ItemOptionsButton({ pageType }: ItemOptionsButtonProps) {
-  const { exportFn } = useExport();
+export function ItemOptionsButton({
+  pageType,
+  itemId,
+}: ItemOptionsButtonProps) {
+  const searchParams = useSearchParams();
 
   // エクスポート可能なページタイプ
   const exportableTypes: PageType[] = ['TABLE', 'USERS', 'GROUPS'];
@@ -32,12 +40,35 @@ export function ItemOptionsButton({ pageType }: ItemOptionsButtonProps) {
     return null;
   }
 
-  const handleExport = () => {
-    console.log('handleExport called, exportFn:', exportFn);
-    if (exportFn) {
-      exportFn();
+  const handleExport = async () => {
+    // URLからフィルタ・ソート条件を取得
+    const filtersParam = searchParams.get('filters');
+    const sortingParam = searchParams.get('sorting');
+
+    const filters = filtersParam ? JSON.parse(filtersParam) : [];
+    const sorting = sortingParam ? JSON.parse(sortingParam) : [];
+
+    let result: { csv?: string; filename?: string; error?: string };
+
+    // ページタイプに応じてServer Actionを呼び出し
+    if (pageType === 'TABLE' && itemId) {
+      result = await exportTableAction(itemId, filters, sorting);
+    } else if (pageType === 'USERS') {
+      result = await exportUsersAction(filters, sorting);
+    } else if (pageType === 'GROUPS') {
+      result = await exportGroupsAction(filters, sorting);
     } else {
-      console.error('exportFn is null or undefined');
+      console.error('Unknown page type:', pageType);
+      return;
+    }
+
+    if (result.error) {
+      console.error('Export error:', result.error);
+      return;
+    }
+
+    if (result.csv && result.filename) {
+      downloadCSV(result.csv, result.filename);
     }
   };
 

--- a/features/layout/components/item-options-button/index.tsx
+++ b/features/layout/components/item-options-button/index.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { Ellipsis, FileOutput, FileInput } from 'lucide-react';
-import type { ItemType } from '@prisma/client';
+import type { PageType } from './container';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -9,23 +9,37 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import { Button } from '@/components/ui/button';
+import { useExport } from '@/features/layout/providers/export-provider';
 
 /**
  * アイテムオプションボタンのProps型
  */
 type ItemOptionsButtonProps = {
-  itemType: ItemType;
+  pageType: PageType;
 };
 
 /**
  * アイテムオプションボタンコンポーネント
- * アイテムタイプに応じてインポート/エクスポートオプションを表示
+ * ページタイプに応じてインポート/エクスポートオプションを表示
  */
-export function ItemOptionsButton({ itemType }: ItemOptionsButtonProps) {
-  // TABLEのみボタンを表示
-  if (itemType !== 'TABLE') {
+export function ItemOptionsButton({ pageType }: ItemOptionsButtonProps) {
+  const { exportFn } = useExport();
+
+  // エクスポート可能なページタイプ
+  const exportableTypes: PageType[] = ['TABLE', 'USERS', 'GROUPS'];
+
+  if (!exportableTypes.includes(pageType)) {
     return null;
   }
+
+  const handleExport = () => {
+    console.log('handleExport called, exportFn:', exportFn);
+    if (exportFn) {
+      exportFn();
+    } else {
+      console.error('exportFn is null or undefined');
+    }
+  };
 
   return (
     <DropdownMenu>
@@ -40,7 +54,7 @@ export function ItemOptionsButton({ itemType }: ItemOptionsButtonProps) {
           <FileInput />
           インポート
         </DropdownMenuItem>
-        <DropdownMenuItem>
+        <DropdownMenuItem onSelect={handleExport}>
           <FileOutput />
           エクスポート
         </DropdownMenuItem>

--- a/features/layout/providers/export-provider.tsx
+++ b/features/layout/providers/export-provider.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import {
+  createContext,
+  useContext,
+  useState,
+  useMemo,
+  type ReactNode,
+} from 'react';
+
+type ExportContextType = {
+  exportFn: (() => void) | null;
+  setExportFn: (fn: (() => void) | null) => void;
+};
+
+const ExportContext = createContext<ExportContextType | undefined>(undefined);
+
+/**
+ * エクスポート機能用のContextプロバイダー
+ * app/(protected)/layout.tsxで全体をラップして使用
+ */
+export function ExportProvider({ children }: { children: ReactNode }) {
+  const [exportFn, setExportFn] = useState<(() => void) | null>(null);
+
+  const value = useMemo(() => ({ exportFn, setExportFn }), [exportFn]);
+
+  return (
+    <ExportContext.Provider value={value}>{children}</ExportContext.Provider>
+  );
+}
+
+/**
+ * エクスポートコンテキストを使用するフック
+ */
+export function useExport() {
+  const context = useContext(ExportContext);
+  if (!context) {
+    throw new Error('useExport は ExportProvider の配下で使用してください。');
+  }
+  return context;
+}

--- a/features/record/api/__tests__/get-records.test.ts
+++ b/features/record/api/__tests__/get-records.test.ts
@@ -1,4 +1,8 @@
 import { getRecords } from '../get-records';
+import type {
+  ExportColumnFilter,
+  ExportSorting,
+} from '@/features/table/types/export';
 
 // Prismaクライアントをモック化
 jest.mock('@/lib/prisma', () => ({
@@ -9,11 +13,24 @@ jest.mock('@/lib/prisma', () => ({
   },
 }));
 
+// filter-converterをモック化
+jest.mock('@/features/table/utils/filter-converter', () => ({
+  convertFiltersToPrismaWhere: jest.fn(() => ({})),
+  convertSortingToPrismaOrderBy: jest.fn(() => []),
+}));
+
 import { prisma } from '@/lib/prisma';
+import {
+  convertFiltersToPrismaWhere,
+  convertSortingToPrismaOrderBy,
+} from '@/features/table/utils/filter-converter';
 
 describe('getRecords', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    // デフォルトのモック戻り値をリセット
+    (convertFiltersToPrismaWhere as jest.Mock).mockReturnValue({});
+    (convertSortingToPrismaOrderBy as jest.Mock).mockReturnValue([]);
   });
 
   it('テーブルに紐づくレコード一覧を取得できる', async () => {
@@ -46,6 +63,8 @@ describe('getRecords', () => {
       where: { tableId },
       orderBy: { createdAt: 'asc' },
     });
+    expect(convertFiltersToPrismaWhere).toHaveBeenCalledWith([]);
+    expect(convertSortingToPrismaOrderBy).toHaveBeenCalled();
   });
 
   it('レコードが存在しない場合は空配列を返す', async () => {
@@ -74,5 +93,101 @@ describe('getRecords', () => {
         orderBy: { createdAt: 'asc' },
       })
     );
+  });
+
+  it('フィルタ条件を指定してレコードを取得できる', async () => {
+    const tableId = 'table-1';
+    const filters: ExportColumnFilter[] = [{ id: 'name', value: 'テスト' }];
+    const mockRecords = [
+      {
+        id: 'record-1',
+        tableId,
+        data: { name: 'テスト1' },
+        createdById: 'user-1',
+        createdAt: new Date('2024-01-01'),
+        updatedAt: new Date('2024-01-01'),
+      },
+    ];
+
+    const mockWhere = { data: { path: ['name'], string_contains: 'テスト' } };
+    (convertFiltersToPrismaWhere as jest.Mock).mockReturnValue(mockWhere);
+    (prisma.record.findMany as jest.Mock).mockResolvedValue(mockRecords);
+
+    const result = await getRecords(tableId, { filters });
+
+    expect(result).toEqual(mockRecords);
+    expect(convertFiltersToPrismaWhere).toHaveBeenCalledWith(filters);
+    expect(prisma.record.findMany).toHaveBeenCalledWith({
+      where: { tableId, ...mockWhere },
+      orderBy: { createdAt: 'asc' },
+    });
+  });
+
+  it('ソート条件を指定してレコードを取得できる', async () => {
+    const tableId = 'table-1';
+    const sorting: ExportSorting[] = [{ id: 'name', desc: true }];
+    const mockRecords = [
+      {
+        id: 'record-2',
+        tableId,
+        data: { name: 'テスト2' },
+        createdById: 'user-1',
+        createdAt: new Date('2024-01-02'),
+        updatedAt: new Date('2024-01-02'),
+      },
+      {
+        id: 'record-1',
+        tableId,
+        data: { name: 'テスト1' },
+        createdById: 'user-1',
+        createdAt: new Date('2024-01-01'),
+        updatedAt: new Date('2024-01-01'),
+      },
+    ];
+
+    const mockOrderBy = [{ data: { path: ['name'], sort: 'desc' } }];
+    (convertSortingToPrismaOrderBy as jest.Mock).mockReturnValue(mockOrderBy);
+    (prisma.record.findMany as jest.Mock).mockResolvedValue(mockRecords);
+
+    const result = await getRecords(tableId, { sorting });
+
+    expect(result).toEqual(mockRecords);
+    expect(convertSortingToPrismaOrderBy).toHaveBeenCalled();
+    expect(prisma.record.findMany).toHaveBeenCalledWith({
+      where: { tableId },
+      orderBy: mockOrderBy,
+    });
+  });
+
+  it('フィルタとソートの両方を指定してレコードを取得できる', async () => {
+    const tableId = 'table-1';
+    const filters: ExportColumnFilter[] = [{ id: 'status', value: 'active' }];
+    const sorting: ExportSorting[] = [{ id: 'createdAt', desc: true }];
+    const mockRecords = [
+      {
+        id: 'record-2',
+        tableId,
+        data: { status: 'active', name: 'テスト2' },
+        createdById: 'user-1',
+        createdAt: new Date('2024-01-02'),
+        updatedAt: new Date('2024-01-02'),
+      },
+    ];
+
+    const mockWhere = { data: { path: ['status'], equals: 'active' } };
+    const mockOrderBy = [{ createdAt: 'desc' }];
+    (convertFiltersToPrismaWhere as jest.Mock).mockReturnValue(mockWhere);
+    (convertSortingToPrismaOrderBy as jest.Mock).mockReturnValue(mockOrderBy);
+    (prisma.record.findMany as jest.Mock).mockResolvedValue(mockRecords);
+
+    const result = await getRecords(tableId, { filters, sorting });
+
+    expect(result).toEqual(mockRecords);
+    expect(convertFiltersToPrismaWhere).toHaveBeenCalledWith(filters);
+    expect(convertSortingToPrismaOrderBy).toHaveBeenCalled();
+    expect(prisma.record.findMany).toHaveBeenCalledWith({
+      where: { tableId, ...mockWhere },
+      orderBy: mockOrderBy,
+    });
   });
 });

--- a/features/record/api/__tests__/get-records.test.ts
+++ b/features/record/api/__tests__/get-records.test.ts
@@ -61,7 +61,7 @@ describe('getRecords', () => {
     expect(result).toEqual(mockRecords);
     expect(prisma.record.findMany).toHaveBeenCalledWith({
       where: { tableId },
-      orderBy: { createdAt: 'asc' },
+      orderBy: { createdAt: 'desc' },
     });
     expect(convertFiltersToPrismaWhere).toHaveBeenCalledWith([]);
     expect(convertSortingToPrismaOrderBy).toHaveBeenCalled();
@@ -77,11 +77,11 @@ describe('getRecords', () => {
     expect(result).toEqual([]);
     expect(prisma.record.findMany).toHaveBeenCalledWith({
       where: { tableId },
-      orderBy: { createdAt: 'asc' },
+      orderBy: { createdAt: 'desc' },
     });
   });
 
-  it('作成日時の昇順でソートされる', async () => {
+  it('作成日時の降順でソートされる', async () => {
     const tableId = 'table-1';
 
     (prisma.record.findMany as jest.Mock).mockResolvedValue([]);
@@ -90,7 +90,7 @@ describe('getRecords', () => {
 
     expect(prisma.record.findMany).toHaveBeenCalledWith(
       expect.objectContaining({
-        orderBy: { createdAt: 'asc' },
+        orderBy: { createdAt: 'desc' },
       })
     );
   });
@@ -119,7 +119,7 @@ describe('getRecords', () => {
     expect(convertFiltersToPrismaWhere).toHaveBeenCalledWith(filters);
     expect(prisma.record.findMany).toHaveBeenCalledWith({
       where: { tableId, ...mockWhere },
-      orderBy: { createdAt: 'asc' },
+      orderBy: { createdAt: 'desc' },
     });
   });
 

--- a/features/record/api/__tests__/get-records.test.ts
+++ b/features/record/api/__tests__/get-records.test.ts
@@ -1,8 +1,5 @@
 import { getRecords } from '../get-records';
-import type {
-  ExportColumnFilter,
-  ExportSorting,
-} from '@/features/table/types/export';
+import type { ExportColumnFilter } from '@/features/table/types/export';
 
 // Prismaクライアントをモック化
 jest.mock('@/lib/prisma', () => ({
@@ -16,21 +13,16 @@ jest.mock('@/lib/prisma', () => ({
 // filter-converterをモック化
 jest.mock('@/features/table/utils/filter-converter', () => ({
   convertFiltersToPrismaWhere: jest.fn(() => ({})),
-  convertSortingToPrismaOrderBy: jest.fn(() => []),
 }));
 
 import { prisma } from '@/lib/prisma';
-import {
-  convertFiltersToPrismaWhere,
-  convertSortingToPrismaOrderBy,
-} from '@/features/table/utils/filter-converter';
+import { convertFiltersToPrismaWhere } from '@/features/table/utils/filter-converter';
 
 describe('getRecords', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     // デフォルトのモック戻り値をリセット
     (convertFiltersToPrismaWhere as jest.Mock).mockReturnValue({});
-    (convertSortingToPrismaOrderBy as jest.Mock).mockReturnValue([]);
   });
 
   it('テーブルに紐づくレコード一覧を取得できる', async () => {
@@ -64,7 +56,6 @@ describe('getRecords', () => {
       orderBy: { createdAt: 'desc' },
     });
     expect(convertFiltersToPrismaWhere).toHaveBeenCalledWith([]);
-    expect(convertSortingToPrismaOrderBy).toHaveBeenCalled();
   });
 
   it('レコードが存在しない場合は空配列を返す', async () => {
@@ -120,74 +111,6 @@ describe('getRecords', () => {
     expect(prisma.record.findMany).toHaveBeenCalledWith({
       where: { tableId, ...mockWhere },
       orderBy: { createdAt: 'desc' },
-    });
-  });
-
-  it('ソート条件を指定してレコードを取得できる', async () => {
-    const tableId = 'table-1';
-    const sorting: ExportSorting[] = [{ id: 'name', desc: true }];
-    const mockRecords = [
-      {
-        id: 'record-2',
-        tableId,
-        data: { name: 'テスト2' },
-        createdById: 'user-1',
-        createdAt: new Date('2024-01-02'),
-        updatedAt: new Date('2024-01-02'),
-      },
-      {
-        id: 'record-1',
-        tableId,
-        data: { name: 'テスト1' },
-        createdById: 'user-1',
-        createdAt: new Date('2024-01-01'),
-        updatedAt: new Date('2024-01-01'),
-      },
-    ];
-
-    const mockOrderBy = [{ data: { path: ['name'], sort: 'desc' } }];
-    (convertSortingToPrismaOrderBy as jest.Mock).mockReturnValue(mockOrderBy);
-    (prisma.record.findMany as jest.Mock).mockResolvedValue(mockRecords);
-
-    const result = await getRecords(tableId, { sorting });
-
-    expect(result).toEqual(mockRecords);
-    expect(convertSortingToPrismaOrderBy).toHaveBeenCalled();
-    expect(prisma.record.findMany).toHaveBeenCalledWith({
-      where: { tableId },
-      orderBy: mockOrderBy,
-    });
-  });
-
-  it('フィルタとソートの両方を指定してレコードを取得できる', async () => {
-    const tableId = 'table-1';
-    const filters: ExportColumnFilter[] = [{ id: 'status', value: 'active' }];
-    const sorting: ExportSorting[] = [{ id: 'createdAt', desc: true }];
-    const mockRecords = [
-      {
-        id: 'record-2',
-        tableId,
-        data: { status: 'active', name: 'テスト2' },
-        createdById: 'user-1',
-        createdAt: new Date('2024-01-02'),
-        updatedAt: new Date('2024-01-02'),
-      },
-    ];
-
-    const mockWhere = { data: { path: ['status'], equals: 'active' } };
-    const mockOrderBy = [{ createdAt: 'desc' }];
-    (convertFiltersToPrismaWhere as jest.Mock).mockReturnValue(mockWhere);
-    (convertSortingToPrismaOrderBy as jest.Mock).mockReturnValue(mockOrderBy);
-    (prisma.record.findMany as jest.Mock).mockResolvedValue(mockRecords);
-
-    const result = await getRecords(tableId, { filters, sorting });
-
-    expect(result).toEqual(mockRecords);
-    expect(convertFiltersToPrismaWhere).toHaveBeenCalledWith(filters);
-    expect(convertSortingToPrismaOrderBy).toHaveBeenCalled();
-    expect(prisma.record.findMany).toHaveBeenCalledWith({
-      where: { tableId, ...mockWhere },
-      orderBy: mockOrderBy,
     });
   });
 });

--- a/features/record/api/__tests__/get-records.test.ts
+++ b/features/record/api/__tests__/get-records.test.ts
@@ -113,4 +113,250 @@ describe('getRecords', () => {
       orderBy: { createdAt: 'desc' },
     });
   });
+
+  it('NUMBER型フィルタでレコードを取得できる', async () => {
+    const tableId = 'table-1';
+    const filters: ExportColumnFilter[] = [
+      {
+        id: 'age',
+        value: { operator: 'gte', value1: 20, value2: null },
+      },
+    ];
+    const mockRecords = [
+      {
+        id: 'record-1',
+        tableId,
+        data: { age: 25 },
+        createdById: 'user-1',
+        createdAt: new Date('2024-01-01'),
+        updatedAt: new Date('2024-01-01'),
+      },
+    ];
+
+    const mockWhere = { data: { path: ['age'], gte: 20 } };
+    (convertFiltersToPrismaWhere as jest.Mock).mockReturnValue(mockWhere);
+    (prisma.record.findMany as jest.Mock).mockResolvedValue(mockRecords);
+
+    const result = await getRecords(tableId, { filters });
+
+    expect(result).toEqual(mockRecords);
+    expect(convertFiltersToPrismaWhere).toHaveBeenCalledWith(filters);
+    expect(prisma.record.findMany).toHaveBeenCalledWith({
+      where: { tableId, ...mockWhere },
+      orderBy: { createdAt: 'desc' },
+    });
+  });
+
+  it('NUMBER型の範囲フィルタでレコードを取得できる', async () => {
+    const tableId = 'table-1';
+    const filters: ExportColumnFilter[] = [
+      {
+        id: 'age',
+        value: { operator: 'range', value1: 20, value2: 30 },
+      },
+    ];
+    const mockRecords = [
+      {
+        id: 'record-1',
+        tableId,
+        data: { age: 25 },
+        createdById: 'user-1',
+        createdAt: new Date('2024-01-01'),
+        updatedAt: new Date('2024-01-01'),
+      },
+    ];
+
+    const mockWhere = {
+      AND: [
+        { data: { path: ['age'], gte: 20 } },
+        { data: { path: ['age'], lte: 30 } },
+      ],
+    };
+    (convertFiltersToPrismaWhere as jest.Mock).mockReturnValue(mockWhere);
+    (prisma.record.findMany as jest.Mock).mockResolvedValue(mockRecords);
+
+    const result = await getRecords(tableId, { filters });
+
+    expect(result).toEqual(mockRecords);
+    expect(convertFiltersToPrismaWhere).toHaveBeenCalledWith(filters);
+    expect(prisma.record.findMany).toHaveBeenCalledWith({
+      where: { tableId, ...mockWhere },
+      orderBy: { createdAt: 'desc' },
+    });
+  });
+
+  it('DATE型フィルタでレコードを取得できる', async () => {
+    const tableId = 'table-1';
+    const filters: ExportColumnFilter[] = [
+      {
+        id: 'birthday',
+        value: {
+          preset: 'custom',
+          startDate: '2024-01-01',
+          endDate: '2024-12-31',
+        },
+      },
+    ];
+    const mockRecords = [
+      {
+        id: 'record-1',
+        tableId,
+        data: { birthday: '2024-06-15' },
+        createdById: 'user-1',
+        createdAt: new Date('2024-01-01'),
+        updatedAt: new Date('2024-01-01'),
+      },
+    ];
+
+    const mockWhere = {
+      AND: [
+        { data: { path: ['birthday'], gte: '2024-01-01' } },
+        { data: { path: ['birthday'], lte: '2024-12-31' } },
+      ],
+    };
+    (convertFiltersToPrismaWhere as jest.Mock).mockReturnValue(mockWhere);
+    (prisma.record.findMany as jest.Mock).mockResolvedValue(mockRecords);
+
+    const result = await getRecords(tableId, { filters });
+
+    expect(result).toEqual(mockRecords);
+    expect(convertFiltersToPrismaWhere).toHaveBeenCalledWith(filters);
+    expect(prisma.record.findMany).toHaveBeenCalledWith({
+      where: { tableId, ...mockWhere },
+      orderBy: { createdAt: 'desc' },
+    });
+  });
+
+  it('SELECT型フィルタでレコードを取得できる', async () => {
+    const tableId = 'table-1';
+    const filters: ExportColumnFilter[] = [
+      { id: 'status', value: ['active', 'pending'] },
+    ];
+    const mockRecords = [
+      {
+        id: 'record-1',
+        tableId,
+        data: { status: 'active' },
+        createdById: 'user-1',
+        createdAt: new Date('2024-01-01'),
+        updatedAt: new Date('2024-01-01'),
+      },
+    ];
+
+    const mockWhere = {
+      OR: [
+        { data: { path: ['status'], equals: 'active' } },
+        { data: { path: ['status'], equals: 'pending' } },
+      ],
+    };
+    (convertFiltersToPrismaWhere as jest.Mock).mockReturnValue(mockWhere);
+    (prisma.record.findMany as jest.Mock).mockResolvedValue(mockRecords);
+
+    const result = await getRecords(tableId, { filters });
+
+    expect(result).toEqual(mockRecords);
+    expect(convertFiltersToPrismaWhere).toHaveBeenCalledWith(filters);
+    expect(prisma.record.findMany).toHaveBeenCalledWith({
+      where: { tableId, ...mockWhere },
+      orderBy: { createdAt: 'desc' },
+    });
+  });
+
+  it('CHECKBOX型フィルタ（checked）でレコードを取得できる', async () => {
+    const tableId = 'table-1';
+    const filters: ExportColumnFilter[] = [
+      { id: 'isActive', value: 'checked' },
+    ];
+    const mockRecords = [
+      {
+        id: 'record-1',
+        tableId,
+        data: { isActive: true },
+        createdById: 'user-1',
+        createdAt: new Date('2024-01-01'),
+        updatedAt: new Date('2024-01-01'),
+      },
+    ];
+
+    const mockWhere = { data: { path: ['isActive'], equals: true } };
+    (convertFiltersToPrismaWhere as jest.Mock).mockReturnValue(mockWhere);
+    (prisma.record.findMany as jest.Mock).mockResolvedValue(mockRecords);
+
+    const result = await getRecords(tableId, { filters });
+
+    expect(result).toEqual(mockRecords);
+    expect(convertFiltersToPrismaWhere).toHaveBeenCalledWith(filters);
+    expect(prisma.record.findMany).toHaveBeenCalledWith({
+      where: { tableId, ...mockWhere },
+      orderBy: { createdAt: 'desc' },
+    });
+  });
+
+  it('CHECKBOX型フィルタ（unchecked）でレコードを取得できる', async () => {
+    const tableId = 'table-1';
+    const filters: ExportColumnFilter[] = [
+      { id: 'isActive', value: 'unchecked' },
+    ];
+    const mockRecords = [
+      {
+        id: 'record-1',
+        tableId,
+        data: { isActive: false },
+        createdById: 'user-1',
+        createdAt: new Date('2024-01-01'),
+        updatedAt: new Date('2024-01-01'),
+      },
+    ];
+
+    const mockWhere = { data: { path: ['isActive'], equals: false } };
+    (convertFiltersToPrismaWhere as jest.Mock).mockReturnValue(mockWhere);
+    (prisma.record.findMany as jest.Mock).mockResolvedValue(mockRecords);
+
+    const result = await getRecords(tableId, { filters });
+
+    expect(result).toEqual(mockRecords);
+    expect(convertFiltersToPrismaWhere).toHaveBeenCalledWith(filters);
+    expect(prisma.record.findMany).toHaveBeenCalledWith({
+      where: { tableId, ...mockWhere },
+      orderBy: { createdAt: 'desc' },
+    });
+  });
+
+  it('複数の異なる型のフィルタを組み合わせてレコードを取得できる', async () => {
+    const tableId = 'table-1';
+    const filters: ExportColumnFilter[] = [
+      { id: 'name', value: 'テスト' },
+      { id: 'age', value: { operator: 'gte', value1: 20, value2: null } },
+      { id: 'isActive', value: 'checked' },
+    ];
+    const mockRecords = [
+      {
+        id: 'record-1',
+        tableId,
+        data: { name: 'テスト1', age: 25, isActive: true },
+        createdById: 'user-1',
+        createdAt: new Date('2024-01-01'),
+        updatedAt: new Date('2024-01-01'),
+      },
+    ];
+
+    const mockWhere = {
+      AND: [
+        { data: { path: ['name'], string_contains: 'テスト' } },
+        { data: { path: ['age'], gte: 20 } },
+        { data: { path: ['isActive'], equals: true } },
+      ],
+    };
+    (convertFiltersToPrismaWhere as jest.Mock).mockReturnValue(mockWhere);
+    (prisma.record.findMany as jest.Mock).mockResolvedValue(mockRecords);
+
+    const result = await getRecords(tableId, { filters });
+
+    expect(result).toEqual(mockRecords);
+    expect(convertFiltersToPrismaWhere).toHaveBeenCalledWith(filters);
+    expect(prisma.record.findMany).toHaveBeenCalledWith({
+      where: { tableId, ...mockWhere },
+      orderBy: { createdAt: 'desc' },
+    });
+  });
 });

--- a/features/record/api/get-records.ts
+++ b/features/record/api/get-records.ts
@@ -2,21 +2,14 @@
 
 import { prisma } from '@/lib/prisma';
 import type { Record } from '../types';
-import type {
-  ExportColumnFilter,
-  ExportSorting,
-} from '@/features/table/types/export';
-import {
-  convertFiltersToPrismaWhere,
-  convertSortingToPrismaOrderBy,
-} from '@/features/table/utils/filter-converter';
+import type { ExportColumnFilter } from '@/features/table/types/export';
+import { convertFiltersToPrismaWhere } from '@/features/table/utils/filter-converter';
 
 /**
  * レコード取得オプション
  */
 type GetRecordsOptions = {
   filters?: ExportColumnFilter[];
-  sorting?: ExportSorting[];
 };
 
 /**
@@ -28,16 +21,15 @@ export async function getRecords(
 ): Promise<Record[]> {
   const { filters = [] } = options || {};
 
-  // フィルタ・ソート条件をPrisma形式に変換
+  // フィルタ条件をPrisma形式に変換
   const where = convertFiltersToPrismaWhere(filters);
-  const orderBy = convertSortingToPrismaOrderBy();
 
   const records = await prisma.record.findMany({
     where: {
       tableId,
       ...where,
     },
-    orderBy: orderBy.length > 0 ? orderBy : { createdAt: 'desc' },
+    orderBy: { createdAt: 'desc' },
   });
 
   // Prismaの`data: Json`フィールドは、カスタム型の`data: RecordData`と互換

--- a/features/record/api/get-records.ts
+++ b/features/record/api/get-records.ts
@@ -37,7 +37,7 @@ export async function getRecords(
       tableId,
       ...where,
     },
-    orderBy: orderBy.length > 0 ? orderBy : { createdAt: 'asc' },
+    orderBy: orderBy.length > 0 ? orderBy : { createdAt: 'desc' },
   });
 
   // Prismaの`data: Json`フィールドは、カスタム型の`data: RecordData`と互換

--- a/features/record/api/get-records.ts
+++ b/features/record/api/get-records.ts
@@ -2,14 +2,42 @@
 
 import { prisma } from '@/lib/prisma';
 import type { Record } from '../types';
+import type {
+  ExportColumnFilter,
+  ExportSorting,
+} from '@/features/table/types/export';
+import {
+  convertFiltersToPrismaWhere,
+  convertSortingToPrismaOrderBy,
+} from '@/features/table/utils/filter-converter';
+
+/**
+ * レコード取得オプション
+ */
+type GetRecordsOptions = {
+  filters?: ExportColumnFilter[];
+  sorting?: ExportSorting[];
+};
 
 /**
  * テーブルに紐づくレコード一覧を取得するServer Action
  */
-export async function getRecords(tableId: string): Promise<Record[]> {
+export async function getRecords(
+  tableId: string,
+  options?: GetRecordsOptions
+): Promise<Record[]> {
+  const { filters = [] } = options || {};
+
+  // フィルタ・ソート条件をPrisma形式に変換
+  const where = convertFiltersToPrismaWhere(filters);
+  const orderBy = convertSortingToPrismaOrderBy();
+
   const records = await prisma.record.findMany({
-    where: { tableId },
-    orderBy: { createdAt: 'asc' },
+    where: {
+      tableId,
+      ...where,
+    },
+    orderBy: orderBy.length > 0 ? orderBy : { createdAt: 'asc' },
   });
 
   // Prismaの`data: Json`フィールドは、カスタム型の`data: RecordData`と互換

--- a/features/table/actions/export-table.ts
+++ b/features/table/actions/export-table.ts
@@ -36,9 +36,9 @@ export async function exportTableAction(
     const data = record.data as RecordData;
     return columns.map((col) => {
       const value = data[col.id];
-      // Date型の場合はフォーマット
-      if (value instanceof Date) {
-        return value.toISOString().split('T')[0]; // YYYY-MM-DD
+      // DATE型カラムの場合はフォーマット（JSONから取得した値は文字列）
+      if (col.type === 'DATE' && typeof value === 'string') {
+        return value.split('T')[0]; // YYYY-MM-DD
       }
       return value as string | number | boolean | null | undefined;
     });

--- a/features/table/actions/export-table.ts
+++ b/features/table/actions/export-table.ts
@@ -25,8 +25,8 @@ export async function exportTableAction(
   const columnSchema = getColumnSchema(item.meta);
   const columns = columnSchema?.columns || [];
 
-  // フィルタ・ソート適用済みのレコードを取得
-  const records = await getRecords(itemId, { filters, sorting });
+  // フィルタ適用済みのレコードを取得
+  const records = await getRecords(itemId, { filters });
 
   // ヘッダー行を作成（カラム名）
   const headers = columns.map((col) => col.name);

--- a/features/table/actions/export-table.ts
+++ b/features/table/actions/export-table.ts
@@ -4,7 +4,7 @@ import { getRecords } from '@/features/record/api/get-records';
 import { getItemById } from '@/features/item/api';
 import { getColumnSchema } from '@/features/column/types/schema';
 import { convertToCSV } from '@/lib/csv';
-import type { ExportColumnFilter, ExportSorting } from '../types/export';
+import type { ExportColumnFilter } from '../types/export';
 import type { RecordData } from '@/features/record/types';
 
 /**
@@ -12,8 +12,7 @@ import type { RecordData } from '@/features/record/types';
  */
 export async function exportTableAction(
   itemId: string,
-  filters: ExportColumnFilter[],
-  sorting: ExportSorting[]
+  filters: ExportColumnFilter[]
 ) {
   // アイテム情報を取得
   const item = await getItemById(itemId);

--- a/features/table/actions/export-table.ts
+++ b/features/table/actions/export-table.ts
@@ -1,0 +1,64 @@
+'use server';
+
+import { getRecords } from '@/features/record/api/get-records';
+import { getItemById } from '@/features/item/api';
+import { getColumnSchema } from '@/features/column/types/schema';
+import { convertToCSV } from '@/lib/csv';
+import type { ExportColumnFilter, ExportSorting } from '../types/export';
+import type { RecordData } from '@/features/record/types';
+
+/**
+ * テーブルデータをCSVエクスポートするServer Action
+ */
+export async function exportTableAction(
+  itemId: string,
+  filters: ExportColumnFilter[],
+  sorting: ExportSorting[]
+) {
+  // アイテム情報を取得
+  const item = await getItemById(itemId);
+  if (!item || item.type !== 'TABLE') {
+    return { error: 'テーブルが見つかりません' };
+  }
+
+  // カラム定義を取得
+  const columnSchema = getColumnSchema(item.meta);
+  const columns = columnSchema?.columns || [];
+
+  // フィルタ・ソート適用済みのレコードを取得
+  const records = await getRecords(itemId, { filters, sorting });
+
+  // ヘッダー行を作成（カラム名）
+  const headers = columns.map((col) => col.name);
+
+  // データ行を作成
+  const rows = records.map((record) => {
+    const data = record.data as RecordData;
+    return columns.map((col) => {
+      const value = data[col.id];
+      // Date型の場合はフォーマット
+      if (value instanceof Date) {
+        return value.toISOString().split('T')[0]; // YYYY-MM-DD
+      }
+      return value as string | number | boolean | null | undefined;
+    });
+  });
+
+  // CSV変換
+  const csv = convertToCSV(headers, rows);
+
+  // タイムスタンプ付きファイル名を生成
+  const timestamp = new Date()
+    .toLocaleString('ja-JP', {
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+      hour: '2-digit',
+      minute: '2-digit',
+      second: '2-digit',
+    })
+    .replace(/[/:\s]/g, '-');
+  const filename = `${item.name}_${timestamp}.csv`;
+
+  return { csv, filename };
+}

--- a/features/table/components/data-table.tsx
+++ b/features/table/components/data-table.tsx
@@ -39,7 +39,6 @@ import { createRecord } from '@/features/record/api/create-record';
 import { applyDefaultValues } from '@/features/column/utils';
 import { hasPermission } from '@/lib/permissions';
 import { useLocalStorage } from '@/hooks/use-local-storage';
-import { exportTableToCSV } from '@/lib/table-export';
 import { createColumns } from './columns';
 import { BulkDeleteButton } from './bulk-delete-button';
 import { FilterButton } from './filter-button';
@@ -55,7 +54,8 @@ type DataTableProps = {
   initialRecords: Record[];
   relationRecords: Map<string, RelationRecord[]>;
   permissionLevel: Permission;
-  onExportCSV?: (exportFn: () => void) => void;
+  initialFilters?: ColumnFiltersState;
+  initialSorting?: SortingState;
 };
 
 /**
@@ -63,12 +63,12 @@ type DataTableProps = {
  */
 export function DataTable({
   tableId,
-  tableName,
   columns,
   initialRecords,
   relationRecords,
   permissionLevel,
-  onExportCSV,
+  initialFilters = [],
+  initialSorting = [],
 }: DataTableProps) {
   const [records, setRecords] = useState<Record[]>(initialRecords);
   const [isPending, startTransition] = useTransition();
@@ -77,12 +77,11 @@ export function DataTable({
   // localStorageに保存するテーブル状態
   const [columnVisibilityRaw, setColumnVisibility] =
     useLocalStorage<VisibilityState>(`table-${tableId}-column-visibility`, {});
-  const [sortingRaw, setSorting] = useLocalStorage<SortingState>(
-    `table-${tableId}-sorting`,
-    []
-  );
-  const [columnFiltersRaw, setColumnFilters] =
-    useLocalStorage<ColumnFiltersState>(`table-${tableId}-filters`, []);
+
+  // フィルタとソートの状態をクライアント側で管理（即座に反映）
+  const [sorting, setSorting] = useState<SortingState>(initialSorting);
+  const [columnFilters, setColumnFilters] =
+    useState<ColumnFiltersState>(initialFilters);
 
   // initialRecordsをrefで保持して、handleCellChangeの依存配列から除外する
   const initialRecordsRef = useRef(initialRecords);
@@ -90,7 +89,7 @@ export function DataTable({
     initialRecordsRef.current = initialRecords;
   }, [initialRecords]);
 
-  // カラム構成変更時に古い状態をクリーンアップ（同期処理）
+  // カラム構成変更時に古い状態をクリーンアップ
   const validColumnIds = useMemo(
     () => new Set(columns.map((c) => c.id)),
     [columns]
@@ -106,15 +105,6 @@ export function DataTable({
     return validVisibility;
   }, [columnVisibilityRaw, validColumnIds]);
 
-  const sorting = useMemo(() => {
-    return sortingRaw.filter((s) => validColumnIds.has(s.id));
-  }, [sortingRaw, validColumnIds]);
-
-  const columnFilters = useMemo(() => {
-    return columnFiltersRaw.filter((f) => validColumnIds.has(f.id));
-  }, [columnFiltersRaw, validColumnIds]);
-
-  // クリーンアップされた状態をlocalStorageに保存
   useEffect(() => {
     if (
       JSON.stringify(columnVisibility) !== JSON.stringify(columnVisibilityRaw)
@@ -122,18 +112,6 @@ export function DataTable({
       setColumnVisibility(columnVisibility);
     }
   }, [columnVisibility, columnVisibilityRaw, setColumnVisibility]);
-
-  useEffect(() => {
-    if (JSON.stringify(sorting) !== JSON.stringify(sortingRaw)) {
-      setSorting(sorting);
-    }
-  }, [sorting, sortingRaw, setSorting]);
-
-  useEffect(() => {
-    if (JSON.stringify(columnFilters) !== JSON.stringify(columnFiltersRaw)) {
-      setColumnFilters(columnFilters);
-    }
-  }, [columnFilters, columnFiltersRaw, setColumnFilters]);
 
   // WRITE権限があるかチェック
   const canWrite = hasPermission(permissionLevel, 'WRITE');
@@ -229,6 +207,7 @@ export function DataTable({
     onColumnVisibilityChange: setColumnVisibility,
     onSortingChange: setSorting,
     onColumnFiltersChange: setColumnFilters,
+    enableSortingRemoval: true,
     state: {
       rowSelection,
       columnVisibility,
@@ -240,16 +219,6 @@ export function DataTable({
   // 選択されたレコードのID一覧
   const selectedRows = table.getFilteredSelectedRowModel().rows;
   const selectedRecordIds = selectedRows.map((row) => row.original.id);
-
-  // CSVエクスポート関数
-  const handleExportCSV = useCallback(() => {
-    exportTableToCSV(table, tableName);
-  }, [table, tableName]);
-
-  // エクスポート関数を親コンポーネントに渡す
-  useEffect(() => {
-    onExportCSV?.(() => handleExportCSV);
-  }, [onExportCSV, handleExportCSV]);
 
   return (
     <div className="w-full h-full flex flex-col">

--- a/features/table/components/data-table.tsx
+++ b/features/table/components/data-table.tsx
@@ -53,8 +53,7 @@ type DataTableProps = {
   initialRecords: Record[];
   relationRecords: Map<string, RelationRecord[]>;
   permissionLevel: Permission;
-  initialFilters?: ColumnFiltersState;
-  initialSorting?: SortingState;
+  initialFilters?: { id: string; value: unknown }[];
 };
 
 /**
@@ -67,7 +66,6 @@ export function DataTable({
   relationRecords,
   permissionLevel,
   initialFilters = [],
-  initialSorting = [],
 }: DataTableProps) {
   const [records, setRecords] = useState<Record[]>(initialRecords);
   const [isPending, startTransition] = useTransition();
@@ -78,9 +76,12 @@ export function DataTable({
     useLocalStorage<VisibilityState>(`table-${tableId}-column-visibility`, {});
 
   // フィルタとソートの状態をクライアント側で管理（即座に反映）
-  const [sorting, setSorting] = useState<SortingState>(initialSorting);
-  const [columnFilters, setColumnFilters] =
-    useState<ColumnFiltersState>(initialFilters);
+  // ソート: クライアントサイドのみ（初期値なし）
+  // フィルタ: サーバーサイド処理（URLパラメータから初期値を取得）
+  const [sorting, setSorting] = useState<SortingState>([]);
+  const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>(
+    initialFilters?.map((f) => ({ id: f.id, value: f.value })) || []
+  );
 
   // initialRecordsをrefで保持して、handleCellChangeの依存配列から除外する
   const initialRecordsRef = useRef(initialRecords);

--- a/features/table/components/data-table.tsx
+++ b/features/table/components/data-table.tsx
@@ -49,7 +49,6 @@ import { ColumnVisibilityButton } from './column-visibility-button';
  */
 type DataTableProps = {
   tableId: string;
-  tableName: string;
   columns: Column[];
   initialRecords: Record[];
   relationRecords: Map<string, RelationRecord[]>;

--- a/features/table/components/data-table.tsx
+++ b/features/table/components/data-table.tsx
@@ -264,7 +264,7 @@ export function DataTable({
 
       {/* テーブル */}
       <ScrollArea className="border-y **:data-[slot=table-container]:overflow-visible">
-        <Table className="table-auto w-max">
+        <Table className="table-auto w-full">
           <TableHeader>
             {table.getHeaderGroups().map((headerGroup) => (
               <TableRow key={headerGroup.id}>

--- a/features/table/components/data-table.tsx
+++ b/features/table/components/data-table.tsx
@@ -39,6 +39,7 @@ import { createRecord } from '@/features/record/api/create-record';
 import { applyDefaultValues } from '@/features/column/utils';
 import { hasPermission } from '@/lib/permissions';
 import { useLocalStorage } from '@/hooks/use-local-storage';
+import { exportTableToCSV } from '@/lib/table-export';
 import { createColumns } from './columns';
 import { BulkDeleteButton } from './bulk-delete-button';
 import { FilterButton } from './filter-button';
@@ -49,10 +50,12 @@ import { ColumnVisibilityButton } from './column-visibility-button';
  */
 type DataTableProps = {
   tableId: string;
+  tableName: string;
   columns: Column[];
   initialRecords: Record[];
   relationRecords: Map<string, RelationRecord[]>;
   permissionLevel: Permission;
+  onExportCSV?: (exportFn: () => void) => void;
 };
 
 /**
@@ -60,10 +63,12 @@ type DataTableProps = {
  */
 export function DataTable({
   tableId,
+  tableName,
   columns,
   initialRecords,
   relationRecords,
   permissionLevel,
+  onExportCSV,
 }: DataTableProps) {
   const [records, setRecords] = useState<Record[]>(initialRecords);
   const [isPending, startTransition] = useTransition();
@@ -235,6 +240,16 @@ export function DataTable({
   // 選択されたレコードのID一覧
   const selectedRows = table.getFilteredSelectedRowModel().rows;
   const selectedRecordIds = selectedRows.map((row) => row.original.id);
+
+  // CSVエクスポート関数
+  const handleExportCSV = useCallback(() => {
+    exportTableToCSV(table, tableName);
+  }, [table, tableName]);
+
+  // エクスポート関数を親コンポーネントに渡す
+  useEffect(() => {
+    onExportCSV?.(() => handleExportCSV);
+  }, [onExportCSV, handleExportCSV]);
 
   return (
     <div className="w-full h-full flex flex-col">

--- a/features/table/components/filter-button.tsx
+++ b/features/table/components/filter-button.tsx
@@ -150,7 +150,7 @@ export function FilterButton({
           <Tooltip>
             <TooltipTrigger asChild>
               <DropdownMenuTrigger asChild>
-                <Button variant="ghost">
+                <Button variant="ghost" size="icon">
                   <Settings2 />
                 </Button>
               </DropdownMenuTrigger>

--- a/features/table/components/filter-button.tsx
+++ b/features/table/components/filter-button.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useTransition } from 'react';
+import { useRouter, usePathname, useSearchParams } from 'next/navigation';
 import { Settings2, ChevronDown, X } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
@@ -65,7 +66,29 @@ export function FilterButton({
   onColumnFiltersChange,
   relationRecords,
 }: FilterButtonProps) {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const [, startTransition] = useTransition();
   const [isOpen, setIsOpen] = useState(false);
+
+  // フィルター更新とURL同期
+  const updateFilters = (newFilters: ColumnFiltersState) => {
+    // 即座にクライアント側のフィルタを更新（リロードなし）
+    onColumnFiltersChange(newFilters);
+
+    // バックグラウンドでURLを更新（状態の永続化）
+    const params = new URLSearchParams(searchParams.toString());
+    if (newFilters.length > 0) {
+      params.set('filters', JSON.stringify(newFilters));
+    } else {
+      params.delete('filters');
+    }
+
+    startTransition(() => {
+      router.replace(`${pathname}?${params.toString()}`, { scroll: false });
+    });
+  };
 
   // フィルター有効なカラムのみ取得
   const filterableColumns = columns.filter(
@@ -118,10 +141,11 @@ export function FilterButton({
         break;
     }
 
-    onColumnFiltersChange([
+    const newFilters = [
       ...columnFilters,
       { id: columnId, value: initialValue },
-    ]);
+    ];
+    updateFilters(newFilters);
     setIsOpen(false);
   };
 
@@ -133,13 +157,14 @@ export function FilterButton({
     if (existingFilterIndex >= 0) {
       const newFilters = [...columnFilters];
       newFilters[existingFilterIndex] = { id: columnId, value };
-      onColumnFiltersChange(newFilters);
+      updateFilters(newFilters);
     }
   };
 
   // フィルター削除
   const removeFilter = (columnId: string) => {
-    onColumnFiltersChange(columnFilters.filter((f) => f.id !== columnId));
+    const newFilters = columnFilters.filter((f) => f.id !== columnId);
+    updateFilters(newFilters);
   };
 
   return (

--- a/features/table/components/sortable-header.tsx
+++ b/features/table/components/sortable-header.tsx
@@ -1,8 +1,11 @@
 'use client';
 
+import { useTransition } from 'react';
 import { Column } from '@tanstack/react-table';
+import { useRouter, usePathname, useSearchParams } from 'next/navigation';
 import { ArrowDown, ArrowUp, ArrowUpDown } from 'lucide-react';
 import { Button } from '@/components/ui/button';
+import type { ExportSorting } from '@/features/table/types/export';
 
 type SortableHeaderProps<TData> = {
   column: Column<TData, unknown>;
@@ -16,6 +19,11 @@ export function SortableHeader<TData>({
   column,
   title,
 }: SortableHeaderProps<TData>) {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const [, startTransition] = useTransition();
+
   if (!column.getCanSort()) {
     return <div>{title}</div>;
   }
@@ -23,13 +31,45 @@ export function SortableHeader<TData>({
   const sorted = column.getIsSorted();
 
   const handleClick = () => {
-    if (sorted === 'asc') {
-      column.toggleSorting(true); // 降順へ
-    } else if (sorted === 'desc') {
-      column.clearSorting(); // ソート解除
+    // 3段階のソート切り替え: なし → asc → desc → なし
+    let newSortDirection: false | 'asc' | 'desc';
+
+    if (!sorted) {
+      newSortDirection = 'asc';
+    } else if (sorted === 'asc') {
+      newSortDirection = 'desc';
     } else {
-      column.toggleSorting(false); // 昇順へ
+      newSortDirection = false;
     }
+
+    // TanStack Tableの状態を更新（即座に反映）
+    if (newSortDirection === false) {
+      column.clearSorting();
+    } else {
+      column.toggleSorting(newSortDirection === 'desc');
+    }
+
+    // バックグラウンドでURLを更新（状態の永続化）
+    const params = new URLSearchParams(searchParams.toString());
+    let newSorting: ExportSorting[];
+
+    if (newSortDirection === 'asc') {
+      newSorting = [{ id: column.id, desc: false }];
+    } else if (newSortDirection === 'desc') {
+      newSorting = [{ id: column.id, desc: true }];
+    } else {
+      newSorting = [];
+    }
+
+    if (newSorting.length > 0) {
+      params.set('sorting', JSON.stringify(newSorting));
+    } else {
+      params.delete('sorting');
+    }
+
+    startTransition(() => {
+      router.replace(`${pathname}?${params.toString()}`, { scroll: false });
+    });
   };
 
   return (

--- a/features/table/components/table-layout.tsx
+++ b/features/table/components/table-layout.tsx
@@ -1,6 +1,9 @@
+'use client';
+
 import type { Permission } from '@prisma/client';
 import type { Column, RelationRecord } from '@/features/column/types';
 import type { Record } from '@/features/record/types';
+import { useExport } from '@/features/layout/providers/export-provider';
 import { DataTable } from './data-table';
 
 /**
@@ -26,6 +29,8 @@ export function TableLayout({
   relationRecords,
   permissionLevel,
 }: TableLayoutProps) {
+  const { setExportFn } = useExport();
+
   return (
     <div className="w-full p-6">
       <div className="mb-6 flex items-center justify-between">
@@ -34,10 +39,12 @@ export function TableLayout({
 
       <DataTable
         tableId={itemId}
+        tableName={itemName}
         columns={columns}
         initialRecords={records}
         relationRecords={relationRecords}
         permissionLevel={permissionLevel}
+        onExportCSV={setExportFn}
       />
     </div>
   );

--- a/features/table/components/table-layout.tsx
+++ b/features/table/components/table-layout.tsx
@@ -3,10 +3,7 @@
 import type { Permission } from '@prisma/client';
 import type { Column, RelationRecord } from '@/features/column/types';
 import type { Record } from '@/features/record/types';
-import type {
-  ExportColumnFilter,
-  ExportSorting,
-} from '@/features/table/types/export';
+import type { ExportColumnFilter } from '@/features/table/types/export';
 import { DataTable } from './data-table';
 
 /**
@@ -20,7 +17,6 @@ type TableLayoutProps = {
   relationRecords: Map<string, RelationRecord[]>;
   permissionLevel: Permission;
   initialFilters?: ExportColumnFilter[];
-  initialSorting?: ExportSorting[];
 };
 
 /**
@@ -34,7 +30,6 @@ export function TableLayout({
   relationRecords,
   permissionLevel,
   initialFilters = [],
-  initialSorting = [],
 }: TableLayoutProps) {
   return (
     <div className="w-full p-6">
@@ -49,7 +44,6 @@ export function TableLayout({
         relationRecords={relationRecords}
         permissionLevel={permissionLevel}
         initialFilters={initialFilters}
-        initialSorting={initialSorting}
       />
     </div>
   );

--- a/features/table/components/table-layout.tsx
+++ b/features/table/components/table-layout.tsx
@@ -3,7 +3,10 @@
 import type { Permission } from '@prisma/client';
 import type { Column, RelationRecord } from '@/features/column/types';
 import type { Record } from '@/features/record/types';
-import { useExport } from '@/features/layout/providers/export-provider';
+import type {
+  ExportColumnFilter,
+  ExportSorting,
+} from '@/features/table/types/export';
 import { DataTable } from './data-table';
 
 /**
@@ -16,6 +19,8 @@ type TableLayoutProps = {
   records: Record[];
   relationRecords: Map<string, RelationRecord[]>;
   permissionLevel: Permission;
+  initialFilters?: ExportColumnFilter[];
+  initialSorting?: ExportSorting[];
 };
 
 /**
@@ -28,9 +33,9 @@ export function TableLayout({
   records,
   relationRecords,
   permissionLevel,
+  initialFilters = [],
+  initialSorting = [],
 }: TableLayoutProps) {
-  const { setExportFn } = useExport();
-
   return (
     <div className="w-full p-6">
       <div className="mb-6 flex items-center justify-between">
@@ -44,7 +49,8 @@ export function TableLayout({
         initialRecords={records}
         relationRecords={relationRecords}
         permissionLevel={permissionLevel}
-        onExportCSV={setExportFn}
+        initialFilters={initialFilters}
+        initialSorting={initialSorting}
       />
     </div>
   );

--- a/features/table/components/table-layout.tsx
+++ b/features/table/components/table-layout.tsx
@@ -44,7 +44,6 @@ export function TableLayout({
 
       <DataTable
         tableId={itemId}
-        tableName={itemName}
         columns={columns}
         initialRecords={records}
         relationRecords={relationRecords}

--- a/features/table/types/export.ts
+++ b/features/table/types/export.ts
@@ -1,0 +1,23 @@
+/**
+ * TanStack Tableのフィルタ条件
+ */
+export type ExportColumnFilter = {
+  id: string;
+  value: unknown;
+};
+
+/**
+ * TanStack Tableのソート条件
+ */
+export type ExportSorting = {
+  id: string;
+  desc: boolean;
+};
+
+/**
+ * エクスポートオプション
+ */
+export type ExportOptions = {
+  filters?: ExportColumnFilter[];
+  sorting?: ExportSorting[];
+};

--- a/features/table/utils/filter-converter.ts
+++ b/features/table/utils/filter-converter.ts
@@ -1,0 +1,281 @@
+import type { Prisma } from '@prisma/client';
+import type { ExportColumnFilter } from '../types/export';
+
+/**
+ * 数値フィルタの値型
+ */
+type NumberFilterValue = {
+  operator: 'eq' | 'ne' | 'gt' | 'gte' | 'lt' | 'lte' | 'range';
+  value1: number | null;
+  value2: number | null;
+};
+
+/**
+ * 日付フィルタの値型
+ */
+type DateFilterValue = {
+  preset: string;
+  startDate: string | null;
+  endDate: string | null;
+};
+
+/**
+ * TanStack TableのフィルタをPrisma WHERE条件に変換
+ * 動的カラムはJSONフィールドとして検索
+ */
+export function convertFiltersToPrismaWhere(
+  filters: ExportColumnFilter[]
+): Prisma.RecordWhereInput {
+  if (!filters || filters.length === 0) {
+    return {};
+  }
+
+  const conditions: Prisma.RecordWhereInput[] = filters
+    .map((filter) => {
+      const { id, value } = filter;
+
+      // 空文字列や空配列の場合はフィルタしない
+      if (value === '' || (Array.isArray(value) && value.length === 0)) {
+        return null;
+      }
+
+      // テキストフィルタ: string
+      if (typeof value === 'string' && value.trim() !== '') {
+        return {
+          data: {
+            path: [id],
+            string_contains: value,
+          },
+        } as Prisma.RecordWhereInput;
+      }
+
+      // 数値フィルタ: NumberFilterValue
+      if (isNumberFilterValue(value)) {
+        return convertNumberFilter(id, value);
+      }
+
+      // 日付フィルタ: DateFilterValue
+      if (isDateFilterValue(value)) {
+        return convertDateFilter(id, value);
+      }
+
+      // 選択肢フィルタ (SELECT/RELATION): string[]
+      if (Array.isArray(value) && value.length > 0) {
+        return {
+          OR: value.map((v) => ({
+            data: {
+              path: [id],
+              equals: v,
+            },
+          })),
+        } as Prisma.RecordWhereInput;
+      }
+
+      // チェックボックスフィルタ: 'all' | 'checked' | 'unchecked'
+      if (value === 'checked') {
+        return {
+          data: {
+            path: [id],
+            equals: true,
+          },
+        } as Prisma.RecordWhereInput;
+      }
+      if (value === 'unchecked') {
+        return {
+          data: {
+            path: [id],
+            equals: false,
+          },
+        } as Prisma.RecordWhereInput;
+      }
+
+      // 'all' の場合はフィルタしない
+      return null;
+    })
+    .filter(
+      (condition): condition is Prisma.RecordWhereInput => condition !== null
+    );
+
+  if (conditions.length === 0) {
+    return {};
+  }
+
+  return { AND: conditions };
+}
+
+/**
+ * 型ガード: NumberFilterValue
+ */
+function isNumberFilterValue(value: unknown): value is NumberFilterValue {
+  if (typeof value !== 'object' || value === null) return false;
+  const v = value as Record<string, unknown>;
+  return (
+    'operator' in v &&
+    typeof v.operator === 'string' &&
+    'value1' in v &&
+    'value2' in v
+  );
+}
+
+/**
+ * 型ガード: DateFilterValue
+ */
+function isDateFilterValue(value: unknown): value is DateFilterValue {
+  if (typeof value !== 'object' || value === null) return false;
+  const v = value as Record<string, unknown>;
+  return (
+    'preset' in v &&
+    typeof v.preset === 'string' &&
+    'startDate' in v &&
+    'endDate' in v
+  );
+}
+
+/**
+ * 数値フィルタをPrisma条件に変換
+ */
+function convertNumberFilter(
+  id: string,
+  value: NumberFilterValue
+): Prisma.RecordWhereInput | null {
+  const { operator, value1, value2 } = value;
+
+  // 値が入力されていない場合はフィルタしない
+  if (value1 === null && operator !== 'range') {
+    return null;
+  }
+
+  switch (operator) {
+    case 'eq':
+      return {
+        data: {
+          path: [id],
+          equals: value1,
+        },
+      } as Prisma.RecordWhereInput;
+
+    case 'ne':
+      return {
+        data: {
+          path: [id],
+          not: value1,
+        },
+      } as Prisma.RecordWhereInput;
+
+    case 'gt':
+      return {
+        data: {
+          path: [id],
+          gt: value1,
+        },
+      } as Prisma.RecordWhereInput;
+
+    case 'gte':
+      return {
+        data: {
+          path: [id],
+          gte: value1,
+        },
+      } as Prisma.RecordWhereInput;
+
+    case 'lt':
+      return {
+        data: {
+          path: [id],
+          lt: value1,
+        },
+      } as Prisma.RecordWhereInput;
+
+    case 'lte':
+      return {
+        data: {
+          path: [id],
+          lte: value1,
+        },
+      } as Prisma.RecordWhereInput;
+
+    case 'range':
+      if (value1 === null && value2 === null) {
+        return null;
+      }
+      const rangeConditions: Prisma.RecordWhereInput[] = [];
+      if (value1 !== null) {
+        rangeConditions.push({
+          data: {
+            path: [id],
+            gte: value1,
+          },
+        } as Prisma.RecordWhereInput);
+      }
+      if (value2 !== null) {
+        rangeConditions.push({
+          data: {
+            path: [id],
+            lte: value2,
+          },
+        } as Prisma.RecordWhereInput);
+      }
+      return {
+        AND: rangeConditions,
+      } as Prisma.RecordWhereInput;
+
+    default:
+      return null;
+  }
+}
+
+/**
+ * 日付フィルタをPrisma条件に変換
+ */
+function convertDateFilter(
+  id: string,
+  value: DateFilterValue
+): Prisma.RecordWhereInput | null {
+  const { startDate, endDate } = value;
+
+  // 日付が入力されていない場合はフィルタしない
+  if (!startDate && !endDate) {
+    return null;
+  }
+
+  const dateConditions: Prisma.RecordWhereInput[] = [];
+
+  if (startDate) {
+    dateConditions.push({
+      data: {
+        path: [id],
+        gte: startDate,
+      },
+    } as Prisma.RecordWhereInput);
+  }
+
+  if (endDate) {
+    dateConditions.push({
+      data: {
+        path: [id],
+        lte: endDate,
+      },
+    } as Prisma.RecordWhereInput);
+  }
+
+  if (dateConditions.length === 0) {
+    return null;
+  }
+
+  return {
+    AND: dateConditions,
+  } as Prisma.RecordWhereInput;
+}
+
+/**
+ * TanStack TableのソートをPrisma ORDER BY条件に変換
+ *
+ * 注意: PrismaはJSONフィールドの動的ソートをサポートしていないため、
+ * ソートはクライアント側でのみ実行されます。
+ * サーバー側では createdAt でソートして全データを返します。
+ */
+export function convertSortingToPrismaOrderBy(): Prisma.RecordOrderByWithRelationInput[] {
+  // PrismaはJSONフィールドの動的ソートをサポートしていないため、
+  // 空配列を返してデフォルトソート（createdAt）を使用
+  return [];
+}

--- a/features/table/utils/filter-converter.ts
+++ b/features/table/utils/filter-converter.ts
@@ -194,7 +194,7 @@ function convertNumberFilter(
         },
       } as Prisma.RecordWhereInput;
 
-    case 'range':
+    case 'range': {
       if (value1 === null && value2 === null) {
         return null;
       }
@@ -218,6 +218,7 @@ function convertNumberFilter(
       return {
         AND: rangeConditions,
       } as Prisma.RecordWhereInput;
+    }
 
     default:
       return null;
@@ -265,17 +266,4 @@ function convertDateFilter(
   return {
     AND: dateConditions,
   } as Prisma.RecordWhereInput;
-}
-
-/**
- * TanStack TableのソートをPrisma ORDER BY条件に変換
- *
- * 注意: PrismaはJSONフィールドの動的ソートをサポートしていないため、
- * ソートはクライアント側でのみ実行されます。
- * サーバー側では createdAt でソートして全データを返します。
- */
-export function convertSortingToPrismaOrderBy(): Prisma.RecordOrderByWithRelationInput[] {
-  // PrismaはJSONフィールドの動的ソートをサポートしていないため、
-  // 空配列を返してデフォルトソート（createdAt）を使用
-  return [];
 }

--- a/features/user/actions/export-users.ts
+++ b/features/user/actions/export-users.ts
@@ -3,18 +3,12 @@
 import { prisma } from '@/lib/prisma';
 import { convertToCSV } from '@/lib/csv';
 import type { UserRole } from '@prisma/client';
-import type {
-  ExportColumnFilter,
-  ExportSorting,
-} from '@/features/table/types/export';
+import type { ExportColumnFilter } from '@/features/table/types/export';
 
 /**
  * ユーザーデータをCSVエクスポートするServer Action
  */
-export async function exportUsersAction(
-  filters: ExportColumnFilter[],
-  sorting: ExportSorting[]
-) {
+export async function exportUsersAction(filters: ExportColumnFilter[]) {
   // フィルタ条件を構築
   const where: {
     email?: { contains: string; mode: 'insensitive' };
@@ -35,24 +29,11 @@ export async function exportUsersAction(
     }
   });
 
-  // ソート条件を構築
-  const orderBy: Record<string, 'asc' | 'desc'>[] = [];
-  sorting.forEach((sort) => {
-    const { id, desc } = sort;
-    if (
-      id === 'email' ||
-      id === 'name' ||
-      id === 'role' ||
-      id === 'createdAt'
-    ) {
-      orderBy.push({ [id]: desc ? 'desc' : 'asc' });
-    }
-  });
-
   // ユーザーデータを取得
+  // 注: ソートはクライアントサイド（TanStack Table）で処理済み
   const users = await prisma.user.findMany({
     where,
-    orderBy: orderBy.length > 0 ? orderBy : { createdAt: 'desc' },
+    orderBy: { createdAt: 'desc' },
     select: {
       id: true,
       email: true,

--- a/features/user/actions/export-users.ts
+++ b/features/user/actions/export-users.ts
@@ -1,0 +1,92 @@
+'use server';
+
+import { prisma } from '@/lib/prisma';
+import { convertToCSV } from '@/lib/csv';
+import type {
+  ExportColumnFilter,
+  ExportSorting,
+} from '@/features/table/types/export';
+
+/**
+ * ユーザーデータをCSVエクスポートするServer Action
+ */
+export async function exportUsersAction(
+  filters: ExportColumnFilter[],
+  sorting: ExportSorting[]
+) {
+  // フィルタ条件を構築
+  const where: {
+    email?: { contains: string; mode: 'insensitive' };
+    name?: { contains: string; mode: 'insensitive' };
+    role?: string;
+  } = {};
+
+  filters.forEach((filter) => {
+    const { id, value } = filter;
+    if (typeof value === 'string' && value.trim() !== '') {
+      if (id === 'email') {
+        where.email = { contains: value, mode: 'insensitive' };
+      } else if (id === 'name') {
+        where.name = { contains: value, mode: 'insensitive' };
+      } else if (id === 'role') {
+        where.role = value;
+      }
+    }
+  });
+
+  // ソート条件を構築
+  const orderBy: Record<string, 'asc' | 'desc'>[] = [];
+  sorting.forEach((sort) => {
+    const { id, desc } = sort;
+    if (
+      id === 'email' ||
+      id === 'name' ||
+      id === 'role' ||
+      id === 'createdAt'
+    ) {
+      orderBy.push({ [id]: desc ? 'desc' : 'asc' });
+    }
+  });
+
+  // ユーザーデータを取得
+  const users = await prisma.user.findMany({
+    orderBy: orderBy.length > 0 ? orderBy : { createdAt: 'desc' },
+    select: {
+      id: true,
+      email: true,
+      name: true,
+      role: true,
+      createdAt: true,
+    },
+  });
+
+  // ヘッダー行を作成
+  const headers = ['ID', 'メールアドレス', '名前', 'ロール', '作成日'];
+
+  // データ行を作成
+  const rows = users.map((user) => [
+    user.id,
+    user.email,
+    user.name || '',
+    user.role,
+    user.createdAt.toISOString().split('T')[0], // YYYY-MM-DD
+  ]);
+
+  // CSV変換
+  const csv = convertToCSV(headers, rows);
+
+  // タイムスタンプ付きファイル名を生成
+  const timestamp = new Date()
+    .toLocaleString('ja-JP', {
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+      hour: '2-digit',
+      minute: '2-digit',
+      second: '2-digit',
+    })
+    .replace(/[/:\s]/g, '-');
+  const filename = `ユーザー管理_${timestamp}.csv`;
+
+  return { csv, filename };
+}

--- a/features/user/actions/export-users.ts
+++ b/features/user/actions/export-users.ts
@@ -2,6 +2,7 @@
 
 import { prisma } from '@/lib/prisma';
 import { convertToCSV } from '@/lib/csv';
+import type { UserRole } from '@prisma/client';
 import type {
   ExportColumnFilter,
   ExportSorting,
@@ -18,7 +19,7 @@ export async function exportUsersAction(
   const where: {
     email?: { contains: string; mode: 'insensitive' };
     name?: { contains: string; mode: 'insensitive' };
-    role?: string;
+    role?: UserRole;
   } = {};
 
   filters.forEach((filter) => {
@@ -29,7 +30,7 @@ export async function exportUsersAction(
       } else if (id === 'name') {
         where.name = { contains: value, mode: 'insensitive' };
       } else if (id === 'role') {
-        where.role = value;
+        where.role = value as UserRole;
       }
     }
   });
@@ -50,6 +51,7 @@ export async function exportUsersAction(
 
   // ユーザーデータを取得
   const users = await prisma.user.findMany({
+    where,
     orderBy: orderBy.length > 0 ? orderBy : { createdAt: 'desc' },
     select: {
       id: true,

--- a/features/user/components/index.ts
+++ b/features/user/components/index.ts
@@ -4,3 +4,4 @@ export * from './create-user-button';
 export * from './edit-user-item';
 export * from './delete-user-item';
 export * from './bulk-delete-button';
+export * from './users-layout';

--- a/features/user/components/user-table.tsx
+++ b/features/user/components/user-table.tsx
@@ -14,7 +14,6 @@ import {
 } from '@tanstack/react-table';
 import { Button } from '@/components/ui/button';
 import { useLocalStorage } from '@/hooks/use-local-storage';
-import { exportTableToCSV } from '@/lib/table-export';
 import { CreateUserButton } from './create-user-button';
 import { BulkDeleteButton } from './bulk-delete-button';
 import { createColumns } from './columns';
@@ -35,27 +34,29 @@ import type { User } from '../types';
  */
 type UserTableProps = {
   users: User[];
-  onExportCSV?: (exportFn: () => void) => void;
+  initialFilters?: ColumnFiltersState;
+  initialSorting?: SortingState;
 };
 
 /**
  * ユーザーテーブルコンポーネント
  */
-export function UserTable({ users, onExportCSV }: UserTableProps) {
+export function UserTable({
+  users,
+  initialFilters = [],
+  initialSorting = [],
+}: UserTableProps) {
   const columns = createColumns();
   const [rowSelection, setRowSelection] = React.useState({});
 
   // localStorageに保存するテーブル状態
   const [columnVisibility, setColumnVisibility] =
     useLocalStorage<VisibilityState>('user-table-column-visibility', {});
-  const [sorting, setSorting] = useLocalStorage<SortingState>(
-    'user-table-sorting',
-    []
-  );
-  const [columnFilters, setColumnFilters] = useLocalStorage<ColumnFiltersState>(
-    'user-table-filters',
-    []
-  );
+
+  // フィルタとソートの状態をクライアント側で管理（即座に反映）
+  const [sorting, setSorting] = React.useState<SortingState>(initialSorting);
+  const [columnFilters, setColumnFilters] =
+    React.useState<ColumnFiltersState>(initialFilters);
 
   // eslint-disable-next-line react-hooks/incompatible-library
   const table = useReactTable({
@@ -69,6 +70,7 @@ export function UserTable({ users, onExportCSV }: UserTableProps) {
     getFilteredRowModel: getFilteredRowModel(),
     onColumnVisibilityChange: setColumnVisibility,
     onRowSelectionChange: setRowSelection,
+    enableSortingRemoval: true,
     state: {
       sorting,
       columnFilters,
@@ -83,16 +85,6 @@ export function UserTable({ users, onExportCSV }: UserTableProps) {
   const handleDeleteComplete = () => {
     table.resetRowSelection();
   };
-
-  // CSV エクスポート関数
-  const handleExportCSV = React.useCallback(() => {
-    exportTableToCSV(table, 'ユーザー管理');
-  }, [table]);
-
-  // エクスポート関数を親コンポーネントに登録
-  React.useEffect(() => {
-    onExportCSV?.(() => handleExportCSV);
-  }, [onExportCSV, handleExportCSV]);
 
   return (
     <div className="w-full">

--- a/features/user/components/user-table.tsx
+++ b/features/user/components/user-table.tsx
@@ -14,6 +14,7 @@ import {
 } from '@tanstack/react-table';
 import { Button } from '@/components/ui/button';
 import { useLocalStorage } from '@/hooks/use-local-storage';
+import { exportTableToCSV } from '@/lib/table-export';
 import { CreateUserButton } from './create-user-button';
 import { BulkDeleteButton } from './bulk-delete-button';
 import { createColumns } from './columns';
@@ -34,12 +35,13 @@ import type { User } from '../types';
  */
 type UserTableProps = {
   users: User[];
+  onExportCSV?: (exportFn: () => void) => void;
 };
 
 /**
  * ユーザーテーブルコンポーネント
  */
-export function UserTable({ users }: UserTableProps) {
+export function UserTable({ users, onExportCSV }: UserTableProps) {
   const columns = createColumns();
   const [rowSelection, setRowSelection] = React.useState({});
 
@@ -81,6 +83,16 @@ export function UserTable({ users }: UserTableProps) {
   const handleDeleteComplete = () => {
     table.resetRowSelection();
   };
+
+  // CSV エクスポート関数
+  const handleExportCSV = React.useCallback(() => {
+    exportTableToCSV(table, 'ユーザー管理');
+  }, [table]);
+
+  // エクスポート関数を親コンポーネントに登録
+  React.useEffect(() => {
+    onExportCSV?.(() => handleExportCSV);
+  }, [onExportCSV, handleExportCSV]);
 
   return (
     <div className="w-full">

--- a/features/user/components/users-layout.tsx
+++ b/features/user/components/users-layout.tsx
@@ -1,19 +1,23 @@
 'use client';
 
-import { useExport } from '@/features/layout/providers/export-provider';
 import { UserTable } from '@/features/user/components';
 import type { User } from '@/features/user/types';
+import type { ColumnFiltersState, SortingState } from '@tanstack/react-table';
 
 type UsersLayoutProps = {
   users: User[];
+  initialFilters?: ColumnFiltersState;
+  initialSorting?: SortingState;
 };
 
 /**
  * ユーザー管理ページのレイアウトコンポーネント
  */
-export function UsersLayout({ users }: UsersLayoutProps) {
-  const { setExportFn } = useExport();
-
+export function UsersLayout({
+  users,
+  initialFilters = [],
+  initialSorting = [],
+}: UsersLayoutProps) {
   return (
     <div className="flex flex-col gap-6 p-6">
       <div className="flex items-center justify-between">
@@ -22,7 +26,11 @@ export function UsersLayout({ users }: UsersLayoutProps) {
         </div>
       </div>
 
-      <UserTable users={users} onExportCSV={setExportFn} />
+      <UserTable
+        users={users}
+        initialFilters={initialFilters}
+        initialSorting={initialSorting}
+      />
     </div>
   );
 }

--- a/features/user/components/users-layout.tsx
+++ b/features/user/components/users-layout.tsx
@@ -1,0 +1,28 @@
+'use client';
+
+import { useExport } from '@/features/layout/providers/export-provider';
+import { UserTable } from '@/features/user/components';
+import type { User } from '@/features/user/types';
+
+type UsersLayoutProps = {
+  users: User[];
+};
+
+/**
+ * ユーザー管理ページのレイアウトコンポーネント
+ */
+export function UsersLayout({ users }: UsersLayoutProps) {
+  const { setExportFn } = useExport();
+
+  return (
+    <div className="flex flex-col gap-6 p-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold">ユーザー管理</h1>
+        </div>
+      </div>
+
+      <UserTable users={users} onExportCSV={setExportFn} />
+    </div>
+  );
+}

--- a/lib/csv.ts
+++ b/lib/csv.ts
@@ -1,0 +1,64 @@
+/**
+ * CSV出力用のユーティリティ関数
+ */
+
+/**
+ * 値をCSVセル用にエスケープする
+ */
+function escapeCsvCell(value: unknown): string {
+  if (value === null || value === undefined) {
+    return '';
+  }
+
+  const str = String(value);
+
+  // カンマ、改行、ダブルクォートを含む場合はダブルクォートで囲む
+  if (str.includes(',') || str.includes('\n') || str.includes('"')) {
+    // ダブルクォートは2つ重ねてエスケープ
+    return `"${str.replace(/"/g, '""')}"`;
+  }
+
+  return str;
+}
+
+/**
+ * データをCSV形式に変換する
+ * @param headers - ヘッダー行の配列
+ * @param rows - データ行の配列（各行は値の配列）
+ * @returns CSV形式の文字列
+ */
+export function convertToCSV(
+  headers: string[],
+  rows: (string | number | boolean | null | undefined)[][]
+): string {
+  const csvHeaders = headers.map(escapeCsvCell).join(',');
+  const csvRows = rows.map((row) => row.map(escapeCsvCell).join(','));
+
+  return [csvHeaders, ...csvRows].join('\n');
+}
+
+/**
+ * CSVファイルをダウンロードする
+ * @param csv - CSV形式の文字列
+ * @param filename - ダウンロードするファイル名
+ */
+export function downloadCSV(csv: string, filename: string): void {
+  // BOM付きUTF-8でエンコード（Excelで正しく開けるようにするため）
+  const bom = '\uFEFF';
+  const blob = new Blob([bom + csv], { type: 'text/csv;charset=utf-8;' });
+
+  // ダウンロード用のリンクを作成
+  const link = document.createElement('a');
+  const url = URL.createObjectURL(blob);
+
+  link.setAttribute('href', url);
+  link.setAttribute('download', filename);
+  link.style.visibility = 'hidden';
+
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+
+  // メモリリークを防ぐためURLを解放
+  URL.revokeObjectURL(url);
+}

--- a/lib/table-export.ts
+++ b/lib/table-export.ts
@@ -1,0 +1,55 @@
+import type { Table } from '@tanstack/react-table';
+import { convertToCSV, downloadCSV } from './csv';
+
+/**
+ * TanStack Tableからフィルター・ソート済みのデータをCSVエクスポートする
+ * @param table - TanStack Tableインスタンス
+ * @param tableName - エクスポートするテーブル名（ファイル名に使用）
+ */
+export function exportTableToCSV<TData>(
+  table: Table<TData>,
+  tableName: string
+): void {
+  const filteredRows = table.getFilteredRowModel().rows;
+  const visibleColumns = table
+    .getAllLeafColumns()
+    .filter(
+      (col) => col.getIsVisible() && col.id !== 'select' && col.id !== 'actions'
+    );
+
+  // ヘッダー行を取得
+  const headers = visibleColumns.map((col) => {
+    const columnDef = col.columnDef;
+    if (typeof columnDef.header === 'string') {
+      return columnDef.header;
+    }
+    return col.id;
+  });
+
+  // データ行を取得
+  const rows = filteredRows.map((row) => {
+    return visibleColumns.map((col) => {
+      const value = row.getValue(col.id);
+      // Date型の場合は日本語ロケールでフォーマット
+      if (value instanceof Date) {
+        return value.toLocaleString('ja-JP');
+      }
+      return value as string | number | boolean | null | undefined;
+    });
+  });
+
+  // CSV変換とダウンロード
+  const csv = convertToCSV(headers, rows);
+  const timestamp = new Date()
+    .toLocaleString('ja-JP', {
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+      hour: '2-digit',
+      minute: '2-digit',
+      second: '2-digit',
+    })
+    .replace(/[/:\s]/g, '-');
+  const filename = `${tableName}_${timestamp}.csv`;
+  downloadCSV(csv, filename);
+}

--- a/lib/table-export.ts
+++ b/lib/table-export.ts
@@ -30,9 +30,9 @@ export function exportTableToCSV<TData>(
   const rows = filteredRows.map((row) => {
     return visibleColumns.map((col) => {
       const value = row.getValue(col.id);
-      // Date型の場合は日本語ロケールでフォーマット
+      // Date型の場合はISO 8601形式でフォーマット
       if (value instanceof Date) {
-        return value.toLocaleString('ja-JP');
+        return value.toISOString().split('T')[0]; // YYYY-MM-DD
       }
       return value as string | number | boolean | null | undefined;
     });


### PR DESCRIPTION
## 概要

ユーザー管理ページとグループ管理ページにURL状態管理とフィルタ・ソート対応のエクスポート機能を追加しました。

## 変更内容

### URL状態管理の実装

#### ユーザー管理ページ
- `app/(protected)/users/page.tsx`: URLからfilters/sortingを取得
- `features/user/components/users-layout.tsx`: initialFilters/initialSortingをpropsで受け取り
- `features/user/components/user-table.tsx`: localStorageからuseStateに移行

#### グループ管理ページ
- `app/(protected)/groups/page.tsx`: URLからfilters/sortingを取得
- `features/group/components/groups-layout.tsx`: initialFilters/initialSortingをpropsで受け取り
- `features/group/components/group-table.tsx`: localStorageからuseStateに移行

### エクスポート機能の統一

#### Server Actions
- `features/user/actions/export-users.ts`: ユーザーエクスポート用Server Action
- `features/group/actions/export-groups.ts`: グループエクスポート用Server Action

#### 既存機能の修正
- `features/layout/components/item-options-button/index.tsx`: 全ページタイプで統一されたエクスポート処理
- ExportProviderの削除（7ファイルから削除）

### ソート機能の改善

- `features/table/components/sortable-header.tsx`: 3段階ソート（なし→asc→desc→なし）の実装
- `features/table/components/data-table.tsx`, `features/user/components/user-table.tsx`, `features/group/components/group-table.tsx`: `enableSortingRemoval: true` を追加

## アーキテクチャ

### URL状態管理フロー

1. ユーザーがソート/フィルターを操作
2. SortableHeader/FilterButtonがTanStack Tableの状態を即座に更新
3. バックグラウンドでrouter.replace()によりURLを更新
4. URL変更によりpage.tsxが再レンダリング
5. searchParamsからfilters/sortingを取得してLayoutに渡す
6. TableコンポーネントがuseStateで初期化

### フィルタ・ソート処理

#### フィルタ（サーバーサイド処理）
- URLから取得したフィルタ条件をPrismaクエリに変換
- PrismaのJSON検索機能で動的カラムのフィルタリングが可能
- `convertFiltersToPrismaWhere()` でWHERE条件を生成

#### ソート（クライアントサイド処理）
- TanStack Tableがメモリ上でソート処理
- PrismaはJSONフィールドの動的ソートに非対応のため
- サーバーサイドでは `createdAt: 'desc'` の固定ソートのみ実行
- URLでソート状態を永続化し、ページリロード時に復元

### エクスポート機能

- URLから現在のfilters/sortingを取得
- ページタイプ（TABLE/USERS/GROUPS）に応じたServer Actionを呼び出し
- サーバーサイドでフィルタを適用してレコード取得
- クライアントサイドのソート状態を反映してCSV生成・ダウンロード

## テスト

- [x] ユーザーページでソート・フィルター動作確認
- [x] グループページでソート・フィルター動作確認
- [x] ユーザーページでエクスポート動作確認
- [x] グループページでエクスポート動作確認
- [x] ソート解除（3段階）動作確認
- [x] URL共有でフィルタ状態が保持されることを確認

## 関連Issue

Closes #70


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * テーブル／ユーザー／グループのCSVエクスポート・インポートUIとサーバー側エクスポート機能を追加
  * レイアウトにアイテム用オプションボタンとエクスポート用プロバイダを導入
  * 各種表示用レイアウトコンポーネントを追加

* **UX改善**
  * フィルタとソートをURLで保持し初期表示に反映（3状態ソート対応、URL同期）
  * テーブルのフィルタ／ソート初期値を外部から注入可能に

* **バグ修正**
  * 既定ソート順を降順に統一

* **テスト**
  * フィルタ変換と取得動作の単体テストを追加

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->