### PR TITLE
ユーザー・グループテーブルをdata-tableと同じUI/UXに統一

### DIFF
--- a/features/column/components/config/select-config-editor.tsx
+++ b/features/column/components/config/select-config-editor.tsx
@@ -252,7 +252,8 @@ export function SelectConfigEditor({
   const handleToggleDefault = (id: string) => {
     let newDefaultValue: string | string[];
     if (localAllowMultiple) {
-      const current = (localDefaultValue as string[]) || [];
+      // 配列であることを保証（文字列の場合は配列に変換）
+      const current = Array.isArray(localDefaultValue) ? localDefaultValue : [];
       if (current.includes(id)) {
         newDefaultValue = current.filter((val) => val !== id);
       } else {

--- a/features/column/types/column.ts
+++ b/features/column/types/column.ts
@@ -79,7 +79,7 @@ export type ColumnTypeConfig = {
   SELECT: {
     options: SelectOption[];
     allowMultiple?: boolean; // 複数選択を許可（デフォルト: false）
-    defaultValue?: string | string[]; // デフォルト値（選択肢のIDまたはIDの配列）
+    defaultValue?: string | string[]; // デフォルト値（選択肢のIDまたはIDの配列。保存時は常に配列に変換される）
   };
   CHECKBOX: {
     checkedLabel?: string; // チェック時のラベル（例: 「完了」）

--- a/features/column/utils/apply-default-values.ts
+++ b/features/column/utils/apply-default-values.ts
@@ -15,9 +15,7 @@ export function applyDefaultValues(columns: Column[]): RecordData {
     } else if (column.type === 'TEXTAREA' && column.config?.defaultValue) {
       data[column.id] = column.config.defaultValue;
     } else if (column.type === 'SELECT' && column.config?.defaultValue) {
-      // SELECT型は常に配列形式で保存
-      const defaultValue = column.config.defaultValue;
-      data[column.id] = Array.isArray(defaultValue) ? defaultValue : [defaultValue];
+      data[column.id] = column.config.defaultValue;
     } else if (
       column.type === 'CHECKBOX' &&
       column.config?.defaultValue !== undefined

--- a/features/column/utils/apply-default-values.ts
+++ b/features/column/utils/apply-default-values.ts
@@ -15,7 +15,9 @@ export function applyDefaultValues(columns: Column[]): RecordData {
     } else if (column.type === 'TEXTAREA' && column.config?.defaultValue) {
       data[column.id] = column.config.defaultValue;
     } else if (column.type === 'SELECT' && column.config?.defaultValue) {
-      data[column.id] = column.config.defaultValue;
+      // SELECT型は常に配列形式で保存
+      const defaultValue = column.config.defaultValue;
+      data[column.id] = Array.isArray(defaultValue) ? defaultValue : [defaultValue];
     } else if (
       column.type === 'CHECKBOX' &&
       column.config?.defaultValue !== undefined

--- a/features/column/utils/normalize-column-value.ts
+++ b/features/column/utils/normalize-column-value.ts
@@ -1,0 +1,95 @@
+import type { Column } from '../types/column';
+
+/**
+ * カラムの値を正しい形式に正規化する
+ *
+ * 目的:
+ * - allowMultiple切り替え時の既存データとの互換性を保つ
+ * - データ取得時に早期に正規化することで、下流のコード（バリデーション、UI）を単純化
+ *
+ * 正規化ルール:
+ * - SELECT/RELATION型でallowMultiple=false: 値をstringに統一（配列なら最初の要素）
+ * - SELECT/RELATION型でallowMultiple=true: 値を配列に統一（文字列なら単一要素の配列）
+ */
+export function normalizeColumnValue(value: unknown, column: Column): unknown {
+  // null/undefinedはそのまま
+  if (value === null || value === undefined) {
+    return value;
+  }
+
+  // SELECT型の正規化
+  if (column.type === 'SELECT') {
+    const allowMultiple = column.config.allowMultiple || false;
+
+    if (allowMultiple) {
+      // 複数選択: 配列に統一
+      if (typeof value === 'string') {
+        return [value];
+      }
+      if (Array.isArray(value)) {
+        return value;
+      }
+      // 不正な型の場合はnullに
+      return null;
+    } else {
+      // 単一選択: 文字列に統一
+      if (typeof value === 'string') {
+        return value;
+      }
+      if (Array.isArray(value) && value.length > 0) {
+        // 配列の場合は最初の要素を使用
+        return value[0];
+      }
+      // 空配列や不正な型の場合はnullに
+      return null;
+    }
+  }
+
+  // RELATION型の正規化
+  if (column.type === 'RELATION') {
+    const allowMultiple = column.config.allowMultiple || false;
+
+    if (allowMultiple) {
+      // 複数参照: 配列に統一
+      if (typeof value === 'string') {
+        return [value];
+      }
+      if (Array.isArray(value)) {
+        return value;
+      }
+      // 不正な型の場合はnullに
+      return null;
+    } else {
+      // 単一参照: 文字列に統一
+      if (typeof value === 'string') {
+        return value;
+      }
+      if (Array.isArray(value) && value.length > 0) {
+        // 配列の場合は最初の要素を使用
+        return value[0];
+      }
+      // 空配列や不正な型の場合はnullに
+      return null;
+    }
+  }
+
+  // その他のカラムタイプはそのまま返す
+  return value;
+}
+
+/**
+ * レコードデータ全体を正規化
+ */
+export function normalizeRecordData(
+  data: Record<string, unknown>,
+  columns: Column[]
+): Record<string, unknown> {
+  const normalized: Record<string, unknown> = {};
+
+  for (const column of columns) {
+    const value = data[column.id];
+    normalized[column.id] = normalizeColumnValue(value, column);
+  }
+
+  return normalized;
+}

--- a/features/column/utils/validate-column-value.ts
+++ b/features/column/utils/validate-column-value.ts
@@ -214,6 +214,9 @@ function validateDateValue(
 
 /**
  * SELECT型のバリデーション
+ *
+ * NOTE: データ正規化は normalizeColumnValue() で事前に行われる想定。
+ * このバリデーションでは、正規化済みのデータに対して厳格にチェックを行う。
  */
 function validateSelectValue(
   value: unknown,
@@ -298,6 +301,9 @@ function validateCheckboxValue(
 
 /**
  * RELATION型のバリデーション
+ *
+ * NOTE: データ正規化は normalizeColumnValue() で事前に行われる想定。
+ * このバリデーションでは、正規化済みのデータに対して厳格にチェックを行う。
  */
 function validateRelationValue(
   value: unknown,
@@ -305,39 +311,24 @@ function validateRelationValue(
 ): ValidationError | null {
   const allowMultiple = column.config.allowMultiple || false;
 
-  // 単一参照の場合（文字列または配列を許容 - 互換性のため）
+  // 単一参照の場合
   if (!allowMultiple) {
-    // 文字列の場合
-    if (typeof value === 'string') {
-      return null;
+    if (typeof value !== 'string') {
+      return {
+        columnId: column.id,
+        columnName: column.name,
+        message: `${column.name}は文字列である必要があります`,
+      };
     }
-    // 配列の場合（allowMultiple切り替え時の互換性）
-    if (Array.isArray(value)) {
-      // 空配列はOK
-      if (value.length === 0) return null;
-      // すべて文字列ならOK
-      const invalidValues = value.filter((v) => typeof v !== 'string');
-      if (invalidValues.length === 0) return null;
-    }
-    return {
-      columnId: column.id,
-      columnName: column.name,
-      message: `${column.name}は文字列またはレコードIDの配列である必要があります`,
-    };
-  }
-
-  // 複数参照の場合（配列または文字列を許容 - 互換性のため）
-  // 文字列の場合（allowMultiple切り替え時の互換性）
-  if (typeof value === 'string') {
     return null;
   }
 
-  // 配列の場合
+  // 複数参照の場合
   if (!Array.isArray(value)) {
     return {
       columnId: column.id,
       columnName: column.name,
-      message: `${column.name}は配列またはレコードIDである必要があります`,
+      message: `${column.name}は配列である必要があります`,
     };
   }
 

--- a/features/column/utils/validate-column-value.ts
+++ b/features/column/utils/validate-column-value.ts
@@ -214,6 +214,7 @@ function validateDateValue(
 
 /**
  * SELECT型のバリデーション
+ * 注: 単一選択・複数選択に関わらず、常に配列形式で保存される
  */
 function validateSelectValue(
   value: unknown,
@@ -221,31 +222,7 @@ function validateSelectValue(
 ): ValidationError | null {
   const allowMultiple = column.config.allowMultiple || false;
 
-  // 単一選択の場合
-  if (!allowMultiple) {
-    if (typeof value !== 'string') {
-      return {
-        columnId: column.id,
-        columnName: column.name,
-        message: `${column.name}は文字列である必要があります`,
-      };
-    }
-
-    const validOptionIds = column.config.options.map((opt) => opt.id);
-
-    // 選択肢のIDにマッチしない場合はエラー
-    if (!validOptionIds.includes(value)) {
-      return {
-        columnId: column.id,
-        columnName: column.name,
-        message: `${column.name}は有効な選択肢から選んでください`,
-      };
-    }
-
-    return null;
-  }
-
-  // 複数選択の場合
+  // 配列でない場合はエラー
   if (!Array.isArray(value)) {
     return {
       columnId: column.id,
@@ -257,6 +234,15 @@ function validateSelectValue(
   // 空配列の場合はOK
   if (value.length === 0) {
     return null;
+  }
+
+  // 単一選択の場合、配列の長さは1まで
+  if (!allowMultiple && value.length > 1) {
+    return {
+      columnId: column.id,
+      columnName: column.name,
+      message: `${column.name}は1つまで選択できます`,
+    };
   }
 
   const validOptionIds = column.config.options.map((opt) => opt.id);

--- a/features/column/utils/validate-column-value.ts
+++ b/features/column/utils/validate-column-value.ts
@@ -214,7 +214,6 @@ function validateDateValue(
 
 /**
  * SELECT型のバリデーション
- * 注: 単一選択・複数選択に関わらず、常に配列形式で保存される
  */
 function validateSelectValue(
   value: unknown,
@@ -222,7 +221,31 @@ function validateSelectValue(
 ): ValidationError | null {
   const allowMultiple = column.config.allowMultiple || false;
 
-  // 配列でない場合はエラー
+  // 単一選択の場合
+  if (!allowMultiple) {
+    if (typeof value !== 'string') {
+      return {
+        columnId: column.id,
+        columnName: column.name,
+        message: `${column.name}は文字列である必要があります`,
+      };
+    }
+
+    const validOptionIds = column.config.options.map((opt) => opt.id);
+
+    // 選択肢のIDにマッチしない場合はエラー
+    if (!validOptionIds.includes(value)) {
+      return {
+        columnId: column.id,
+        columnName: column.name,
+        message: `${column.name}は有効な選択肢から選んでください`,
+      };
+    }
+
+    return null;
+  }
+
+  // 複数選択の場合
   if (!Array.isArray(value)) {
     return {
       columnId: column.id,
@@ -234,15 +257,6 @@ function validateSelectValue(
   // 空配列の場合はOK
   if (value.length === 0) {
     return null;
-  }
-
-  // 単一選択の場合、配列の長さは1まで
-  if (!allowMultiple && value.length > 1) {
-    return {
-      columnId: column.id,
-      columnName: column.name,
-      message: `${column.name}は1つまで選択できます`,
-    };
   }
 
   const validOptionIds = column.config.options.map((opt) => opt.id);
@@ -291,24 +305,39 @@ function validateRelationValue(
 ): ValidationError | null {
   const allowMultiple = column.config.allowMultiple || false;
 
-  // 単一参照の場合
+  // 単一参照の場合（文字列または配列を許容 - 互換性のため）
   if (!allowMultiple) {
-    if (typeof value !== 'string') {
-      return {
-        columnId: column.id,
-        columnName: column.name,
-        message: `${column.name}は文字列である必要があります`,
-      };
+    // 文字列の場合
+    if (typeof value === 'string') {
+      return null;
     }
+    // 配列の場合（allowMultiple切り替え時の互換性）
+    if (Array.isArray(value)) {
+      // 空配列はOK
+      if (value.length === 0) return null;
+      // すべて文字列ならOK
+      const invalidValues = value.filter((v) => typeof v !== 'string');
+      if (invalidValues.length === 0) return null;
+    }
+    return {
+      columnId: column.id,
+      columnName: column.name,
+      message: `${column.name}は文字列またはレコードIDの配列である必要があります`,
+    };
+  }
+
+  // 複数参照の場合（配列または文字列を許容 - 互換性のため）
+  // 文字列の場合（allowMultiple切り替え時の互換性）
+  if (typeof value === 'string') {
     return null;
   }
 
-  // 複数参照の場合
+  // 配列の場合
   if (!Array.isArray(value)) {
     return {
       columnId: column.id,
       columnName: column.name,
-      message: `${column.name}は配列である必要があります`,
+      message: `${column.name}は配列またはレコードIDである必要があります`,
     };
   }
 

--- a/features/group/actions/export-groups.ts
+++ b/features/group/actions/export-groups.ts
@@ -12,6 +12,7 @@ export async function exportGroupsAction(filters: ExportColumnFilter[]) {
   const where: {
     name?: { contains: string; mode: 'insensitive' };
     description?: { contains: string; mode: 'insensitive' };
+    parentId?: string | null;
   } = {};
 
   filters.forEach((filter) => {
@@ -21,6 +22,8 @@ export async function exportGroupsAction(filters: ExportColumnFilter[]) {
         where.name = { contains: value, mode: 'insensitive' };
       } else if (id === 'description') {
         where.description = { contains: value, mode: 'insensitive' };
+      } else if (id === 'parentId') {
+        where.parentId = value;
       }
     }
   });
@@ -35,6 +38,11 @@ export async function exportGroupsAction(filters: ExportColumnFilter[]) {
       name: true,
       description: true,
       createdAt: true,
+      parent: {
+        select: {
+          name: true,
+        },
+      },
       _count: {
         select: {
           members: true,
@@ -44,13 +52,21 @@ export async function exportGroupsAction(filters: ExportColumnFilter[]) {
   });
 
   // ヘッダー行を作成
-  const headers = ['ID', 'グループ名', '説明', 'メンバー数', '作成日'];
+  const headers = [
+    'ID',
+    'グループ名',
+    '説明',
+    '親グループ',
+    'メンバー数',
+    '作成日',
+  ];
 
   // データ行を作成
   const rows = groups.map((group) => [
     group.id,
     group.name,
     group.description || '',
+    group.parent?.name || '',
     group._count.members.toString(),
     group.createdAt.toISOString().split('T')[0], // YYYY-MM-DD
   ]);

--- a/features/group/components/columns.tsx
+++ b/features/group/components/columns.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState } from 'react';
-import { ColumnDef, FilterFn } from '@tanstack/react-table';
+import { ColumnDef } from '@tanstack/react-table';
 import { MoreHorizontal } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Checkbox } from '@/components/ui/checkbox';
@@ -11,6 +11,10 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import { SortableHeader } from '@/features/table/components/sortable-header';
+import {
+  createTextFilterFn,
+  createDateFilterFn,
+} from '@/features/table/utils/filter-functions';
 import { EditGroupOption } from './edit-group-option';
 import { DeleteGroupOption } from './delete-group-option';
 import { ManageMembersOption } from './manage-members-option';
@@ -25,40 +29,9 @@ type User = {
   name: string | null;
 };
 
-/**
- * テキストフィルタ関数
- */
-const textFilterFn: FilterFn<Group> = (row, columnId, filterValue) => {
-  const value = row.getValue(columnId) as string | null;
-  const search = filterValue as string;
-  if (!search) return true;
-  return (value || '').toLowerCase().includes(search.toLowerCase());
-};
-
-/**
- * DATEフィルタ関数
- */
-const dateFilterFn: FilterFn<Group> = (row, columnId, filterValue) => {
-  const value = row.getValue(columnId) as Date | string | null;
-  const filter = filterValue as {
-    preset?: string;
-    startDate: Date | null;
-    endDate: Date | null;
-  };
-  if (!value) return false;
-  if (!filter.startDate && !filter.endDate) return true;
-
-  const date = new Date(value);
-  const start = filter.startDate ? new Date(filter.startDate) : new Date(0);
-  const end = filter.endDate
-    ? new Date(filter.endDate)
-    : new Date(8640000000000000);
-
-  start.setHours(0, 0, 0, 0);
-  end.setHours(23, 59, 59, 999);
-
-  return date >= start && date <= end;
-};
+// フィルタ関数を生成
+const textFilterFn = createTextFilterFn<Group>();
+const dateFilterFn = createDateFilterFn<Group>();
 
 /**
  * グループテーブルのカラム定義を生成する関数

--- a/features/group/components/columns.tsx
+++ b/features/group/components/columns.tsx
@@ -96,14 +96,14 @@ export const createColumns = (
       <SortableHeader column={column} title="グループ名" />
     ),
     cell: ({ row }) => <div>{row.getValue('name')}</div>,
-    meta: { width: 'w-[15%]' },
+    meta: { width: 'w-[15%]', title: 'グループ名' },
     filterFn: textFilterFn,
   },
   {
     accessorKey: 'description',
     header: ({ column }) => <SortableHeader column={column} title="説明" />,
     cell: ({ row }) => <div>{row.getValue('description') || '-'}</div>,
-    meta: { width: 'w-[20%]' },
+    meta: { width: 'w-[20%]', title: '説明' },
     filterFn: textFilterFn,
   },
   {
@@ -115,7 +115,7 @@ export const createColumns = (
       const group = row.original;
       return <div>{group.parent?.name || '-'}</div>;
     },
-    meta: { width: 'w-[15%]' },
+    meta: { width: 'w-[15%]', title: '親グループ' },
   },
   {
     accessorKey: 'members',
@@ -126,7 +126,7 @@ export const createColumns = (
       const group = row.original;
       return <div>{group._count?.members || 0}人</div>;
     },
-    meta: { width: 'w-[15%]' },
+    meta: { width: 'w-[15%]', title: 'メンバー数' },
   },
   {
     accessorKey: 'createdAt',
@@ -135,7 +135,7 @@ export const createColumns = (
       const date = row.getValue('createdAt') as Date;
       return <div>{new Date(date).toLocaleDateString('ja-JP')}</div>;
     },
-    meta: { width: 'w-[15%]' },
+    meta: { width: 'w-[15%]', title: '作成日' },
     filterFn: dateFilterFn,
   },
   {

--- a/features/group/components/columns.tsx
+++ b/features/group/components/columns.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState } from 'react';
-import { ColumnDef } from '@tanstack/react-table';
+import { ColumnDef, FilterFn } from '@tanstack/react-table';
 import { MoreHorizontal } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Checkbox } from '@/components/ui/checkbox';
@@ -10,6 +10,7 @@ import {
   DropdownMenuContent,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
+import { SortableHeader } from '@/features/table/components/sortable-header';
 import { EditGroupOption } from './edit-group-option';
 import { DeleteGroupOption } from './delete-group-option';
 import { ManageMembersOption } from './manage-members-option';
@@ -22,6 +23,41 @@ type User = {
   id: string;
   email: string;
   name: string | null;
+};
+
+/**
+ * テキストフィルタ関数
+ */
+const textFilterFn: FilterFn<Group> = (row, columnId, filterValue) => {
+  const value = row.getValue(columnId) as string | null;
+  const search = filterValue as string;
+  if (!search) return true;
+  return (value || '').toLowerCase().includes(search.toLowerCase());
+};
+
+/**
+ * DATEフィルタ関数
+ */
+const dateFilterFn: FilterFn<Group> = (row, columnId, filterValue) => {
+  const value = row.getValue(columnId) as Date | string | null;
+  const filter = filterValue as {
+    preset?: string;
+    startDate: Date | null;
+    endDate: Date | null;
+  };
+  if (!value) return false;
+  if (!filter.startDate && !filter.endDate) return true;
+
+  const date = new Date(value);
+  const start = filter.startDate ? new Date(filter.startDate) : new Date(0);
+  const end = filter.endDate
+    ? new Date(filter.endDate)
+    : new Date(8640000000000000);
+
+  start.setHours(0, 0, 0, 0);
+  end.setHours(23, 59, 59, 999);
+
+  return date >= start && date <= end;
 };
 
 /**
@@ -56,19 +92,25 @@ export const createColumns = (
   },
   {
     accessorKey: 'name',
-    header: 'グループ名',
+    header: ({ column }) => (
+      <SortableHeader column={column} title="グループ名" />
+    ),
     cell: ({ row }) => <div>{row.getValue('name')}</div>,
     meta: { width: 'w-[15%]' },
+    filterFn: textFilterFn,
   },
   {
     accessorKey: 'description',
-    header: '説明',
+    header: ({ column }) => <SortableHeader column={column} title="説明" />,
     cell: ({ row }) => <div>{row.getValue('description') || '-'}</div>,
     meta: { width: 'w-[20%]' },
+    filterFn: textFilterFn,
   },
   {
     accessorKey: 'parentId',
-    header: '親グループ',
+    header: ({ column }) => (
+      <SortableHeader column={column} title="親グループ" />
+    ),
     cell: ({ row }) => {
       const group = row.original;
       return <div>{group.parent?.name || '-'}</div>;
@@ -77,7 +119,9 @@ export const createColumns = (
   },
   {
     accessorKey: 'members',
-    header: 'メンバー数',
+    header: ({ column }) => (
+      <SortableHeader column={column} title="メンバー数" />
+    ),
     cell: ({ row }) => {
       const group = row.original;
       return <div>{group._count?.members || 0}人</div>;
@@ -86,12 +130,13 @@ export const createColumns = (
   },
   {
     accessorKey: 'createdAt',
-    header: '作成日',
+    header: ({ column }) => <SortableHeader column={column} title="作成日" />,
     cell: ({ row }) => {
       const date = row.getValue('createdAt') as Date;
       return <div>{new Date(date).toLocaleDateString('ja-JP')}</div>;
     },
     meta: { width: 'w-[15%]' },
+    filterFn: dateFilterFn,
   },
   {
     id: 'actions',

--- a/features/group/components/group-table.tsx
+++ b/features/group/components/group-table.tsx
@@ -17,8 +17,9 @@ import { useLocalStorage } from '@/hooks/use-local-storage';
 import { CreateGroupButton } from './create-group-button';
 import { BulkDeleteButton } from './bulk-delete-button';
 import { createColumns } from './columns';
-import { Input } from '@/components/ui/input';
 import { ColumnVisibilityButton } from '@/features/table/components/column-visibility-button';
+import { FilterButton } from '@/features/table/components/filter-button';
+import type { Column } from '@/features/column/types';
 import {
   Table,
   TableBody,
@@ -47,6 +48,39 @@ type GroupTableProps = {
   initialFilters?: ColumnFiltersState;
   initialSorting?: SortingState;
 };
+
+/**
+ * グループテーブル用のフィルター可能なカラム定義
+ */
+const filterableColumns: Column[] = [
+  {
+    id: 'name',
+    name: 'グループ名',
+    type: 'TEXT',
+    order: 0,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    enableFilter: true,
+  },
+  {
+    id: 'description',
+    name: '説明',
+    type: 'TEXT',
+    order: 1,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    enableFilter: true,
+  },
+  {
+    id: 'createdAt',
+    name: '作成日',
+    type: 'DATE',
+    order: 2,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    enableFilter: true,
+  },
+];
 
 /**
  * グループテーブルコンポーネント
@@ -100,13 +134,10 @@ export function GroupTable({
   return (
     <div className="w-full">
       <div className="flex items-center justify-between py-4">
-        <Input
-          placeholder="グループ名で検索..."
-          value={(table.getColumn('name')?.getFilterValue() as string) ?? ''}
-          onChange={(event) =>
-            table.getColumn('name')?.setFilterValue(event.target.value)
-          }
-          className="max-w-sm"
+        <FilterButton
+          columns={filterableColumns}
+          columnFilters={columnFilters}
+          onColumnFiltersChange={setColumnFilters}
         />
         <div className="flex items-center gap-2">
           <ColumnVisibilityButton table={table} />

--- a/features/group/types/index.ts
+++ b/features/group/types/index.ts
@@ -1,9 +1,1 @@
 export * from './group';
-
-// TanStack Tableのメタ型を拡張
-declare module '@tanstack/react-table' {
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  interface ColumnMeta<TData, TValue> {
-    width?: string;
-  }
-}

--- a/features/table/actions/export-table.ts
+++ b/features/table/actions/export-table.ts
@@ -73,9 +73,11 @@ export async function exportTableAction(
         return value.split('T')[0]; // YYYY-MM-DD
       }
 
-      // SELECT型カラムの場合はIDをラベルに変換（文字列・配列両方対応）
+      // SELECT型カラムの場合はIDをラベルに変換
+      // NOTE: エクスポート時は DB から直接データを取得するため、
+      // allowMultiple切り替え前の古いデータ形式が残っている可能性がある
       if (col.type === 'SELECT' && col.config?.options && value) {
-        // 配列または文字列を配列に統一
+        // 配列または文字列を配列に統一（互換性のため）
         const ids = Array.isArray(value) ? value : [value];
         return ids
           .map((id) => {
@@ -85,12 +87,14 @@ export async function exportTableAction(
           .join(', ');
       }
 
-      // RELATION型カラムの場合はIDを表示値に変換（文字列・配列両方対応）
+      // RELATION型カラムの場合はIDを表示値に変換
+      // NOTE: エクスポート時は DB から直接データを取得するため、
+      // allowMultiple切り替え前の古いデータ形式が残っている可能性がある
       if (col.type === 'RELATION' && value) {
         const idToValueMap = relationDataMap.get(col.id);
         if (!idToValueMap) return '';
 
-        // 配列または文字列を配列に統一
+        // 配列または文字列を配列に統一（互換性のため）
         const ids = Array.isArray(value) ? value : [value];
         return ids.map((id) => idToValueMap.get(id as string) || id).join(', ');
       }

--- a/features/table/actions/export-table.ts
+++ b/features/table/actions/export-table.ts
@@ -27,20 +27,33 @@ export async function exportTableAction(
   // フィルタ適用済みのレコードを取得
   const records = await getRecords(itemId, { filters });
 
-  // ヘッダー行を作成（カラム名）
-  const headers = columns.map((col) => col.name);
+  // ヘッダー行を作成（IDを1列目に追加）
+  const headers = ['ID', ...columns.map((col) => col.name)];
 
-  // データ行を作成
+  // データ行を作成（record.idを1列目に追加）
   const rows = records.map((record) => {
     const data = record.data as RecordData;
-    return columns.map((col) => {
+    const columnValues = columns.map((col) => {
       const value = data[col.id];
+
       // DATE型カラムの場合はフォーマット（JSONから取得した値は文字列）
       if (col.type === 'DATE' && typeof value === 'string') {
         return value.split('T')[0]; // YYYY-MM-DD
       }
+
+      // SELECT型カラムの場合はIDをラベルに変換（常に配列形式）
+      if (col.type === 'SELECT' && col.config?.options && Array.isArray(value)) {
+        return value
+          .map((id) => {
+            const option = col.config.options.find((opt) => opt.id === id);
+            return option?.label || id;
+          })
+          .join(', ');
+      }
+
       return value as string | number | boolean | null | undefined;
     });
+    return [record.id, ...columnValues];
   });
 
   // CSV変換

--- a/features/table/actions/export-table.ts
+++ b/features/table/actions/export-table.ts
@@ -4,8 +4,10 @@ import { getRecords } from '@/features/record/api/get-records';
 import { getItemById } from '@/features/item/api';
 import { getColumnSchema } from '@/features/column/types/schema';
 import { convertToCSV } from '@/lib/csv';
+import { prisma } from '@/lib/prisma';
 import type { ExportColumnFilter } from '../types/export';
 import type { RecordData } from '@/features/record/types';
+import type { RelationColumn } from '@/features/column/types';
 
 /**
  * テーブルデータをCSVエクスポートするServer Action
@@ -27,6 +29,36 @@ export async function exportTableAction(
   // フィルタ適用済みのレコードを取得
   const records = await getRecords(itemId, { filters });
 
+  // RELATION型カラムのリレーション先データを取得
+  const relationColumns = columns.filter(
+    (col) => col.type === 'RELATION'
+  ) as RelationColumn[];
+  const relationDataMap = new Map<string, Map<string, string>>();
+
+  for (const relationCol of relationColumns) {
+    const referencedTableId = relationCol.config.referencedTableId;
+    const displayField = relationCol.config.displayField;
+
+    // リレーション先のテーブルを取得
+    const referencedTable = await getItemById(referencedTableId);
+    if (!referencedTable || referencedTable.type !== 'TABLE') continue;
+
+    // リレーション先のレコードを全件取得
+    const referencedRecords = await prisma.record.findMany({
+      where: { tableId: referencedTableId },
+    });
+
+    // レコードIDから表示値へのマップを作成
+    const idToValueMap = new Map<string, string>();
+    for (const record of referencedRecords) {
+      const data = record.data as RecordData;
+      const displayValue = data[displayField];
+      idToValueMap.set(record.id, String(displayValue ?? ''));
+    }
+
+    relationDataMap.set(relationCol.id, idToValueMap);
+  }
+
   // ヘッダー行を作成（IDを1列目に追加）
   const headers = ['ID', ...columns.map((col) => col.name)];
 
@@ -41,14 +73,26 @@ export async function exportTableAction(
         return value.split('T')[0]; // YYYY-MM-DD
       }
 
-      // SELECT型カラムの場合はIDをラベルに変換（常に配列形式）
-      if (col.type === 'SELECT' && col.config?.options && Array.isArray(value)) {
-        return value
+      // SELECT型カラムの場合はIDをラベルに変換（文字列・配列両方対応）
+      if (col.type === 'SELECT' && col.config?.options && value) {
+        // 配列または文字列を配列に統一
+        const ids = Array.isArray(value) ? value : [value];
+        return ids
           .map((id) => {
             const option = col.config.options.find((opt) => opt.id === id);
             return option?.label || id;
           })
           .join(', ');
+      }
+
+      // RELATION型カラムの場合はIDを表示値に変換（文字列・配列両方対応）
+      if (col.type === 'RELATION' && value) {
+        const idToValueMap = relationDataMap.get(col.id);
+        if (!idToValueMap) return '';
+
+        // 配列または文字列を配列に統一
+        const ids = Array.isArray(value) ? value : [value];
+        return ids.map((id) => idToValueMap.get(id as string) || id).join(', ');
       }
 
       return value as string | number | boolean | null | undefined;

--- a/features/table/actions/export-table.ts
+++ b/features/table/actions/export-table.ts
@@ -43,9 +43,28 @@ export async function exportTableAction(
     const referencedTable = await getItemById(referencedTableId);
     if (!referencedTable || referencedTable.type !== 'TABLE') continue;
 
-    // リレーション先のレコードを全件取得
+    // 実際に使用されているレコードIDを収集
+    const usedRecordIds = new Set<string>();
+    for (const record of records) {
+      const data = record.data as RecordData;
+      const value = data[relationCol.id];
+      if (value) {
+        // 文字列または配列の両方に対応
+        const ids = Array.isArray(value) ? value : [value];
+        ids.forEach((id) => {
+          if (typeof id === 'string') {
+            usedRecordIds.add(id);
+          }
+        });
+      }
+    }
+
+    // 使用されているIDのみ取得（パフォーマンス・セキュリティ改善）
     const referencedRecords = await prisma.record.findMany({
-      where: { tableId: referencedTableId },
+      where: {
+        tableId: referencedTableId,
+        id: { in: Array.from(usedRecordIds) },
+      },
     });
 
     // レコードIDから表示値へのマップを作成

--- a/features/table/components/cells/relation-cell.tsx
+++ b/features/table/components/cells/relation-cell.tsx
@@ -36,9 +36,11 @@ export function RelationCell({
 }: RelationCellProps) {
   const [open, setOpen] = useState(false);
   // 複数選択用のローカルステート（常に呼び出す）
-  const [localValue, setLocalValue] = useState<string[]>(
-    Array.isArray(value) ? value : []
-  );
+  // 値の形式を正規化: stringもarrayとして扱う
+  const [localValue, setLocalValue] = useState<string[]>(() => {
+    if (!value) return [];
+    return Array.isArray(value) ? value : [value];
+  });
 
   // 選択中のレコードを取得
   const selectedRecords = (() => {
@@ -91,10 +93,16 @@ export function RelationCell({
     // メニューが開いたときに値を同期
     const handleOpenChange = (newOpen: boolean) => {
       if (newOpen) {
-        setLocalValue(Array.isArray(value) ? value : []);
+        // 値の形式を正規化: stringもarrayとして扱う
+        if (!value) {
+          setLocalValue([]);
+        } else {
+          setLocalValue(Array.isArray(value) ? value : [value]);
+        }
       } else {
         // 閉じたときに変更があれば保存
-        const currentIds = Array.isArray(value) ? value : [];
+        // 値の形式を正規化して比較
+        const currentIds = !value ? [] : Array.isArray(value) ? value : [value];
         const hasChanges =
           localValue.length !== currentIds.length ||
           localValue.some((id) => !currentIds.includes(id));
@@ -183,9 +191,17 @@ export function RelationCell({
     setOpen(false);
   };
 
+  // 単一選択モードでの値を正規化（配列の場合は最初の要素を使用）
+  const singleValue = (() => {
+    if (!value) return undefined;
+    if (typeof value === 'string') return value;
+    // 配列の場合は最初の要素を使用（allowMultiple切り替え時の互換性）
+    return Array.isArray(value) && value.length > 0 ? value[0] : undefined;
+  })();
+
   return (
     <Select
-      value={(value as string) || undefined}
+      value={singleValue}
       onValueChange={handleSelect}
       open={open}
       onOpenChange={setOpen}

--- a/features/table/components/cells/relation-cell.tsx
+++ b/features/table/components/cells/relation-cell.tsx
@@ -36,16 +36,16 @@ export function RelationCell({
 }: RelationCellProps) {
   const [open, setOpen] = useState(false);
   // 複数選択用のローカルステート（常に呼び出す）
-  // 値の形式を正規化: stringもarrayとして扱う
-  const [localValue, setLocalValue] = useState<string[]>(() => {
-    if (!value) return [];
-    return Array.isArray(value) ? value : [value];
-  });
+  // NOTE: データは normalizeColumnValue() で正規化済み
+  // allowMultiple=true なら value は配列、allowMultiple=false なら文字列
+  const [localValue, setLocalValue] = useState<string[]>(
+    (value as string[]) || []
+  );
 
   // 選択中のレコードを取得
   const selectedRecords = (() => {
     if (!value) return [];
-    const ids = Array.isArray(value) ? value : [value];
+    const ids = allowMultiple ? (value as string[]) : [value as string];
     return ids
       .map((id) => {
         const record = records.find((r) => r.id === id);
@@ -93,16 +93,10 @@ export function RelationCell({
     // メニューが開いたときに値を同期
     const handleOpenChange = (newOpen: boolean) => {
       if (newOpen) {
-        // 値の形式を正規化: stringもarrayとして扱う
-        if (!value) {
-          setLocalValue([]);
-        } else {
-          setLocalValue(Array.isArray(value) ? value : [value]);
-        }
+        setLocalValue((value as string[]) || []);
       } else {
         // 閉じたときに変更があれば保存
-        // 値の形式を正規化して比較
-        const currentIds = !value ? [] : Array.isArray(value) ? value : [value];
+        const currentIds = (value as string[]) || [];
         const hasChanges =
           localValue.length !== currentIds.length ||
           localValue.some((id) => !currentIds.includes(id));
@@ -191,17 +185,9 @@ export function RelationCell({
     setOpen(false);
   };
 
-  // 単一選択モードでの値を正規化（配列の場合は最初の要素を使用）
-  const singleValue = (() => {
-    if (!value) return undefined;
-    if (typeof value === 'string') return value;
-    // 配列の場合は最初の要素を使用（allowMultiple切り替え時の互換性）
-    return Array.isArray(value) && value.length > 0 ? value[0] : undefined;
-  })();
-
   return (
     <Select
-      value={singleValue}
+      value={(value as string) || undefined}
       onValueChange={handleSelect}
       open={open}
       onOpenChange={setOpen}

--- a/features/table/components/cells/select-cell.tsx
+++ b/features/table/components/cells/select-cell.tsx
@@ -16,8 +16,8 @@ import {
 import type { SelectOption } from '@/features/column/types';
 
 type SelectCellProps = {
-  value: string | string[] | null;
-  onChange: (value: string | string[] | null) => void;
+  value: string[] | null;
+  onChange: (value: string[] | null) => void;
   options: SelectOption[];
   allowMultiple?: boolean;
   readOnly?: boolean;
@@ -174,14 +174,18 @@ export function SelectCell({
     if (optionId === '__clear__') {
       onChange(null);
     } else {
-      onChange(optionId);
+      // 単一選択でも配列形式で保存
+      onChange([optionId]);
     }
     setOpen(false);
   };
 
+  // 単一選択の現在値を取得（配列の最初の要素）
+  const singleValue = Array.isArray(value) ? value[0] : value;
+
   return (
     <Select
-      value={(value as string) || undefined}
+      value={(singleValue as string) || undefined}
       onValueChange={handleSelect}
       open={open}
       onOpenChange={setOpen}

--- a/features/table/components/cells/select-cell.tsx
+++ b/features/table/components/cells/select-cell.tsx
@@ -16,8 +16,8 @@ import {
 import type { SelectOption } from '@/features/column/types';
 
 type SelectCellProps = {
-  value: string[] | null;
-  onChange: (value: string[] | null) => void;
+  value: string | string[] | null;
+  onChange: (value: string | string[] | null) => void;
   options: SelectOption[];
   allowMultiple?: boolean;
   readOnly?: boolean;
@@ -174,18 +174,14 @@ export function SelectCell({
     if (optionId === '__clear__') {
       onChange(null);
     } else {
-      // 単一選択でも配列形式で保存
-      onChange([optionId]);
+      onChange(optionId);
     }
     setOpen(false);
   };
 
-  // 単一選択の現在値を取得（配列の最初の要素）
-  const singleValue = Array.isArray(value) ? value[0] : value;
-
   return (
     <Select
-      value={(singleValue as string) || undefined}
+      value={(value as string) || undefined}
       onValueChange={handleSelect}
       open={open}
       onOpenChange={setOpen}

--- a/features/table/components/cells/select-cell.tsx
+++ b/features/table/components/cells/select-cell.tsx
@@ -58,14 +58,16 @@ export function SelectCell({
 }: SelectCellProps) {
   const [open, setOpen] = useState(false);
   // 複数選択用のローカルステート（常に呼び出す）
+  // NOTE: データは normalizeColumnValue() で正規化済み
+  // allowMultiple=true なら value は配列、allowMultiple=false なら文字列
   const [localValue, setLocalValue] = useState<string[]>(
-    Array.isArray(value) ? value : []
+    (value as string[]) || []
   );
 
   // 選択中のオプションを取得
   const selectedOptions = (() => {
     if (!value) return [];
-    const ids = Array.isArray(value) ? value : [value];
+    const ids = allowMultiple ? (value as string[]) : [value as string];
     return ids
       .map((id) => options.find((opt) => opt.id === id))
       .filter((opt) => opt !== undefined);
@@ -96,10 +98,10 @@ export function SelectCell({
     // メニューが開いたときに値を同期
     const handleOpenChange = (newOpen: boolean) => {
       if (newOpen) {
-        setLocalValue(Array.isArray(value) ? value : []);
+        setLocalValue((value as string[]) || []);
       } else {
         // 閉じたときに変更があれば保存
-        const currentIds = Array.isArray(value) ? value : [];
+        const currentIds = (value as string[]) || [];
         const hasChanges =
           localValue.length !== currentIds.length ||
           localValue.some((id) => !currentIds.includes(id));

--- a/features/table/components/columns.tsx
+++ b/features/table/components/columns.tsx
@@ -181,7 +181,7 @@ export const createColumns = (
         case 'SELECT':
           return (
             <SelectCell
-              value={(value as string | string[]) ?? null}
+              value={(value as string[]) ?? null}
               onChange={handleChange}
               options={(column as SelectColumn).config?.options ?? []}
               allowMultiple={(column as SelectColumn).config?.allowMultiple}

--- a/features/table/components/columns.tsx
+++ b/features/table/components/columns.tsx
@@ -181,7 +181,7 @@ export const createColumns = (
         case 'SELECT':
           return (
             <SelectCell
-              value={(value as string[]) ?? null}
+              value={(value as string | string[]) ?? null}
               onChange={handleChange}
               options={(column as SelectColumn).config?.options ?? []}
               allowMultiple={(column as SelectColumn).config?.allowMultiple}

--- a/features/table/components/columns.tsx
+++ b/features/table/components/columns.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { ColumnDef, FilterFn, SortingFn } from '@tanstack/react-table';
+import { ColumnDef, SortingFn } from '@tanstack/react-table';
 import { Checkbox } from '@/components/ui/checkbox';
 import type {
   Column,
@@ -10,6 +10,13 @@ import type {
   ColumnType,
 } from '@/features/column/types';
 import type { Record, RecordData } from '@/features/record/types';
+import {
+  createTextFilterFn,
+  createNumberFilterFn,
+  createDateFilterFn,
+  createRelationFilterFn,
+  createCheckboxFilterFn,
+} from '@/features/table/utils/filter-functions';
 import { TextCell } from './cells/text-cell';
 import { NumberCell } from './cells/number-cell';
 import { SelectCell } from './cells/select-cell';
@@ -65,106 +72,30 @@ function getSortingFn(
   }
 }
 
+// フィルタ関数を生成（共通ユーティリティを使用）
+const textFilterFn = createTextFilterFn<Record>();
+const numberFilterFn = createNumberFilterFn<Record>();
+const dateFilterFn = createDateFilterFn<Record>();
+const relationFilterFn = createRelationFilterFn<Record>();
+const checkboxFilterFn = createCheckboxFilterFn<Record>();
+
 /**
  * カラム種別に応じたフィルタ関数を取得
  */
-function getFilterFn(columnType: ColumnType): FilterFn<Record> | undefined {
+function getFilterFn(columnType: ColumnType) {
   switch (columnType) {
     case 'TEXT':
     case 'TEXTAREA':
-      return (row, columnId, filterValue) => {
-        const value = row.getValue(columnId) as string | null;
-        const search = filterValue as string;
-        if (!search) return true;
-        return (value || '').toLowerCase().includes(search.toLowerCase());
-      };
+      return textFilterFn;
     case 'NUMBER':
-      return (row, columnId, filterValue) => {
-        const value = row.getValue(columnId) as number | null;
-        const filter = filterValue as {
-          operator: string;
-          value1: number | null;
-          value2: number | null;
-        };
-        if (value === null) return false;
-        if (filter.value1 === null) return true;
-
-        switch (filter.operator) {
-          case 'eq':
-            return value === filter.value1;
-          case 'ne':
-            return value !== filter.value1;
-          case 'gt':
-            return value > filter.value1;
-          case 'gte':
-            return value >= filter.value1;
-          case 'lt':
-            return value < filter.value1;
-          case 'lte':
-            return value <= filter.value1;
-          case 'range':
-            if (filter.value2 === null) return value >= filter.value1;
-            return value >= filter.value1 && value <= filter.value2;
-          default:
-            return true;
-        }
-      };
+      return numberFilterFn;
     case 'DATE':
-      return (row, columnId, filterValue) => {
-        const value = row.getValue(columnId) as string | null;
-        const filter = filterValue as {
-          startDate: Date | null;
-          endDate: Date | null;
-        };
-        if (!value) return false;
-        if (!filter.startDate && !filter.endDate) return true;
-
-        const date = new Date(value);
-        const start = filter.startDate
-          ? new Date(filter.startDate)
-          : new Date(0);
-        const end = filter.endDate
-          ? new Date(filter.endDate)
-          : new Date(8640000000000000);
-
-        start.setHours(0, 0, 0, 0);
-        end.setHours(23, 59, 59, 999);
-
-        return date >= start && date <= end;
-      };
+      return dateFilterFn;
     case 'SELECT':
-      return (row, columnId, filterValue) => {
-        const value = row.getValue(columnId) as string | string[] | null;
-        const filter = filterValue as string[];
-        if (!filter || filter.length === 0) return true;
-        if (!value) return false;
-
-        if (Array.isArray(value)) {
-          return value.some((v) => filter.includes(v));
-        }
-        return filter.includes(value);
-      };
     case 'RELATION':
-      return (row, columnId, filterValue) => {
-        const value = row.getValue(columnId) as string | string[] | null;
-        const filter = filterValue as string[];
-        if (!filter || filter.length === 0) return true;
-        if (!value) return false;
-
-        if (Array.isArray(value)) {
-          return value.some((v) => filter.includes(v));
-        }
-        return filter.includes(value);
-      };
+      return relationFilterFn;
     case 'CHECKBOX':
-      return (row, columnId, filterValue) => {
-        const value = row.getValue(columnId) as boolean;
-        const filter = filterValue as 'all' | 'checked' | 'unchecked';
-        if (filter === 'all') return true;
-        if (filter === 'checked') return value === true;
-        if (filter === 'unchecked') return value === false;
-        return true;
-      };
+      return checkboxFilterFn;
     default:
       return undefined;
   }

--- a/features/table/components/data-table.tsx
+++ b/features/table/components/data-table.tsx
@@ -37,7 +37,10 @@ import { ScrollArea, ScrollBar } from '@/components/ui/scroll-area';
 import { updateRecord } from '@/features/record/api/update-record';
 import { createRecord } from '@/features/record/api/create-record';
 import { applyDefaultValues } from '@/features/column/utils';
-import { normalizeRecordData } from '@/features/column/utils/normalize-column-value';
+import {
+  normalizeRecordData,
+  normalizeColumnValue,
+} from '@/features/column/utils/normalize-column-value';
 import { hasPermission } from '@/lib/permissions';
 import { useLocalStorage } from '@/hooks/use-local-storage';
 import { createColumns } from './columns';
@@ -101,9 +104,12 @@ export function DataTable({
   }, [initialRecords]);
 
   // 正規化されたレコードをステートに反映
+  // NOTE: サーバー更新中（isPending=true）は上書きしない（編集中のデータ保護）
   useEffect(() => {
-    setRecords(normalizedInitialRecords);
-  }, [normalizedInitialRecords]);
+    if (!isPending) {
+      setRecords(normalizedInitialRecords);
+    }
+  }, [normalizedInitialRecords, isPending]);
 
   // カラム構成変更時に古い状態をクリーンアップ
   const validColumnIds = useMemo(
@@ -135,7 +141,13 @@ export function DataTable({
   // セル値の更新ハンドラ
   const handleCellChange = useCallback(
     (recordId: string, columnId: string, value: unknown) => {
-      // 楽観的更新
+      // カラム定義を取得して値を正規化
+      const column = columns.find((col) => col.id === columnId);
+      const normalizedValue = column
+        ? normalizeColumnValue(value, column)
+        : value;
+
+      // 楽観的更新（正規化済みの値を使用）
       setRecords((prev) =>
         prev.map((record) =>
           record.id === recordId
@@ -143,16 +155,18 @@ export function DataTable({
                 ...record,
                 data: {
                   ...(record.data as RecordData),
-                  [columnId]: value,
+                  [columnId]: normalizedValue,
                 },
               }
             : record
         )
       );
 
-      // サーバーに保存
+      // サーバーに保存（正規化済みの値を使用）
       startTransition(async () => {
-        const result = await updateRecord(recordId, { [columnId]: value });
+        const result = await updateRecord(recordId, {
+          [columnId]: normalizedValue,
+        });
         if (result.error) {
           console.error('更新エラー:', result.error);
           // エラー時はリバート（簡易実装）
@@ -160,7 +174,7 @@ export function DataTable({
         }
       });
     },
-    []
+    [columns]
   );
 
   // 新規レコード作成

--- a/features/table/components/data-table.tsx
+++ b/features/table/components/data-table.tsx
@@ -37,6 +37,7 @@ import { ScrollArea, ScrollBar } from '@/components/ui/scroll-area';
 import { updateRecord } from '@/features/record/api/update-record';
 import { createRecord } from '@/features/record/api/create-record';
 import { applyDefaultValues } from '@/features/column/utils';
+import { normalizeRecordData } from '@/features/column/utils/normalize-column-value';
 import { hasPermission } from '@/lib/permissions';
 import { useLocalStorage } from '@/hooks/use-local-storage';
 import { createColumns } from './columns';
@@ -67,7 +68,17 @@ export function DataTable({
   permissionLevel,
   initialFilters = [],
 }: DataTableProps) {
-  const [records, setRecords] = useState<Record[]>(initialRecords);
+  // 初期レコードのデータを正規化（SELECT/RELATION型の形式統一）
+  const normalizedInitialRecords = useMemo(
+    () =>
+      initialRecords.map((record) => ({
+        ...record,
+        data: normalizeRecordData(record.data as RecordData, columns),
+      })),
+    [initialRecords, columns]
+  );
+
+  const [records, setRecords] = useState<Record[]>(normalizedInitialRecords);
   const [isPending, startTransition] = useTransition();
   const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
 
@@ -88,6 +99,11 @@ export function DataTable({
   useEffect(() => {
     initialRecordsRef.current = initialRecords;
   }, [initialRecords]);
+
+  // 正規化されたレコードをステートに反映
+  useEffect(() => {
+    setRecords(normalizedInitialRecords);
+  }, [normalizedInitialRecords]);
 
   // カラム構成変更時に古い状態をクリーンアップ
   const validColumnIds = useMemo(

--- a/features/table/components/filter-button.tsx
+++ b/features/table/components/filter-button.tsx
@@ -33,9 +33,11 @@ import {
   SelectFilter,
   RelationFilter,
   CheckboxFilter,
-  type NumberFilterValue,
-  type DateFilterValue,
 } from './filters';
+import type {
+  NumberFilterValue,
+  DateFilterValue,
+} from '@/features/table/utils/filter-functions';
 
 /**
  * FilterButtonのProps型

--- a/features/table/components/filters/checkbox-filter.tsx
+++ b/features/table/components/filters/checkbox-filter.tsx
@@ -2,8 +2,7 @@
 
 import { Checkbox } from '@/components/ui/checkbox';
 import { Label } from '@/components/ui/label';
-
-type CheckboxFilterValue = 'all' | 'checked' | 'unchecked';
+import type { CheckboxFilterValue } from '@/features/table/utils/filter-functions';
 
 type CheckboxFilterProps = {
   value: CheckboxFilterValue;

--- a/features/table/components/filters/date-filter.tsx
+++ b/features/table/components/filters/date-filter.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useState } from 'react';
 import { Calendar } from '@/components/ui/calendar';
 import { Button } from '@/components/ui/button';
 import {
@@ -92,6 +93,8 @@ export function DateFilter({ value, onChange }: DateFilterProps) {
   const preset = value.preset || 'custom';
   const startDate = value.startDate || undefined;
   const endDate = value.endDate || undefined;
+  const [startOpen, setStartOpen] = useState(false);
+  const [endOpen, setEndOpen] = useState(false);
 
   const handlePresetChange = (newPreset: DatePreset) => {
     const [start, end] = getPresetDates(newPreset);
@@ -108,6 +111,7 @@ export function DateFilter({ value, onChange }: DateFilterProps) {
       startDate: date || null,
       endDate: value.endDate,
     });
+    setStartOpen(false);
   };
 
   const handleEndDateChange = (date: Date | undefined) => {
@@ -116,6 +120,7 @@ export function DateFilter({ value, onChange }: DateFilterProps) {
       startDate: value.startDate,
       endDate: date || null,
     });
+    setEndOpen(false);
   };
 
   return (
@@ -133,60 +138,65 @@ export function DateFilter({ value, onChange }: DateFilterProps) {
         </SelectContent>
       </Select>
       {preset === 'custom' && (
-        <div className="flex items-center gap-2">
-          <Popover>
-            <PopoverTrigger asChild>
-              <Button
-                variant="outline"
-                className={cn(
-                  'h-8 w-full justify-start text-left font-normal',
-                  !startDate && 'text-muted-foreground'
-                )}
-              >
-                <CalendarIcon className="mr-2 h-4 w-4" />
-                {startDate ? (
-                  format(startDate, 'yyyy/MM/dd', { locale: ja })
-                ) : (
-                  <span>開始日</span>
-                )}
-              </Button>
-            </PopoverTrigger>
-            <PopoverContent className="w-auto p-0">
-              <Calendar
-                mode="single"
-                selected={startDate}
-                onSelect={handleStartDateChange}
-                locale={ja}
-              />
-            </PopoverContent>
-          </Popover>
-          <span className="text-muted-foreground text-sm">～</span>
-          <Popover>
-            <PopoverTrigger asChild>
-              <Button
-                variant="outline"
-                className={cn(
-                  'h-8 w-full justify-start text-left font-normal',
-                  !endDate && 'text-muted-foreground'
-                )}
-              >
-                <CalendarIcon className="mr-2 h-4 w-4" />
-                {endDate ? (
-                  format(endDate, 'yyyy/MM/dd', { locale: ja })
-                ) : (
-                  <span>終了日</span>
-                )}
-              </Button>
-            </PopoverTrigger>
-            <PopoverContent className="w-auto p-0">
-              <Calendar
-                mode="single"
-                selected={endDate}
-                onSelect={handleEndDateChange}
-                locale={ja}
-              />
-            </PopoverContent>
-          </Popover>
+        <div className="flex flex-col gap-2">
+          <div className="flex flex-col gap-1">
+            <span className="text-xs text-muted-foreground">開始日</span>
+            <Popover open={startOpen} onOpenChange={setStartOpen}>
+              <PopoverTrigger asChild>
+                <Button
+                  variant="outline"
+                  className={cn(
+                    'h-8 w-full justify-start text-left font-normal',
+                    !startDate && 'text-muted-foreground'
+                  )}
+                >
+                  <CalendarIcon className="mr-2 h-4 w-4" />
+                  {startDate ? (
+                    format(startDate, 'yyyy/MM/dd', { locale: ja })
+                  ) : (
+                    <span>開始日</span>
+                  )}
+                </Button>
+              </PopoverTrigger>
+              <PopoverContent className="w-auto p-0">
+                <Calendar
+                  mode="single"
+                  selected={startDate}
+                  onSelect={handleStartDateChange}
+                  locale={ja}
+                />
+              </PopoverContent>
+            </Popover>
+          </div>
+          <div className="flex flex-col gap-1">
+            <span className="text-xs text-muted-foreground">終了日</span>
+            <Popover open={endOpen} onOpenChange={setEndOpen}>
+              <PopoverTrigger asChild>
+                <Button
+                  variant="outline"
+                  className={cn(
+                    'h-8 w-full justify-start text-left font-normal',
+                    !endDate && 'text-muted-foreground'
+                  )}
+                >
+                  <CalendarIcon className="mr-2 h-4 w-4" />
+                  {endDate ? (
+                    format(endDate, 'yyyy/MM/dd', { locale: ja })
+                  ) : (
+                    <span>終了日</span>
+                  )}
+                </Button>
+              </PopoverTrigger>
+              <PopoverContent className="w-auto p-0">
+                <Calendar
+                  mode="single"
+                  selected={endDate}
+                  onSelect={handleEndDateChange}
+                  locale={ja}
+                />
+              </PopoverContent>
+            </Popover>
+          </div>
         </div>
       )}
     </div>

--- a/features/table/components/filters/date-filter.tsx
+++ b/features/table/components/filters/date-filter.tsx
@@ -19,22 +19,10 @@ import { cn } from '@/lib/utils';
 import { format } from 'date-fns';
 import { ja } from 'date-fns/locale';
 import { CalendarIcon } from 'lucide-react';
-
-type DatePreset =
-  | 'today'
-  | 'this_week'
-  | 'this_month'
-  | 'last_month'
-  | 'custom';
-
-/**
- * 日付フィルタの値の型
- */
-export type DateFilterValue = {
-  preset: DatePreset;
-  startDate: Date | null;
-  endDate: Date | null;
-};
+import type {
+  DateFilterValue,
+  DatePreset,
+} from '@/features/table/utils/filter-functions';
 
 type DateFilterProps = {
   value: DateFilterValue;

--- a/features/table/components/filters/index.ts
+++ b/features/table/components/filters/index.ts
@@ -1,6 +1,6 @@
 export { TextFilter } from './text-filter';
-export { NumberFilter, type NumberFilterValue } from './number-filter';
-export { DateFilter, type DateFilterValue } from './date-filter';
+export { NumberFilter } from './number-filter';
+export { DateFilter } from './date-filter';
 export { SelectFilter } from './select-filter';
 export { RelationFilter } from './relation-filter';
 export { CheckboxFilter } from './checkbox-filter';

--- a/features/table/components/filters/number-filter.tsx
+++ b/features/table/components/filters/number-filter.tsx
@@ -8,17 +8,9 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
+import type { NumberFilterValue } from '@/features/table/utils/filter-functions';
 
 type NumberOperator = 'eq' | 'ne' | 'gt' | 'gte' | 'lt' | 'lte' | 'range';
-
-/**
- * 数値フィルタの値の型
- */
-export type NumberFilterValue = {
-  operator: NumberOperator;
-  value1: number | null;
-  value2: number | null;
-};
 
 type NumberFilterProps = {
   value: NumberFilterValue;

--- a/features/table/utils/filter-functions.ts
+++ b/features/table/utils/filter-functions.ts
@@ -12,10 +12,20 @@ const MAX_DATE_VALUE = 8640000000000000;
 const MIN_DATE_VALUE = 0;
 
 /**
+ * 日付プリセットの型
+ */
+export type DatePreset =
+  | 'today'
+  | 'this_week'
+  | 'this_month'
+  | 'last_month'
+  | 'custom';
+
+/**
  * 日付フィルタの値の型
  */
 export type DateFilterValue = {
-  preset?: string;
+  preset: DatePreset;
   startDate: Date | null;
   endDate: Date | null;
 };
@@ -24,10 +34,20 @@ export type DateFilterValue = {
  * 数値フィルタの値の型
  */
 export type NumberFilterValue = {
-  operator: string;
+  operator: 'eq' | 'ne' | 'gt' | 'gte' | 'lt' | 'lte' | 'range';
   value1: number | null;
   value2: number | null;
 };
+
+/**
+ * セレクト/リレーションフィルタの値の型（文字列配列）
+ */
+export type SelectFilterValue = string[];
+
+/**
+ * チェックボックスフィルタの値の型
+ */
+export type CheckboxFilterValue = 'all' | 'checked' | 'unchecked';
 
 /**
  * テキストフィルタ関数
@@ -62,12 +82,12 @@ export function createSelectFilterFn<TData>(): FilterFn<TData> {
     // フィルタ値の型チェック
     if (!Array.isArray(filterValue)) {
       console.warn(
-        `selectFilterFn: Expected array filter value, got ${typeof filterValue}`
+        `selectFilterFn: Expected SelectFilterValue, got ${typeof filterValue}`
       );
       return true;
     }
 
-    const filter = filterValue as string[];
+    const filter = filterValue as SelectFilterValue;
     if (!filter || filter.length === 0) return true;
     if (!value) return false;
     return filter.includes(value);
@@ -113,5 +133,109 @@ export function createDateFilterFn<TData>(): FilterFn<TData> {
     end.setHours(23, 59, 59, 999);
 
     return date >= start && date <= end;
+  };
+}
+
+/**
+ * NUMBERフィルタ関数（data-table用）
+ * 数値の比較演算を行います
+ */
+export function createNumberFilterFn<TData>(): FilterFn<TData> {
+  return (row, columnId, filterValue) => {
+    const value = row.getValue(columnId) as number | null;
+
+    // フィルタ値の型チェック
+    if (
+      typeof filterValue !== 'object' ||
+      filterValue === null ||
+      !('operator' in filterValue)
+    ) {
+      console.warn(
+        `numberFilterFn: Expected NumberFilterValue, got ${typeof filterValue}`
+      );
+      return true;
+    }
+
+    const filter = filterValue as NumberFilterValue;
+
+    if (value === null) return false;
+    if (filter.value1 === null) return true;
+
+    switch (filter.operator) {
+      case 'eq':
+        return value === filter.value1;
+      case 'ne':
+        return value !== filter.value1;
+      case 'gt':
+        return value > filter.value1;
+      case 'gte':
+        return value >= filter.value1;
+      case 'lt':
+        return value < filter.value1;
+      case 'lte':
+        return value <= filter.value1;
+      case 'range':
+        if (filter.value2 === null) return value >= filter.value1;
+        return value >= filter.value1 && value <= filter.value2;
+      default:
+        return true;
+    }
+  };
+}
+
+/**
+ * RELATIONフィルタ関数（data-table用）
+ * 配列値もサポートするSELECT/RELATIONフィルタ
+ */
+export function createRelationFilterFn<TData>(): FilterFn<TData> {
+  return (row, columnId, filterValue) => {
+    const value = row.getValue(columnId) as string | string[] | null;
+
+    // フィルタ値の型チェック
+    if (!Array.isArray(filterValue)) {
+      console.warn(
+        `relationFilterFn: Expected SelectFilterValue, got ${typeof filterValue}`
+      );
+      return true;
+    }
+
+    const filter = filterValue as SelectFilterValue;
+    if (!filter || filter.length === 0) return true;
+    if (!value) return false;
+
+    // 値が配列の場合、いずれかの要素がフィルタに含まれているかチェック
+    if (Array.isArray(value)) {
+      return value.some((v) => filter.includes(v));
+    }
+    return filter.includes(value);
+  };
+}
+
+/**
+ * CHECKBOXフィルタ関数（data-table用）
+ * boolean値のフィルタ
+ */
+export function createCheckboxFilterFn<TData>(): FilterFn<TData> {
+  return (row, columnId, filterValue) => {
+    const value = row.getValue(columnId) as boolean;
+
+    // フィルタ値の型チェック
+    if (
+      filterValue !== 'all' &&
+      filterValue !== 'checked' &&
+      filterValue !== 'unchecked'
+    ) {
+      console.warn(
+        `checkboxFilterFn: Expected CheckboxFilterValue, got ${filterValue}`
+      );
+      return true;
+    }
+
+    const filter = filterValue as CheckboxFilterValue;
+
+    if (filter === 'all') return true;
+    if (filter === 'checked') return value === true;
+    if (filter === 'unchecked') return value === false;
+    return true;
   };
 }

--- a/features/table/utils/filter-functions.ts
+++ b/features/table/utils/filter-functions.ts
@@ -1,0 +1,117 @@
+import type { FilterFn } from '@tanstack/react-table';
+
+/**
+ * JavaScriptで表現可能な最大日付値
+ * Date型で扱える最大のタイムスタンプ（8640000000000000ミリ秒）
+ */
+const MAX_DATE_VALUE = 8640000000000000;
+
+/**
+ * JavaScriptで表現可能な最小日付値
+ */
+const MIN_DATE_VALUE = 0;
+
+/**
+ * 日付フィルタの値の型
+ */
+export type DateFilterValue = {
+  preset?: string;
+  startDate: Date | null;
+  endDate: Date | null;
+};
+
+/**
+ * 数値フィルタの値の型
+ */
+export type NumberFilterValue = {
+  operator: string;
+  value1: number | null;
+  value2: number | null;
+};
+
+/**
+ * テキストフィルタ関数
+ * 大文字小文字を区別せずに部分一致検索を行います
+ */
+export function createTextFilterFn<TData>(): FilterFn<TData> {
+  return (row, columnId, filterValue) => {
+    const value = row.getValue(columnId) as string | null;
+
+    // フィルタ値の型チェック
+    if (typeof filterValue !== 'string') {
+      console.warn(
+        `textFilterFn: Expected string filter value, got ${typeof filterValue}`
+      );
+      return true;
+    }
+
+    const search = filterValue;
+    if (!search) return true;
+    return (value || '').toLowerCase().includes(search.toLowerCase());
+  };
+}
+
+/**
+ * SELECTフィルタ関数
+ * 指定された値のいずれかと完全一致するかチェックします
+ */
+export function createSelectFilterFn<TData>(): FilterFn<TData> {
+  return (row, columnId, filterValue) => {
+    const value = row.getValue(columnId) as string | null;
+
+    // フィルタ値の型チェック
+    if (!Array.isArray(filterValue)) {
+      console.warn(
+        `selectFilterFn: Expected array filter value, got ${typeof filterValue}`
+      );
+      return true;
+    }
+
+    const filter = filterValue as string[];
+    if (!filter || filter.length === 0) return true;
+    if (!value) return false;
+    return filter.includes(value);
+  };
+}
+
+/**
+ * DATEフィルタ関数
+ * 指定された日付範囲内かどうかをチェックします
+ */
+export function createDateFilterFn<TData>(): FilterFn<TData> {
+  return (row, columnId, filterValue) => {
+    const value = row.getValue(columnId) as Date | string | null;
+
+    // フィルタ値の型チェック
+    if (
+      typeof filterValue !== 'object' ||
+      filterValue === null ||
+      !('startDate' in filterValue) ||
+      !('endDate' in filterValue)
+    ) {
+      console.warn(
+        `dateFilterFn: Expected DateFilterValue, got ${typeof filterValue}`
+      );
+      return true;
+    }
+
+    const filter = filterValue as DateFilterValue;
+
+    if (!value) return false;
+    if (!filter.startDate && !filter.endDate) return true;
+
+    const date = new Date(value);
+    const start = filter.startDate
+      ? new Date(filter.startDate)
+      : new Date(MIN_DATE_VALUE);
+    const end = filter.endDate
+      ? new Date(filter.endDate)
+      : new Date(MAX_DATE_VALUE);
+
+    // 時刻を正規化（開始日は0:00:00、終了日は23:59:59）
+    start.setHours(0, 0, 0, 0);
+    end.setHours(23, 59, 59, 999);
+
+    return date >= start && date <= end;
+  };
+}

--- a/features/user/components/columns.tsx
+++ b/features/user/components/columns.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState } from 'react';
-import { ColumnDef, FilterFn } from '@tanstack/react-table';
+import { ColumnDef } from '@tanstack/react-table';
 import { MoreHorizontal } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Checkbox } from '@/components/ui/checkbox';
@@ -11,55 +11,19 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import { SortableHeader } from '@/features/table/components/sortable-header';
+import {
+  createTextFilterFn,
+  createSelectFilterFn,
+  createDateFilterFn,
+} from '@/features/table/utils/filter-functions';
 import { EditUserOption } from './edit-user-option';
 import { DeleteUserOption } from './delete-user-option';
 import type { User } from '../types';
 
-/**
- * テキストフィルタ関数
- */
-const textFilterFn: FilterFn<User> = (row, columnId, filterValue) => {
-  const value = row.getValue(columnId) as string | null;
-  const search = filterValue as string;
-  if (!search) return true;
-  return (value || '').toLowerCase().includes(search.toLowerCase());
-};
-
-/**
- * SELECTフィルタ関数
- */
-const selectFilterFn: FilterFn<User> = (row, columnId, filterValue) => {
-  const value = row.getValue(columnId) as string | null;
-  const filter = filterValue as string[];
-  if (!filter || filter.length === 0) return true;
-  if (!value) return false;
-  return filter.includes(value);
-};
-
-/**
- * DATEフィルタ関数
- */
-const dateFilterFn: FilterFn<User> = (row, columnId, filterValue) => {
-  const value = row.getValue(columnId) as Date | string | null;
-  const filter = filterValue as {
-    preset?: string;
-    startDate: Date | null;
-    endDate: Date | null;
-  };
-  if (!value) return false;
-  if (!filter.startDate && !filter.endDate) return true;
-
-  const date = new Date(value);
-  const start = filter.startDate ? new Date(filter.startDate) : new Date(0);
-  const end = filter.endDate
-    ? new Date(filter.endDate)
-    : new Date(8640000000000000);
-
-  start.setHours(0, 0, 0, 0);
-  end.setHours(23, 59, 59, 999);
-
-  return date >= start && date <= end;
-};
+// フィルタ関数を生成
+const textFilterFn = createTextFilterFn<User>();
+const selectFilterFn = createSelectFilterFn<User>();
+const dateFilterFn = createDateFilterFn<User>();
 
 /**
  * ユーザーテーブルのカラム定義を生成する関数

--- a/features/user/components/columns.tsx
+++ b/features/user/components/columns.tsx
@@ -94,14 +94,14 @@ export const createColumns = (): ColumnDef<User>[] => [
       <SortableHeader column={column} title="メールアドレス" />
     ),
     cell: ({ row }) => <div className="lowercase">{row.getValue('email')}</div>,
-    meta: { width: 'w-[30%]' },
+    meta: { width: 'w-[30%]', title: 'メールアドレス' },
     filterFn: textFilterFn,
   },
   {
     accessorKey: 'name',
     header: ({ column }) => <SortableHeader column={column} title="名前" />,
     cell: ({ row }) => <div>{row.getValue('name') || 'Unknown'}</div>,
-    meta: { width: 'w-[15%]' },
+    meta: { width: 'w-[15%]', title: '名前' },
     filterFn: textFilterFn,
   },
   {
@@ -111,7 +111,7 @@ export const createColumns = (): ColumnDef<User>[] => [
       const role = row.getValue('role') as string;
       return <div>{role === 'ADMIN' ? '管理者' : 'メンバー'}</div>;
     },
-    meta: { width: 'w-[15%]' },
+    meta: { width: 'w-[15%]', title: 'ロール' },
     filterFn: selectFilterFn,
   },
   {
@@ -121,7 +121,7 @@ export const createColumns = (): ColumnDef<User>[] => [
       const date = row.getValue('createdAt') as Date;
       return <div>{new Date(date).toLocaleDateString('ja-JP')}</div>;
     },
-    meta: { width: 'w-[15%]' },
+    meta: { width: 'w-[15%]', title: '登録日' },
     filterFn: dateFilterFn,
   },
   {

--- a/features/user/components/columns.tsx
+++ b/features/user/components/columns.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState } from 'react';
-import { ColumnDef } from '@tanstack/react-table';
+import { ColumnDef, FilterFn } from '@tanstack/react-table';
 import { MoreHorizontal } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Checkbox } from '@/components/ui/checkbox';
@@ -10,9 +10,56 @@ import {
   DropdownMenuContent,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
+import { SortableHeader } from '@/features/table/components/sortable-header';
 import { EditUserOption } from './edit-user-option';
 import { DeleteUserOption } from './delete-user-option';
 import type { User } from '../types';
+
+/**
+ * テキストフィルタ関数
+ */
+const textFilterFn: FilterFn<User> = (row, columnId, filterValue) => {
+  const value = row.getValue(columnId) as string | null;
+  const search = filterValue as string;
+  if (!search) return true;
+  return (value || '').toLowerCase().includes(search.toLowerCase());
+};
+
+/**
+ * SELECTフィルタ関数
+ */
+const selectFilterFn: FilterFn<User> = (row, columnId, filterValue) => {
+  const value = row.getValue(columnId) as string | null;
+  const filter = filterValue as string[];
+  if (!filter || filter.length === 0) return true;
+  if (!value) return false;
+  return filter.includes(value);
+};
+
+/**
+ * DATEフィルタ関数
+ */
+const dateFilterFn: FilterFn<User> = (row, columnId, filterValue) => {
+  const value = row.getValue(columnId) as Date | string | null;
+  const filter = filterValue as {
+    preset?: string;
+    startDate: Date | null;
+    endDate: Date | null;
+  };
+  if (!value) return false;
+  if (!filter.startDate && !filter.endDate) return true;
+
+  const date = new Date(value);
+  const start = filter.startDate ? new Date(filter.startDate) : new Date(0);
+  const end = filter.endDate
+    ? new Date(filter.endDate)
+    : new Date(8640000000000000);
+
+  start.setHours(0, 0, 0, 0);
+  end.setHours(23, 59, 59, 999);
+
+  return date >= start && date <= end;
+};
 
 /**
  * ユーザーテーブルのカラム定義を生成する関数
@@ -43,33 +90,39 @@ export const createColumns = (): ColumnDef<User>[] => [
   },
   {
     accessorKey: 'email',
-    header: 'メールアドレス',
+    header: ({ column }) => (
+      <SortableHeader column={column} title="メールアドレス" />
+    ),
     cell: ({ row }) => <div className="lowercase">{row.getValue('email')}</div>,
     meta: { width: 'w-[30%]' },
+    filterFn: textFilterFn,
   },
   {
     accessorKey: 'name',
-    header: '名前',
+    header: ({ column }) => <SortableHeader column={column} title="名前" />,
     cell: ({ row }) => <div>{row.getValue('name') || 'Unknown'}</div>,
     meta: { width: 'w-[15%]' },
+    filterFn: textFilterFn,
   },
   {
     accessorKey: 'role',
-    header: 'ロール',
+    header: ({ column }) => <SortableHeader column={column} title="ロール" />,
     cell: ({ row }) => {
       const role = row.getValue('role') as string;
       return <div>{role === 'ADMIN' ? '管理者' : 'メンバー'}</div>;
     },
     meta: { width: 'w-[15%]' },
+    filterFn: selectFilterFn,
   },
   {
     accessorKey: 'createdAt',
-    header: '登録日',
+    header: ({ column }) => <SortableHeader column={column} title="登録日" />,
     cell: ({ row }) => {
       const date = row.getValue('createdAt') as Date;
       return <div>{new Date(date).toLocaleDateString('ja-JP')}</div>;
     },
     meta: { width: 'w-[15%]' },
+    filterFn: dateFilterFn,
   },
   {
     id: 'actions',

--- a/features/user/components/user-table.tsx
+++ b/features/user/components/user-table.tsx
@@ -17,8 +17,9 @@ import { useLocalStorage } from '@/hooks/use-local-storage';
 import { CreateUserButton } from './create-user-button';
 import { BulkDeleteButton } from './bulk-delete-button';
 import { createColumns } from './columns';
-import { Input } from '@/components/ui/input';
 import { ColumnVisibilityButton } from '@/features/table/components/column-visibility-button';
+import { FilterButton } from '@/features/table/components/filter-button';
+import type { Column } from '@/features/column/types';
 import {
   Table,
   TableBody,
@@ -37,6 +38,54 @@ type UserTableProps = {
   initialFilters?: ColumnFiltersState;
   initialSorting?: SortingState;
 };
+
+/**
+ * ユーザーテーブル用のフィルター可能なカラム定義
+ */
+const filterableColumns: Column[] = [
+  {
+    id: 'email',
+    name: 'メールアドレス',
+    type: 'TEXT',
+    order: 0,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    enableFilter: true,
+  },
+  {
+    id: 'name',
+    name: '名前',
+    type: 'TEXT',
+    order: 1,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    enableFilter: true,
+  },
+  {
+    id: 'role',
+    name: 'ロール',
+    type: 'SELECT',
+    order: 2,
+    config: {
+      options: [
+        { id: 'ADMIN', label: '管理者' },
+        { id: 'MEMBER', label: 'メンバー' },
+      ],
+    },
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    enableFilter: true,
+  },
+  {
+    id: 'createdAt',
+    name: '登録日',
+    type: 'DATE',
+    order: 3,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    enableFilter: true,
+  },
+];
 
 /**
  * ユーザーテーブルコンポーネント
@@ -89,13 +138,10 @@ export function UserTable({
   return (
     <div className="w-full">
       <div className="flex items-center justify-between py-4">
-        <Input
-          placeholder="メールアドレスで検索..."
-          value={(table.getColumn('email')?.getFilterValue() as string) ?? ''}
-          onChange={(event) =>
-            table.getColumn('email')?.setFilterValue(event.target.value)
-          }
-          className="max-w-sm"
+        <FilterButton
+          columns={filterableColumns}
+          columnFilters={columnFilters}
+          onColumnFiltersChange={setColumnFilters}
         />
         <div className="flex items-center gap-2">
           <ColumnVisibilityButton table={table} />

--- a/features/user/types/index.ts
+++ b/features/user/types/index.ts
@@ -1,9 +1,1 @@
 export * from './user';
-
-// TanStack Tableのメタ型を拡張
-declare module '@tanstack/react-table' {
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  interface ColumnMeta<TData, TValue> {
-    width?: string;
-  }
-}

--- a/types/tanstack-table.d.ts
+++ b/types/tanstack-table.d.ts
@@ -1,0 +1,15 @@
+/**
+ * TanStack Table型拡張
+ * プロジェクト全体で使用するカラムメタ型を定義
+ */
+declare module '@tanstack/react-table' {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  interface ColumnMeta<TData, TValue> {
+    /** カラムの幅クラス（Tailwind CSS） */
+    width?: string;
+    /** カラムの表示名（ColumnVisibilityButtonで使用） */
+    title?: string;
+  }
+}
+
+export {};


### PR DESCRIPTION
## 概要

ユーザーテーブル(`user-table`)とグループテーブル(`group-table`)をデータテーブル(`data-table`)と同じUI/UXに統一しました。

## 実装内容

### 1. フィルタ機能の統一

- `FilterButton`コンポーネントを導入（data-tableと同じ）
- 複数カラムのフィルタに対応
- フィルタ関数（`textFilterFn`, `selectFilterFn`, `dateFilterFn`）を各カラム定義に追加

**ユーザーテーブル**:
- メールアドレス（TEXT）
- 名前（TEXT）
- ロール（SELECT）
- 登録日（DATE）

**グループテーブル**:
- グループ名（TEXT）
- 説明（TEXT）
- 作成日（DATE）

### 2. ソート機能の追加

- カラムヘッダーに`SortableHeader`を使用（data-tableと同じ）
- クリックでソート切り替え（昇順→降順→なし）

### 3. カラム表示・非表示の改善

- **型定義の拡張**: `types/tanstack-table.d.ts`でColumnMetaに`title`プロパティを追加
- 内部的なカラム名から日本語表示名に変更
  - ユーザーテーブル: `email` → `メールアドレス`, `name` → `名前`, `role` → `ロール`, `createdAt` → `登録日`
  - グループテーブル: `name` → `グループ名`, `description` → `説明`, `parentId` → `親グループ`, `members` → `メンバー数`, `createdAt` → `作成日`

### 4. 日付フィルタUIの改善

- カスタム日付選択時のレイアウトを2行に変更（ダイアログからはみ出さないように）
- 開始日・終了日のラベルを追加（視認性向上）
- カレンダーで日付選択時に自動的にポップオーバーを閉じる機能を追加

## テスト

- [x] ユーザーテーブルでフィルタが正しく動作することを確認
- [x] グループテーブルでフィルタが正しく動作することを確認
- [x] カラム表示/非表示ボタンで日本語表示名が表示されることを確認
- [x] 日付フィルタのカスタム選択でUIが正しく表示されることを確認
- [x] カレンダーで日付選択時に自動的に閉じることを確認

## 関連Issue

Closes #74

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 列ヘッダーがソート可能になりました。
  * フィルターが拡張され、テキスト・日付（開始／終了）・数値・選択・チェックボックス・リレーションをサポートします。
  * CSVエクスポートに「親グループ」列とレコードID／関連表示ラベルが追加されました。

* **UX Improvements**
  * 各列のFilterボタンで統一されたフィルター操作が可能に。
  * 日付フィルターが開始日／終了日で分かれ、操作性が向上しました。
  * 選択系入力の値の正規化で挙動がより安定しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->