### PR TITLE
リレーション参照先にUsers・Groupsを追加

### DIFF
--- a/features/column/components/config/relation-config-editor.tsx
+++ b/features/column/components/config/relation-config-editor.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import { Label } from '@/components/ui/label';
 import {
   Select,
@@ -10,8 +10,29 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 import { Checkbox } from '@/components/ui/checkbox';
-import type { ColumnTypeConfig } from '../../types/column';
+import type { ColumnTypeConfig, SystemTable } from '../../types/column';
 import type { Item } from '@/features/item/types';
+
+/**
+ * システムテーブルの定義
+ */
+const SYSTEM_TABLES: SystemTable[] = [
+  {
+    id: 'users',
+    name: 'ユーザー',
+    type: 'SYSTEM',
+    fields: [
+      { id: 'name', name: '名前', type: 'text' },
+      { id: 'email', name: 'メールアドレス', type: 'text' },
+    ],
+  },
+  {
+    id: 'groups',
+    name: 'グループ',
+    type: 'SYSTEM',
+    fields: [{ id: 'name', name: 'グループ名', type: 'text' }],
+  },
+];
 
 /**
  * RelationConfigEditorのProps
@@ -43,26 +64,44 @@ export function RelationConfigEditor({
     setLocalConfig(config);
   }, [config]);
 
+  // 参照可能なテーブル一覧（システムテーブル + 通常のテーブル）
+  const selectableTables = useMemo(
+    () => [
+      ...SYSTEM_TABLES,
+      ...tables
+        .filter(
+          (table) => table.type === 'TABLE' && table.id !== currentTableId
+        )
+        .map((table) => ({
+          id: table.id,
+          name: table.name,
+          type: 'TABLE' as const,
+          fields:
+            (
+              table.meta as {
+                schema?: { columns?: Array<{ id: string; name: string }> };
+              }
+            )?.schema?.columns || [],
+        })),
+    ],
+    [tables, currentTableId]
+  );
+
   // 参照先テーブルが選択されたら、そのテーブルのカラム一覧を取得
   useEffect(() => {
     if (localConfig.referencedTableId) {
-      const selectedTable = tables.find(
+      const selectedTable = selectableTables.find(
         (t) => t.id === localConfig.referencedTableId
       );
-      if (selectedTable && selectedTable.type === 'TABLE') {
-        // メタデータからカラム一覧を取得
-        const tableMeta = selectedTable.meta as {
-          schema?: { columns?: Array<{ id: string; name: string }> };
-        };
-        const columns = tableMeta?.schema?.columns || [];
-        setAvailableFields(columns);
+      if (selectedTable) {
+        setAvailableFields(selectedTable.fields);
       } else {
         setAvailableFields([]);
       }
     } else {
       setAvailableFields([]);
     }
-  }, [localConfig.referencedTableId, tables]);
+  }, [localConfig.referencedTableId, tables, selectableTables]);
 
   // 参照先テーブル変更
   const handleTableChange = (tableId: string) => {
@@ -88,11 +127,6 @@ export function RelationConfigEditor({
     setLocalConfig(newConfig);
     onChange(newConfig);
   };
-
-  // 参照可能なテーブル一覧（自己参照を除外）
-  const selectableTables = tables.filter(
-    (table) => table.type === 'TABLE' && table.id !== currentTableId
-  );
 
   return (
     <div className="space-y-4">

--- a/features/column/types/column.ts
+++ b/features/column/types/column.ts
@@ -32,6 +32,25 @@ export type RelationRecord = {
 };
 
 /**
+ * システムテーブルのタイプ
+ */
+export type SystemTableType = 'users' | 'groups';
+
+/**
+ * システムテーブルの型
+ */
+export type SystemTable = {
+  id: SystemTableType;
+  name: string;
+  type: 'SYSTEM';
+  fields: {
+    id: string;
+    name: string;
+    type: string;
+  }[];
+};
+
+/**
  * 日付精度の型
  */
 export type DatePrecision = 'year' | 'month' | 'day' | 'day_weekday';

--- a/features/record/api/__tests__/get-relation-records.test.ts
+++ b/features/record/api/__tests__/get-relation-records.test.ts
@@ -10,7 +10,18 @@ jest.mock('@/lib/prisma', () => ({
   },
 }));
 
