### PR TITLE
カラムの必須項目設定が解除できない問題を修正

### DIFF
--- a/features/column/components/add-column-dialog.tsx
+++ b/features/column/components/add-column-dialog.tsx
@@ -212,7 +212,7 @@ export function AddColumnDialog({
         name: columnName,
         type: columnType,
         order: nextOrder,
-        validation: isRequired ? { required: true } : undefined,
+        validation: { required: isRequired },
         config: config as never,
       });
 

--- a/features/column/components/config/checkbox-config-editor.tsx
+++ b/features/column/components/config/checkbox-config-editor.tsx
@@ -98,7 +98,7 @@ export function CheckboxConfigEditor({
           onCheckedChange={(checked) =>
             onChange({
               ...config,
-              defaultValue: checked === true ? true : undefined,
+              defaultValue: checked === true,
             })
           }
         />

--- a/features/column/components/edit-column-option.tsx
+++ b/features/column/components/edit-column-option.tsx
@@ -245,7 +245,7 @@ export function EditColumnOption({
 
       const result = await updateColumn(itemId, column.id, {
         name: columnName,
-        validation: isRequired ? { required: true } : undefined,
+        validation: { required: isRequired },
         config: config as never,
       });
 


### PR DESCRIPTION
## 概要
テーブル管理画面のカラム編集ダイアログにおいて、「必須項目にする」のチェックを外して更新しても、変更が適用されず、必須項目のままとなってしまう問題を修正。

## 原因
Next.js Server Actions の仕様上、`undefined` のプロパティは削除されてサーバーに送信されるため、サーバー側で既存の validation 設定（`required: true`）が維持されてしまっていました。

## 修正内容
以下のファイルで、`validation` および `defaultValue` を明示的な boolean 値として常に送信するように変更しました:

- `features/column/components/edit-column-option.tsx`: validation を `{ required: false }` として明示
- `features/column/components/add-column-dialog.tsx`: 同様の修正
- `features/column/components/config/checkbox-config-editor.tsx`: defaultValue を明示的 boolean 化

## 関連Issue

Closes #99

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * カラムの追加・編集時の検証処理を改善し、検証オブジェクトの値の一貫性を向上させました。
  * チェックボックスのデフォルト値処理をより確実にしました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->