### PR TITLE
フォルダ管理機能の強化およびワークスペースUIの統一

### DIFF
--- a/app/(protected)/workspace/page.tsx
+++ b/app/(protected)/workspace/page.tsx
@@ -1,5 +1,5 @@
-import Link from 'next/link';
 import { getItems } from '@/features/item/api';
+import { WorkspaceLayout } from '@/features/workspace/components';
 
 export const dynamic = 'force-dynamic';
 
@@ -7,45 +7,7 @@ export const dynamic = 'force-dynamic';
  * ワークスペースページ
  */
 export default async function WorkspacePage() {
-  const folders = await getItems();
+  const items = await getItems();
 
-  return (
-    <div className="container mx-auto p-6">
-      <div className="mb-6 flex items-center justify-between">
-        <h1 className="text-2xl font-bold">ワークスペース</h1>
-      </div>
-
-      <div className="grid gap-4">
-        {folders.length > 0 ? (
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-            {folders.map((folder) => (
-              <Link
-                key={folder.id}
-                href={`/${folder.id}`}
-                className="block rounded-lg border p-4 hover:bg-accent transition-colors"
-              >
-                <h2 className="font-semibold mb-2">{folder.name}</h2>
-                <div className="text-sm text-muted-foreground space-y-1">
-                  {folder._count && (
-                    <p>子フォルダ数: {folder._count.children}</p>
-                  )}
-                  <p>
-                    作成日時:{' '}
-                    {new Date(folder.createdAt).toLocaleString('ja-JP')}
-                  </p>
-                </div>
-              </Link>
-            ))}
-          </div>
-        ) : (
-          <div className="rounded-lg border p-8 text-center">
-            <p className="text-muted-foreground">ワークスペースがありません</p>
-            <p className="text-sm text-muted-foreground mt-2">
-              サイドバーの「ワークスペース」から新しいワークスペースを作成できます
-            </p>
-          </div>
-        )}
-      </div>
-    </div>
-  );
+  return <WorkspaceLayout items={items} />;
 }

--- a/features/folder/components/folder-layout.tsx
+++ b/features/folder/components/folder-layout.tsx
@@ -311,9 +311,9 @@ export function FolderLayout({ item }: FolderLayoutProps) {
         </DndContext>
       ) : (
         <div className="rounded-lg border p-8 text-center">
-          <p className="text-muted-foreground">このフォルダは空です</p>
+          <p className="text-muted-foreground">アイテムがありません</p>
           <p className="text-sm text-muted-foreground mt-2">
-            サイドバーの「ワークスペース」から新しいアイテムを作成できます
+            「新規作成」ボタンから新しいアイテムを作成できます
           </p>
         </div>
       )}

--- a/features/folder/components/folder-layout.tsx
+++ b/features/folder/components/folder-layout.tsx
@@ -1,15 +1,13 @@
 'use client';
 
 import { useState, useRef, useCallback, useMemo, useEffect } from 'react';
-import Link from 'next/link';
 import { useRouter } from 'next/navigation';
-import { Settings2 } from 'lucide-react';
-import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { getItemIcon } from '@/features/item/utils';
 import { ITEM_CONFIGS } from '@/features/item/constants';
 import { reorderItems } from '@/features/item/api';