+// システムテーブルAPIをモック化
+jest.mock('@/features/user/api/get-users', () => ({
+  getUsers: jest.fn(),
+}));
+
+jest.mock('@/features/group/api/get-groups', () => ({
+  getGroups: jest.fn(),
+}));
+
 import { prisma } from '@/lib/prisma';
+import { getUsers } from '@/features/user/api/get-users';
+import { getGroups } from '@/features/group/api/get-groups';
 
 describe('getRelationRecords', () => {
   beforeEach(() => {
@@ -385,5 +396,366 @@ describe('getRelationRecords', () => {
         orderBy: { createdAt: 'desc' },
       })
     );
+  });
+
+  describe('システムテーブル: users', () => {
+    it('usersテーブルを参照できる', async () => {
+      const columns: Column[] = [
+        {
+          id: 'col-1',
+          name: '担当者',
+          type: 'RELATION',
+          order: 0,
+          config: {
+            referencedTableId: 'users',
+            displayField: 'name',
+            allowMultiple: false,
+          },
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+      ];
+
+      const mockUsers = [
+        {
+          id: 'user-1',
+          email: 'user1@example.com',
+          name: '山田太郎',
+          role: 'ADMIN',
+          createdAt: new Date('2024-01-01'),
+          updatedAt: new Date('2024-01-01'),
+        },
+        {
+          id: 'user-2',
+          email: 'user2@example.com',
+          name: '佐藤花子',
+          role: 'USER',
+          createdAt: new Date('2024-01-02'),
+          updatedAt: new Date('2024-01-02'),
+        },
+      ];
+
+      (getUsers as jest.Mock).mockResolvedValue(mockUsers);
+
+      const result = await getRelationRecords(columns);
+
+      expect(result.size).toBe(1);
+      expect(result.get('col-1')).toEqual([
+        { id: 'user-1', displayValue: '山田太郎', exists: true },
+        { id: 'user-2', displayValue: '佐藤花子', exists: true },
+      ]);
+      expect(getUsers).toHaveBeenCalledTimes(1);
+      expect(prisma.record.findMany).not.toHaveBeenCalled();
+    });
+
+    it('users: displayFieldにemailを指定できる', async () => {
+      const columns: Column[] = [
+        {
+          id: 'col-1',
+          name: '担当者',
+          type: 'RELATION',
+          order: 0,
+          config: {
+            referencedTableId: 'users',
+            displayField: 'email',
+            allowMultiple: false,
+          },
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+      ];
+
+      const mockUsers = [
+        {
+          id: 'user-1',
+          email: 'user1@example.com',
+          name: '山田太郎',
+          role: 'ADMIN',
+          createdAt: new Date('2024-01-01'),
+          updatedAt: new Date('2024-01-01'),
+        },
+      ];
+
+      (getUsers as jest.Mock).mockResolvedValue(mockUsers);
+
+      const result = await getRelationRecords(columns);
+
+      expect(result.get('col-1')).toEqual([
+        { id: 'user-1', displayValue: 'user1@example.com', exists: true },
+      ]);
+    });
+
+    it('users: displayFieldが空の場合はnameまたはemailを使用する', async () => {
+      const columns: Column[] = [
+        {
+          id: 'col-1',
+          name: '担当者',
+          type: 'RELATION',
+          order: 0,
+          config: {
+            referencedTableId: 'users',
+            displayField: '',
+            allowMultiple: false,
+          },
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+      ];
+
+      const mockUsers = [
+        {
+          id: 'user-1',
+          email: 'user1@example.com',
+          name: '山田太郎',
+          role: 'ADMIN',
+          createdAt: new Date('2024-01-01'),
+          updatedAt: new Date('2024-01-01'),
+        },
+      ];
+
+      (getUsers as jest.Mock).mockResolvedValue(mockUsers);
+
+      const result = await getRelationRecords(columns);
+
+      expect(result.get('col-1')).toEqual([
+        { id: 'user-1', displayValue: '山田太郎', exists: true },
+      ]);
+    });
+
+    it('users: nameが空の場合はemailをフォールバックする', async () => {
+      const columns: Column[] = [
+        {
+          id: 'col-1',
+          name: '担当者',
+          type: 'RELATION',
+          order: 0,
+          config: {
+            referencedTableId: 'users',
+            displayField: 'name',
+            allowMultiple: false,
+          },
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+      ];
+
+      const mockUsers = [
+        {
+          id: 'user-1',
+          email: 'user1@example.com',
+          name: '',
+          role: 'ADMIN',
+          createdAt: new Date('2024-01-01'),
+          updatedAt: new Date('2024-01-01'),
+        },
+      ];
+
+      (getUsers as jest.Mock).mockResolvedValue(mockUsers);
+
+      const result = await getRelationRecords(columns);
+
+      expect(result.get('col-1')).toEqual([
+        { id: 'user-1', displayValue: 'user1@example.com', exists: true },
+      ]);
+    });
+  });
+
+  describe('システムテーブル: groups', () => {
+    it('groupsテーブルを参照できる', async () => {
+      const columns: Column[] = [
+        {
+          id: 'col-1',
+          name: '所属グループ',
+          type: 'RELATION',
+          order: 0,
+          config: {
+            referencedTableId: 'groups',
+            displayField: 'name',
+            allowMultiple: false,
+          },
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+      ];
+
+      const mockGroups = [
+        {
+          id: 'group-1',
+          name: '営業部',
+          description: '営業活動を行う部門',
+          parentId: null,
+          parent: null,
+          members: [],
+          _count: { members: 0 },
+          createdAt: new Date('2024-01-01'),
+          updatedAt: new Date('2024-01-01'),
+        },
+        {
+          id: 'group-2',
+          name: '開発部',
+          description: '開発を行う部門',
+          parentId: null,
+          parent: null,
+          members: [],
+          _count: { members: 0 },
+          createdAt: new Date('2024-01-02'),
+          updatedAt: new Date('2024-01-02'),
+        },
+      ];
+
+      (getGroups as jest.Mock).mockResolvedValue(mockGroups);
+
+      const result = await getRelationRecords(columns);
+
+      expect(result.size).toBe(1);
+      expect(result.get('col-1')).toEqual([
+        { id: 'group-1', displayValue: '営業部', exists: true },
+        { id: 'group-2', displayValue: '開発部', exists: true },
+      ]);
+      expect(getGroups).toHaveBeenCalledTimes(1);
+      expect(prisma.record.findMany).not.toHaveBeenCalled();
+    });
+
+    it('groups: displayFieldが空の場合はnameを使用する', async () => {
+      const columns: Column[] = [
+        {
+          id: 'col-1',
+          name: '所属グループ',
+          type: 'RELATION',
+          order: 0,
+          config: {
+            referencedTableId: 'groups',
+            displayField: '',
+            allowMultiple: false,
+          },
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+      ];
+
+      const mockGroups = [
+        {
+          id: 'group-1',
+          name: '営業部',
+          description: '営業活動を行う部門',
+          parentId: null,
+          parent: null,
+          members: [],
+          _count: { members: 0 },
+          createdAt: new Date('2024-01-01'),
+          updatedAt: new Date('2024-01-01'),
+        },
+      ];
+
+      (getGroups as jest.Mock).mockResolvedValue(mockGroups);
+
+      const result = await getRelationRecords(columns);
+
+      expect(result.get('col-1')).toEqual([
+        { id: 'group-1', displayValue: '営業部', exists: true },
+      ]);
+    });
+  });
+
+  describe('システムテーブルと通常テーブルの混在', () => {
+    it('usersとgroupsと通常テーブルを同時に参照できる', async () => {
+      const columns: Column[] = [
+        {
+          id: 'col-1',
+          name: '担当者',
+          type: 'RELATION',
+          order: 0,
+          config: {
+            referencedTableId: 'users',
+            displayField: 'name',
+            allowMultiple: false,
+          },
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+        {
+          id: 'col-2',
+          name: 'グループ',
+          type: 'RELATION',
+          order: 1,
+          config: {
+            referencedTableId: 'groups',
+            displayField: 'name',
+            allowMultiple: false,
+          },
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+        {
+          id: 'col-3',
+          name: '顧客',
+          type: 'RELATION',
+          order: 2,
+          config: {
+            referencedTableId: 'table-1',
+            displayField: 'companyName',
+            allowMultiple: false,
+          },
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+      ];
+
+      const mockUsers = [
+        {
+          id: 'user-1',
+          email: 'user1@example.com',
+          name: '山田太郎',
+          role: 'ADMIN',
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+      ];
+
+      const mockGroups = [
+        {
+          id: 'group-1',
+          name: '営業部',
+          description: null,
+          parentId: null,
+          parent: null,
+          members: [],
+          _count: { members: 0 },
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+      ];
+
+      const mockRecords = [
+        {
+          id: 'record-1',
+          tableId: 'table-1',
+          data: { companyName: 'A社' },
+          createdById: 'user-1',
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+      ];
+
+      (getUsers as jest.Mock).mockResolvedValue(mockUsers);
+      (getGroups as jest.Mock).mockResolvedValue(mockGroups);
+      (prisma.record.findMany as jest.Mock).mockResolvedValue(mockRecords);
+
+      const result = await getRelationRecords(columns);
+
+      expect(result.size).toBe(3);
+      expect(result.get('col-1')).toEqual([
+        { id: 'user-1', displayValue: '山田太郎', exists: true },
+      ]);
+      expect(result.get('col-2')).toEqual([
+        { id: 'group-1', displayValue: '営業部', exists: true },
+      ]);
+      expect(result.get('col-3')).toEqual([
+        { id: 'record-1', displayValue: 'A社', exists: true },
+      ]);
+      expect(getUsers).toHaveBeenCalledTimes(1);
+      expect(getGroups).toHaveBeenCalledTimes(1);
+      expect(prisma.record.findMany).toHaveBeenCalledTimes(1);
+    });
   });
 });

--- a/features/record/api/get-relation-records.ts
+++ b/features/record/api/get-relation-records.ts
@@ -1,6 +1,8 @@
 'use server';
 
 import { prisma } from '@/lib/prisma';
+import { getUsers } from '@/features/user/api/get-users';
+import { getGroups } from '@/features/group/api/get-groups';
 import type {
   Column,
   RelationColumn,
@@ -29,7 +31,35 @@ export async function getRelationRecords(
     relationColumns.map(async (col) => {
       const { referencedTableId, displayField } = col.config;
 
-      // レコードを取得
+      // システムテーブル: users
+      if (referencedTableId === 'users') {
+        const users = await getUsers();
+        const relationRecords: RelationRecord[] = users.map((user) => ({
+          id: user.id,
+          displayValue:
+            (user[displayField as keyof typeof user] as string) ||
+            user.name ||
+            user.email,
+          exists: true,
+        }));
+        relationRecordsMap.set(col.id, relationRecords);
+        return;
+      }
+
+      // システムテーブル: groups
+      if (referencedTableId === 'groups') {
+        const groups = await getGroups();
+        const relationRecords: RelationRecord[] = groups.map((group) => ({
+          id: group.id,
+          displayValue:
+            (group[displayField as keyof typeof group] as string) || group.name,
+          exists: true,
+        }));
+        relationRecordsMap.set(col.id, relationRecords);
+        return;
+      }
+
+      // 通常のテーブル
       const records = await prisma.record.findMany({
         where: { tableId: referencedTableId },
         orderBy: { createdAt: 'desc' },

--- a/features/record/utils/enrich-with-relations.ts
+++ b/features/record/utils/enrich-with-relations.ts
@@ -2,6 +2,8 @@ import { prisma } from '@/lib/prisma';
 import { getUsers } from '@/features/user/api/get-users';
 import { getGroups } from '@/features/group/api/get-groups';
 import type { Record as PrismaRecord } from '@prisma/client';
+import type { User } from '@/features/user/types';
+import type { Group } from '@/features/group/types';
 import type {
   Column,
   RelationColumn,
@@ -57,22 +59,37 @@ export async function enrichWithRelations(
     return records;
   }
 
-  // テーブルごとに参照先データを取得してMapを作成
-  const dataMap = new Map<string, RelationRecord>();
+  // カラムごとに参照先データを取得してMapを作成
+  // Map<カラムID, Map<レコードID, RelationRecord>>
+  const columnDataMap = new Map<string, Map<string, RelationRecord>>();
 
-  for (const [tableId, ids] of tableReferencedIds.entries()) {
+  // テーブルごとに生データをキャッシュ（重複取得を防ぐ）
+  const tableDataCache = new Map<
+    string,
+    Map<string, unknown> | Array<unknown>
+  >();
+
+  // カラムごとにデータを取得
+  for (const col of relationColumns) {
+    const { referencedTableId, displayField } = col.config;
+    const ids = tableReferencedIds.get(referencedTableId);
+    if (!ids || ids.size === 0) continue;
+
     const idsArray = Array.from(ids);
+    const dataMap = new Map<string, RelationRecord>();
 
     // システムテーブル: users
-    if (tableId === 'users') {
-      const users = await getUsers();
-      const userMap = new Map(users.map((u) => [u.id, u]));
+    if (referencedTableId === 'users') {
+      // キャッシュがなければ取得
+      if (!tableDataCache.has('users')) {
+        const users = await getUsers();
+        tableDataCache.set('users', new Map(users.map((u) => [u.id, u])));
+      }
+      const userMap = tableDataCache.get('users') as Map<string, User>;
+
       idsArray.forEach((id) => {
         const user = userMap.get(id);
         if (user) {
-          const displayField = relationColumns.find(
-            (c) => c.config.referencedTableId === 'users'
-          )?.config.displayField;
           dataMap.set(id, {
             id: user.id,
             displayValue:
@@ -87,19 +104,19 @@ export async function enrichWithRelations(
           dataMap.set(id, { id, displayValue: id, exists: false });
         }
       });
-      continue;
     }
-
     // システムテーブル: groups
-    if (tableId === 'groups') {
-      const groups = await getGroups();
-      const groupMap = new Map(groups.map((g) => [g.id, g]));
+    else if (referencedTableId === 'groups') {
+      // キャッシュがなければ取得
+      if (!tableDataCache.has('groups')) {
+        const groups = await getGroups();
+        tableDataCache.set('groups', new Map(groups.map((g) => [g.id, g])));
+      }
+      const groupMap = tableDataCache.get('groups') as Map<string, Group>;
+
       idsArray.forEach((id) => {
         const group = groupMap.get(id);
         if (group) {
-          const displayField = relationColumns.find(
-            (c) => c.config.referencedTableId === 'groups'
-          )?.config.displayField;
           dataMap.set(id, {
             id: group.id,
             displayValue:
@@ -112,39 +129,50 @@ export async function enrichWithRelations(
           dataMap.set(id, { id, displayValue: id, exists: false });
         }
       });
-      continue;
+    }
+    // 通常のテーブル
+    else {
+      // キャッシュがなければ取得
+      if (!tableDataCache.has(referencedTableId)) {
+        const tableIds = tableReferencedIds.get(referencedTableId);
+        if (tableIds) {
+          const referencedRecords = await prisma.record.findMany({
+            where: {
+              id: { in: Array.from(tableIds) },
+            },
+          });
+          tableDataCache.set(
+            referencedTableId,
+            new Map(referencedRecords.map((r) => [r.id, r]))
+          );
+        }
+      }
+      const recordMap = tableDataCache.get(referencedTableId) as Map<
+        string,
+        PrismaRecord
+      >;
+
+      idsArray.forEach((id) => {
+        const refRecord = recordMap?.get(id);
+        if (refRecord) {
+          const displayFieldValue = displayField
+            ? (refRecord.data as Record<string, unknown>)[displayField]
+            : null;
+
+          dataMap.set(refRecord.id, {
+            id: refRecord.id,
+            displayValue: displayFieldValue
+              ? String(displayFieldValue)
+              : refRecord.id,
+            exists: true,
+          });
+        } else {
+          dataMap.set(id, { id, displayValue: id, exists: false });
+        }
+      });
     }
 
-    // 通常のテーブル
-    const referencedRecords = await prisma.record.findMany({
-      where: {
-        id: { in: idsArray },
-      },
-    });
-
-    referencedRecords.forEach((refRecord) => {
-      const displayField = relationColumns.find(
-        (c) => c.config.referencedTableId === tableId
-      )?.config.displayField;
-      const displayFieldValue = displayField
-        ? (refRecord.data as Record<string, unknown>)[displayField]
-        : null;
-
-      dataMap.set(refRecord.id, {
-        id: refRecord.id,
-        displayValue: displayFieldValue
-          ? String(displayFieldValue)
-          : refRecord.id,
-        exists: true,
-      });
-    });
-
-    // 存在しないIDの処理
-    idsArray.forEach((id) => {
-      if (!dataMap.has(id)) {
-        dataMap.set(id, { id, displayValue: id, exists: false });
-      }
-    });
+    columnDataMap.set(col.id, dataMap);
   }
 
   // 各レコードに参照先データを付与
@@ -157,11 +185,14 @@ export async function enrichWithRelations(
     relationColumns.forEach((col) => {
       const value = (record.data as Record<string, unknown>)[col.id];
       if (value) {
+        const colDataMap = columnDataMap.get(col.id);
+        if (!colDataMap) return;
+
         const ids = Array.isArray(value) ? value : [value];
         const referencedData = ids
           .map((id) => {
             if (typeof id !== 'string') return null;
-            return dataMap.get(id) || null;
+            return colDataMap.get(id) || null;
           })
           .filter((d) => d !== null);
 

--- a/features/record/utils/enrich-with-relations.ts
+++ b/features/record/utils/enrich-with-relations.ts
@@ -1,4 +1,6 @@
 import { prisma } from '@/lib/prisma';
+import { getUsers } from '@/features/user/api/get-users';
+import { getGroups } from '@/features/group/api/get-groups';
 import type { Record as PrismaRecord } from '@prisma/client';
 import type {
   Column,
@@ -28,8 +30,8 @@ export async function enrichWithRelations(
     return records;
   }
 
-  // すべての参照先レコードIDを収集
-  const allReferencedIds = new Set<string>();
+  // 参照先IDをテーブルごとに分類して収集
+  const tableReferencedIds = new Map<string, Set<string>>();
   records.forEach((record) => {
     relationColumns.forEach((col) => {
       const value = (record.data as Record<string, unknown>)[col.id];
@@ -37,7 +39,13 @@ export async function enrichWithRelations(
         const ids = Array.isArray(value) ? value : [value];
         ids.forEach((id) => {
           if (typeof id === 'string') {
-            allReferencedIds.add(id);
+            if (!tableReferencedIds.has(col.config.referencedTableId)) {
+              tableReferencedIds.set(
+                col.config.referencedTableId,
+                new Set<string>()
+              );
+            }
+            tableReferencedIds.get(col.config.referencedTableId)!.add(id);
           }
         });
       }
@@ -45,19 +53,99 @@ export async function enrichWithRelations(
   });
 
   // 参照先レコードがない場合はそのまま返す
-  if (allReferencedIds.size === 0) {
+  if (tableReferencedIds.size === 0) {
     return records;
   }
 
-  // 参照先レコードを一括取得（N+1を回避）
-  const referencedRecords = await prisma.record.findMany({
-    where: {
-      id: { in: Array.from(allReferencedIds) },
-    },
-  });
+  // テーブルごとに参照先データを取得してMapを作成
+  const dataMap = new Map<string, RelationRecord>();
 
-  // レコードIDをキーにしたMapを作成（高速検索用）
-  const recordMap = new Map(referencedRecords.map((r) => [r.id, r]));
+  for (const [tableId, ids] of tableReferencedIds.entries()) {
+    const idsArray = Array.from(ids);
+
+    // システムテーブル: users
+    if (tableId === 'users') {
+      const users = await getUsers();
+      const userMap = new Map(users.map((u) => [u.id, u]));
+      idsArray.forEach((id) => {
+        const user = userMap.get(id);
+        if (user) {
+          const displayField = relationColumns.find(
+            (c) => c.config.referencedTableId === 'users'
+          )?.config.displayField;
+          dataMap.set(id, {
+            id: user.id,
+            displayValue:
+              (displayField
+                ? (user[displayField as keyof typeof user] as string)
+                : null) ||
+              user.name ||
+              user.email,
+            exists: true,
+          });
+        } else {
+          dataMap.set(id, { id, displayValue: id, exists: false });
+        }
+      });
+      continue;
+    }
+
+    // システムテーブル: groups
+    if (tableId === 'groups') {
+      const groups = await getGroups();
+      const groupMap = new Map(groups.map((g) => [g.id, g]));
+      idsArray.forEach((id) => {
+        const group = groupMap.get(id);
+        if (group) {
+          const displayField = relationColumns.find(
+            (c) => c.config.referencedTableId === 'groups'
+          )?.config.displayField;
+          dataMap.set(id, {
+            id: group.id,
+            displayValue:
+              (displayField
+                ? (group[displayField as keyof typeof group] as string)
+                : null) || group.name,
+            exists: true,
+          });
+        } else {
+          dataMap.set(id, { id, displayValue: id, exists: false });
+        }
+      });
+      continue;
+    }
+
+    // 通常のテーブル
+    const referencedRecords = await prisma.record.findMany({
+      where: {
+        id: { in: idsArray },
+      },
+    });
+
+    referencedRecords.forEach((refRecord) => {
+      const displayField = relationColumns.find(
+        (c) => c.config.referencedTableId === tableId
+      )?.config.displayField;
+      const displayFieldValue = displayField
+        ? (refRecord.data as Record<string, unknown>)[displayField]
+        : null;
+
+      dataMap.set(refRecord.id, {
+        id: refRecord.id,
+        displayValue: displayFieldValue
+          ? String(displayFieldValue)
+          : refRecord.id,
+        exists: true,
+      });
+    });
+
+    // 存在しないIDの処理
+    idsArray.forEach((id) => {
+      if (!dataMap.has(id)) {
+        dataMap.set(id, { id, displayValue: id, exists: false });
+      }
+    });
+  }
 
   // 各レコードに参照先データを付与
   return records.map((record) => {
@@ -73,21 +161,7 @@ export async function enrichWithRelations(
         const referencedData = ids
           .map((id) => {
             if (typeof id !== 'string') return null;
-            const refRecord = recordMap.get(id);
-            if (!refRecord) return null;
-
-            // 表示フィールドの値を取得
-            const displayFieldValue = (
-              refRecord.data as Record<string, unknown>
-            )[col.config.displayField];
-
-            return {
-              id: refRecord.id,
-              displayValue: displayFieldValue
-                ? String(displayFieldValue)
-                : refRecord.id,
-              exists: true,
-            };
+            return dataMap.get(id) || null;
           })
           .filter((d) => d !== null);
 


### PR DESCRIPTION
## 概要

リレーションカラムで通常のテーブルに加えて、システムテーブル（ユーザー・グループ）を参照先として選択可能にしました。

## 実装内容

### 1. 型定義の追加
- `SystemTable`型と`SystemTableType`型を追加
- システムテーブルの構造を定義

### 2. UI: RelationConfigEditor
- システムテーブルを選択可能に
- 表示順: ユーザー → グループ → カスタムテーブル
- 表示フィールド: ユーザー(name, email)、グループ(name)

### 3. API: getRelationRecords
- システムテーブル対応を追加
- `getUsers()`/`getGroups()`でデータ取得
- 通常テーブルと同じインターフェースで利用可能

### 4. Utils: enrichWithRelations
- **完全に書き換え**てパフォーマンスを最適化
- テーブルごとにIDを分類して必要なデータのみ取得
- システムテーブルと通常テーブルを統一的に処理
- N+1問題を回避

## 変更ファイル

- `features/column/types/column.ts` - システムテーブル型定義
- `features/column/components/config/relation-config-editor.tsx` - UI拡張
- `features/record/api/get-relation-records.ts` - システムテーブル対応
- `features/record/utils/enrich-with-relations.ts` - 最適化された実装
- `features/record/api/__tests__/get-relation-records.test.ts` - テスト追加

## 動作確認

- [x] テーブル編集でRELATIONカラムを追加
- [x] 参照先として「ユーザー」を選択
- [x] 表示フィールドとして「名前」または「メールアドレス」を選択
- [x] レコード作成・編集でユーザーが選択可能
- [x] 参照先として「グループ」を選択
- [x] 表示フィールドとして「グループ名」を選択
- [x] レコード作成・編集でグループが選択可能

## 関連Issue

Closes #97

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * リレーションカラムでシステムテーブル（ユーザー／グループ）を参照可能に。参照先選択肢として表示され、該当データが自動取得・表示されます。表示フィールドは優先順（名前／メール／IDなど）で選択されます。

* **テスト**
  * システムテーブル参照の振る舞い（表示フィールド、空データ時のフォールバック、混在ケース等）を網羅するテストを追加しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->