+import { CreateItemButton } from '@/features/item/components';
 import type { Item } from '@/features/item/types';
 import {
   DndContext,
@@ -265,14 +263,12 @@ export function FolderLayout({ item }: FolderLayoutProps) {
 
   return (
     <div className="container mx-auto p-6">
-      <div className="mb-6 flex items-center justify-between">
+      <div className="mb-6">
         <h1 className="text-2xl font-bold">{item.name}</h1>
-        <Link href={`/${item.id}/edit`}>
-          <Button variant="outline">
-            <Settings2 className="size-4" />
-            フォルダ管理
-          </Button>
-        </Link>
+      </div>
+
+      <div className="mb-6 flex items-center justify-end">
+        <CreateItemButton parentId={item.id} />
       </div>
 
       {sortedChildren.length > 0 ? (

--- a/features/folder/components/folder-layout.tsx
+++ b/features/folder/components/folder-layout.tsx
@@ -82,16 +82,23 @@ function SortableGridItem({
   };
 
   return (
-    <div
+    <button
       ref={setNodeRef}
       style={style}
       {...attributes}
       {...listeners}
-      className="touch-none cursor-pointer"
+      className="touch-none cursor-pointer w-full text-left"
       onClick={handleClick}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          handleClick(e as unknown as React.MouseEvent);
+        }
+      }}
+      type="button"
     >
       <Card
-        className={`flex flex-col h-full p-4 ${isDropTarget ? 'bg-primary/10' : ''}`}
+        className={`flex flex-col h-full p-4 ${isDropTarget ? 'bg-primary/10' : ''} hover:bg-accent/50 transition-colors focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none`}
       >
         <div className="flex justify-end mb-2">
           <Badge variant="secondary" className="flex items-center">
@@ -105,7 +112,7 @@ function SortableGridItem({
           <h2 className="font-semibold text-lg line-clamp-2">{child.name}</h2>
         </div>
       </Card>
-    </div>
+    </button>
   );
 }
 

--- a/features/item/components/create-item-button/create-folder-option.tsx
+++ b/features/item/components/create-item-button/create-folder-option.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState, useActionState, useEffect } from 'react';
-import { Table } from 'lucide-react';
+import { Folder } from 'lucide-react';
 import {
   Dialog,
   DialogContent,
@@ -15,53 +15,53 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { toast } from 'sonner';
-import { createTable } from '@/features/item/api/create-table';
+import { createFolder } from '@/features/item/api/create-folder';
 
 /**
- * テーブル作成オプションのProps型
+ * フォルダ作成オプションのProps型
  */
-type CreateTableOptionProps = {
-  parentId: string;
+type CreateFolderOptionProps = {
+  parentId?: string;
   onOpenChange: (open: boolean) => void;
 };
 
 /**
- * テーブル作成コンテンツのProps型
+ * フォルダ作成コンテンツのProps型
  */
-type CreateTableContentProps = {
-  parentId: string;
+type CreateFolderContentProps = {
+  parentId?: string;
   onClose: () => void;
 };
 
 /**
- * テーブル作成コンテンツコンポーネント
+ * フォルダ作成コンテンツコンポーネント
  */
-function CreateTableContent({ parentId, onClose }: CreateTableContentProps) {
-  const [state, formAction] = useActionState(createTable, {});
+function CreateFolderContent({ parentId, onClose }: CreateFolderContentProps) {
+  const [state, formAction] = useActionState(createFolder, {});
 
   // 成功・エラー時の処理
   useEffect(() => {
     if (state.error) {
-      toast.error('テーブルの作成に失敗しました', {
+      toast.error('フォルダの作成に失敗しました', {
         description: state.error,
       });
     } else if (state.success) {
-      toast.success('テーブルを作成しました');
+      toast.success('フォルダを作成しました');
       onClose();
     }
   }, [state, onClose]);
 
   return (
     <form action={formAction}>
-      <input type="hidden" name="parentId" value={parentId} />
+      {parentId && <input type="hidden" name="parentId" value={parentId} />}
 
       <div className="grid gap-4 py-4">
         <div className="grid gap-2">
-          <Label htmlFor="name">テーブル名</Label>
+          <Label htmlFor="name">フォルダ名</Label>
           <Input
             id="name"
             name="name"
-            placeholder="テーブル名を入力"
+            placeholder="フォルダ名を入力"
             autoFocus
             required
           />
@@ -86,12 +86,12 @@ function CreateTableContent({ parentId, onClose }: CreateTableContentProps) {
 }
 
 /**
- * テーブル作成オプションコンポーネント
+ * フォルダ作成オプションコンポーネント
  */
-export function CreateTableOption({
+export function CreateFolderOption({
   parentId,
   onOpenChange: onDropdownOpenChange,
-}: CreateTableOptionProps) {
+}: CreateFolderOptionProps) {
   const [open, setOpen] = useState(false);
   const [resetKey, setResetKey] = useState(0);
 
@@ -115,17 +115,17 @@ export function CreateTableOption({
           setOpen(true);
         }}
       >
-        <Table />
-        テーブルを追加
+        <Folder />
+        フォルダを追加
       </DropdownMenuItem>
 
       <Dialog open={open} onOpenChange={handleOpenChange}>
         <DialogContent>
           <DialogHeader>
-            <DialogTitle>テーブルを作成</DialogTitle>
-            <DialogDescription>新しいテーブルを作成します</DialogDescription>
+            <DialogTitle>フォルダを作成</DialogTitle>
+            <DialogDescription>新しいフォルダを作成します</DialogDescription>
           </DialogHeader>
-          <CreateTableContent
+          <CreateFolderContent
             key={resetKey}
             parentId={parentId}
             onClose={handleClose}

--- a/features/item/components/create-item-button/create-table-option.tsx
+++ b/features/item/components/create-item-button/create-table-option.tsx
@@ -21,7 +21,7 @@ import { createTable } from '@/features/item/api/create-table';
  * テーブル作成オプションのProps型
  */
 type CreateTableOptionProps = {
-  parentId: string;
+  parentId?: string;
   onOpenChange: (open: boolean) => void;
 };
 
@@ -29,7 +29,7 @@ type CreateTableOptionProps = {
  * テーブル作成コンテンツのProps型
  */
 type CreateTableContentProps = {
-  parentId: string;
+  parentId?: string;
   onClose: () => void;
 };
 
@@ -53,7 +53,7 @@ function CreateTableContent({ parentId, onClose }: CreateTableContentProps) {
 
   return (
     <form action={formAction}>
-      <input type="hidden" name="parentId" value={parentId} />
+      {parentId && <input type="hidden" name="parentId" value={parentId} />}
 
       <div className="grid gap-4 py-4">
         <div className="grid gap-2">

--- a/features/item/components/create-item-button/index.tsx
+++ b/features/item/components/create-item-button/index.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import { useState } from 'react';
+import { Plus } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import { CreateFolderOption } from './create-folder-option';
+import { CreateTableOption } from './create-table-option';
+
+/**
+ * アイテム作成ボタンのProps型
+ */
+type CreateItemButtonProps = {
+  parentId?: string;
+};
+
+/**
+ * アイテム作成ボタンコンポーネント
+ */
+export function CreateItemButton({ parentId }: CreateItemButtonProps) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <DropdownMenu open={open} onOpenChange={setOpen}>
+      <DropdownMenuTrigger asChild>
+        <Button>
+          <Plus />
+          新規作成
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        <CreateFolderOption parentId={parentId} onOpenChange={setOpen} />
+        <CreateTableOption parentId={parentId} onOpenChange={setOpen} />
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/features/item/components/index.ts
+++ b/features/item/components/index.ts
@@ -1,2 +1,3 @@
 export { ItemIconPicker } from './item-icon-picker';
 export { IconPickerDialog } from './icon-picker-dialog';
+export { CreateItemButton } from './create-item-button/index';

--- a/features/layout/components/item-options-button/index.tsx
+++ b/features/layout/components/item-options-button/index.tsx
@@ -1,17 +1,38 @@
 'use client';
 
 import { useState, useEffect, useCallback } from 'react';
-import { useSearchParams } from 'next/navigation';
-import { Ellipsis, FileOutput, FileInput } from 'lucide-react';
+import { useSearchParams, useRouter } from 'next/navigation';
+import {
+  Ellipsis,
+  FileOutput,
+  FileInput,
+  Settings,
+  Trash2,
+  AlertCircle,
+} from 'lucide-react';
+import Link from 'next/link';
 import type { PageType } from './container';
 import type { ExportColumnFilter } from '@/features/table/types/export';
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
 import { Button } from '@/components/ui/button';
+import { toast } from 'sonner';
+import { deleteItem } from '@/features/item/api';
 import { exportTableAction } from '@/features/table/actions/export-table';
 import { exportUsersAction } from '@/features/user/actions/export-users';
 import { exportGroupsAction } from '@/features/group/actions/export-groups';
@@ -38,24 +59,27 @@ export function ItemOptionsButton({
   pageType,
   itemId,
 }: ItemOptionsButtonProps) {
+  const router = useRouter();
   const searchParams = useSearchParams();
   const [importDialogOpen, setImportDialogOpen] = useState(false);
-  const [tableName, setTableName] = useState<string>('');
+  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
+  const [itemName, setItemName] = useState<string>('');
 
   // エクスポート可能なページタイプ
   const exportableTypes: PageType[] = ['TABLE', 'USERS', 'GROUPS'];
 
-  // テーブル名を取得（TABLE用）
+  // アイテム名を取得（TABLE/FOLDER用）
   useEffect(() => {
-    if (pageType !== 'TABLE' || !itemId) return;
+    if ((pageType !== 'TABLE' && pageType !== 'FOLDER') || !itemId) return;
 
-    const fetchTableName = async () => {
+    const fetchItemName = async () => {
       const item = await getItemById(itemId);
       if (item) {
-        setTableName(item.name);
+        setItemName(item.name);
       }
     };
-    fetchTableName();
+    fetchItemName();
   }, [pageType, itemId]);
 
   // インポート実行関数
@@ -73,7 +97,32 @@ export function ItemOptionsButton({
     [pageType, itemId]
   );
 
-  if (!exportableTypes.includes(pageType)) {
+  // 削除ハンドラー
+  const handleDelete = async () => {
+    if (!itemId) return;
+
+    setIsDeleting(true);
+
+    const result = await deleteItem(itemId);
+
+    setDeleteDialogOpen(false);
+    setIsDeleting(false);
+
+    if (result.error) {
+      toast.error('削除に失敗しました', {
+        description: result.error,
+      });
+    } else {
+      const itemLabel = pageType === 'TABLE' ? 'テーブル' : 'フォルダ';
+      toast.success(`${itemLabel}を削除しました`, {
+        description: `${itemName}を削除しました`,
+      });
+      router.push('/workspace');
+    }
+  };
+
+  // 表示条件: エクスポート可能 または FOLDER
+  if (!exportableTypes.includes(pageType) && pageType !== 'FOLDER') {
     return null;
   }
 
@@ -127,21 +176,103 @@ export function ItemOptionsButton({
           </Button>
         </DropdownMenuTrigger>
         <DropdownMenuContent align="end">
-          <DropdownMenuItem onSelect={() => setImportDialogOpen(true)}>
-            <FileInput />
-            インポート
-          </DropdownMenuItem>
-          <DropdownMenuItem onSelect={handleExport}>
-            <FileOutput />
-            エクスポート
-          </DropdownMenuItem>
+          {pageType === 'TABLE' && itemId && (
+            <>
+              <DropdownMenuItem asChild>
+                <Link href={`/${itemId}/edit`} className="cursor-pointer">
+                  <Settings />
+                  テーブル管理
+                </Link>
+              </DropdownMenuItem>
+              <DropdownMenuItem
+                className="text-destructive hover:text-destructive focus:text-destructive"
+                onSelect={(e) => {
+                  e.preventDefault();
+                  setDeleteDialogOpen(true);
+                }}
+              >
+                <Trash2 className="text-destructive" />
+                削除
+              </DropdownMenuItem>
+              <DropdownMenuSeparator />
+            </>
+          )}
+          {pageType === 'FOLDER' && itemId && (
+            <>
+              <DropdownMenuItem asChild>
+                <Link href={`/${itemId}/edit`} className="cursor-pointer">
+                  <Settings />
+                  フォルダ管理
+                </Link>
+              </DropdownMenuItem>
+              <DropdownMenuItem
+                className="text-destructive hover:text-destructive focus:text-destructive"
+                onSelect={(e) => {
+                  e.preventDefault();
+                  setDeleteDialogOpen(true);
+                }}
+              >
+                <Trash2 className="text-destructive" />
+                削除
+              </DropdownMenuItem>
+            </>
+          )}
+          {exportableTypes.includes(pageType) && (
+            <>
+              <DropdownMenuItem onSelect={() => setImportDialogOpen(true)}>
+                <FileInput />
+                インポート
+              </DropdownMenuItem>
+              <DropdownMenuItem onSelect={handleExport}>
+                <FileOutput />
+                エクスポート
+              </DropdownMenuItem>
+            </>
+          )}
         </DropdownMenuContent>
       </DropdownMenu>
+
+      {/* 削除確認ダイアログ */}
+      {(pageType === 'TABLE' || pageType === 'FOLDER') && itemId && (
+        <AlertDialog open={deleteDialogOpen} onOpenChange={setDeleteDialogOpen}>
+          <AlertDialogContent>
+            <AlertDialogHeader>
+              <div className="flex items-center space-x-2">
+                <AlertCircle className="text-destructive" />
+                <AlertDialogTitle className="text-destructive">
+                  {itemName}を削除
+                </AlertDialogTitle>
+              </div>
+              <AlertDialogDescription>
+                削除した{pageType === 'TABLE' ? 'テーブル' : 'フォルダ'}
+                は復元できません。
+                <br />
+                {pageType === 'TABLE' ? 'テーブル' : 'フォルダ'}
+                内のすべてのデータが完全に削除されます。
+                <br />
+                本当に削除しますか？
+              </AlertDialogDescription>
+            </AlertDialogHeader>
+            <AlertDialogFooter>
+              <AlertDialogCancel disabled={isDeleting}>
+                キャンセル
+              </AlertDialogCancel>
+              <AlertDialogAction
+                onClick={handleDelete}
+                disabled={isDeleting}
+                className="bg-destructive text-white hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60"
+              >
+                {isDeleting ? '削除中...' : '削除'}
+              </AlertDialogAction>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialog>
+      )}
 
       {/* インポートダイアログ */}
       {pageType === 'TABLE' && itemId && (
         <ImportDialog
-          title={`${tableName} - データインポート`}
+          title={`${itemName} - データインポート`}
           description="CSVファイルからレコードデータを一括インポートします"
           previewMessage={(count) => `${count}件のレコードをインポートします`}
           noticeMessage="レコードIDが存在する場合は既存レコードを更新、存在しない場合は新規作成します"

--- a/features/layout/components/workspace-menu/create-item-button/create-folder-option.tsx
+++ b/features/layout/components/workspace-menu/create-item-button/create-folder-option.tsx
@@ -69,10 +69,17 @@ function CreateFolderContent({ parentId, onClose }: CreateFolderContentProps) {
       </div>
 
       <DialogFooter>
-        <Button type="button" variant="outline" onClick={onClose}>
+        <Button
+          type="button"
+          variant="outline"
+          className="cursor-pointer"
+          onClick={onClose}
+        >
           キャンセル
         </Button>
-        <Button type="submit">作成</Button>
+        <Button type="submit" className="cursor-pointer">
+          作成
+        </Button>
       </DialogFooter>
     </form>
   );

--- a/features/workspace/components/index.ts
+++ b/features/workspace/components/index.ts
@@ -1,0 +1,1 @@
+export { WorkspaceLayout } from './workspace-layout';

--- a/features/workspace/components/workspace-layout.tsx
+++ b/features/workspace/components/workspace-layout.tsx
@@ -1,0 +1,65 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { Card } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { getItemIcon } from '@/features/item/utils';
+import { ITEM_CONFIGS } from '@/features/item/constants';
+import type { Item } from '@/features/item/types';
+
+type WorkspaceLayoutProps = {
+  items: Item[];
+};
+
+function GridItem({ item }: { item: Item }) {
+  const router = useRouter();
+  const Icon = getItemIcon(item);
+  const DefaultIcon = ITEM_CONFIGS[item.type].icon;
+
+  const handleClick = () => {
+    router.push(`/${item.id}`);
+  };
+
+  return (
+    <div className="cursor-pointer" onClick={handleClick}>
+      <Card className="flex flex-col h-full p-4 hover:bg-accent/50 transition-colors">
+        <div className="flex justify-end mb-2">
+          <Badge variant="secondary" className="flex items-center">
+            <DefaultIcon className="size-5!" />
+          </Badge>
+        </div>
+        <div className="flex-1 flex items-center justify-center">
+          <Icon className="size-12 text-primary" />
+        </div>
+        <div className="text-center mt-2">
+          <h2 className="font-semibold text-lg line-clamp-2">{item.name}</h2>
+        </div>
+      </Card>
+    </div>
+  );
+}
+
+export function WorkspaceLayout({ items }: WorkspaceLayoutProps) {
+  return (
+    <div className="container mx-auto p-6">
+      <div className="mb-6">
+        <h1 className="text-2xl font-bold">ワークスペース</h1>
+      </div>
+
+      {items.length > 0 ? (
+        <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-4">
+          {items.map((item) => (
+            <GridItem key={item.id} item={item} />
+          ))}
+        </div>
+      ) : (
+        <div className="rounded-lg border p-8 text-center">
+          <p className="text-muted-foreground">ワークスペースがありません</p>
+          <p className="text-sm text-muted-foreground mt-2">
+            サイドバーの「ワークスペース」から新しいアイテムを作成できます
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/features/workspace/components/workspace-layout.tsx
+++ b/features/workspace/components/workspace-layout.tsx
@@ -71,9 +71,9 @@ export function WorkspaceLayout({ items }: WorkspaceLayoutProps) {
         </div>
       ) : (
         <div className="rounded-lg border p-8 text-center">
-          <p className="text-muted-foreground">ワークスペースがありません</p>
+          <p className="text-muted-foreground">アイテムがありません</p>
           <p className="text-sm text-muted-foreground mt-2">
-            サイドバーの「ワークスペース」から新しいアイテムを作成できます
+            「新規作成」ボタンから新しいアイテムを作成できます
           </p>
         </div>
       )}

--- a/features/workspace/components/workspace-layout.tsx
+++ b/features/workspace/components/workspace-layout.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import { useMemo, createElement } from 'react';
+
 import { useRouter } from 'next/navigation';
 import { Card } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
@@ -14,7 +16,7 @@ type WorkspaceLayoutProps = {
 
 function GridItem({ item }: { item: Item }) {
   const router = useRouter();
-  const Icon = getItemIcon(item);
+  const icon = useMemo(() => getItemIcon(item), [item]);
   const DefaultIcon = ITEM_CONFIGS[item.type].icon;
 
   const handleClick = () => {
@@ -30,7 +32,7 @@ function GridItem({ item }: { item: Item }) {
           </Badge>
         </div>
         <div className="flex-1 flex items-center justify-center">
-          <Icon className="size-12 text-primary" />
+          {createElement(icon, { className: 'size-12 text-primary' })}
         </div>
         <div className="text-center mt-2">
           <h2 className="font-semibold text-lg line-clamp-2">{item.name}</h2>

--- a/features/workspace/components/workspace-layout.tsx
+++ b/features/workspace/components/workspace-layout.tsx
@@ -5,6 +5,7 @@ import { Card } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { getItemIcon } from '@/features/item/utils';
 import { ITEM_CONFIGS } from '@/features/item/constants';
+import { CreateItemButton } from '@/features/item/components';
 import type { Item } from '@/features/item/types';
 
 type WorkspaceLayoutProps = {
@@ -44,6 +45,10 @@ export function WorkspaceLayout({ items }: WorkspaceLayoutProps) {
     <div className="container mx-auto p-6">
       <div className="mb-6">
         <h1 className="text-2xl font-bold">ワークスペース</h1>
+      </div>
+
+      <div className="mb-6 flex items-center justify-end">
+        <CreateItemButton />
       </div>
 
       {items.length > 0 ? (

--- a/features/workspace/components/workspace-layout.tsx
+++ b/features/workspace/components/workspace-layout.tsx
@@ -24,8 +24,18 @@ function GridItem({ item }: { item: Item }) {
   };
 
   return (
-    <div className="cursor-pointer" onClick={handleClick}>
-      <Card className="flex flex-col h-full p-4 hover:bg-accent/50 transition-colors">
+    <button
+      type="button"
+      className="cursor-pointer w-full text-left"
+      onClick={handleClick}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          handleClick();
+        }
+      }}
+    >
+      <Card className="flex flex-col h-full p-4 hover:bg-accent/50 transition-colors focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none">
         <div className="flex justify-end mb-2">
           <Badge variant="secondary" className="flex items-center">
             <DefaultIcon className="size-5!" />
@@ -38,7 +48,7 @@ function GridItem({ item }: { item: Item }) {
           <h2 className="font-semibold text-lg line-clamp-2">{item.name}</h2>
         </div>
       </Card>
-    </div>
+    </button>
   );
 }
 


### PR DESCRIPTION
## 概要
フォルダ詳細画面およびヘッダーにおける3点リーダーメニューの仕様を整備し、テーブル画面やワークスペース画面とのUI統一を行いました。
また、フォルダに対する「管理」「削除」機能を実装しました。

## 変更内容

### 機能追加
- **フォルダメニューの実装**:
  - フォルダに対しても3点リーダーメニューを表示するようにしました。
  - メニュー項目:
    - **フォルダ管理**: フォルダの設定画面へ遷移します。
    - **削除**: 削除確認ダイアログを表示し、フォルダを削除します。
  - ※インポート/エクスポート機能はフォルダには表示されません。

## 動作確認

- **フォルダメニューの確認**:
   - 任意のフォルダを開き、画面右上のヘッダーにある「︙」ボタンをクリックする。
   - 「フォルダ管理」「削除」が表示され、「インポート/エクスポート」が表示されないことを確認する。
- **機能動作の確認**:
   - 「フォルダ管理」をクリックし、設定画面へ遷移できることを確認する。
   - 「削除」をクリックし、確認ダイアログが表示されることを確認する。

## 関連Issue

Closes #83

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * ワークスペース向けの新レイアウトを追加し、アイテム表示を統一
  * 「新規作成」ボタンにフォルダ作成・テーブル作成のモーダルフローを追加
  * アイテム操作メニューに削除（確認ダイアログ）を追加し、削除後の遷移と通知を実装

* **UI改善**
  * アイテムカードとフォルダ項目をキーボード操作可能なボタンに変更しアクセシビリティ向上
  * ヘッダー操作を右寄せに整理、ボタンのホバー／フォーカスとカーソル表示を改善
  * 空フォルダ文言をより自然な日本語表現に更新

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->