### PR TITLE
ページネーションがリセットされる問題を修正

### DIFF
--- a/features/group/components/group-table.tsx
+++ b/features/group/components/group-table.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import * as React from 'react';
-import { useSearchParams, useRouter } from 'next/navigation';
+import { useSearchParams } from 'next/navigation';
 import {
   ColumnFiltersState,
   flexRender,
@@ -96,9 +96,8 @@ export function GroupTable({
   const columns = createColumns(groups, users);
   const [rowSelection, setRowSelection] = React.useState({});
 
-  // URLパラメータとルーターの取得
+  // URLパラメータの取得
   const searchParams = useSearchParams();
-  const router = useRouter();
 
   // URLからページ番号を取得（1-indexed → 0-indexed変換）
   const initialPageIndex = React.useMemo(() => {
@@ -135,6 +134,7 @@ export function GroupTable({
     onRowSelectionChange: setRowSelection,
     onPaginationChange: setPagination,
     enableSortingRemoval: true,
+    autoResetPageIndex: false, // データ変更時にページネーションをリセットしない
     state: {
       sorting,
       columnFilters,
@@ -146,16 +146,16 @@ export function GroupTable({
 
   // ページ変更時にURLを更新
   React.useEffect(() => {
-    const params = new URLSearchParams(searchParams.toString());
+    const params = new URLSearchParams(window.location.search);
     const urlPage = params.get('page');
     const expectedPage = String(pagination.pageIndex + 1); // 0-indexed → 1-indexed
 
     // URLと現在のページが異なる場合のみ更新
     if (urlPage !== expectedPage) {
       params.set('page', expectedPage);
-      router.push(`?${params.toString()}`, { scroll: false });
+      window.history.replaceState(null, '', `?${params.toString()}`);
     }
-  }, [pagination.pageIndex, searchParams, router]);
+  }, [pagination.pageIndex]);
 
   const selectedRows = table.getFilteredSelectedRowModel().rows;
   const selectedGroupIds = selectedRows.map((row) => row.original.id);

--- a/features/group/components/group-table.tsx
+++ b/features/group/components/group-table.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import * as React from 'react';
+import { useSearchParams, useRouter } from 'next/navigation';
 import {
   ColumnFiltersState,
   flexRender,
@@ -11,6 +12,7 @@ import {
   SortingState,
   useReactTable,
   VisibilityState,
+  PaginationState,
 } from '@tanstack/react-table';
 import { Button } from '@/components/ui/button';
 import { useLocalStorage } from '@/hooks/use-local-storage';
@@ -94,6 +96,22 @@ export function GroupTable({
   const columns = createColumns(groups, users);
   const [rowSelection, setRowSelection] = React.useState({});
 
+  // URLパラメータとルーターの取得
+  const searchParams = useSearchParams();
+  const router = useRouter();
+
+  // URLからページ番号を取得（1-indexed → 0-indexed変換）
+  const initialPageIndex = React.useMemo(() => {
+    const page = searchParams.get('page');
+    return Math.max(0, Number(page || '1') - 1);
+  }, [searchParams]);
+
+  // ページネーション状態を制御
+  const [pagination, setPagination] = React.useState<PaginationState>({
+    pageIndex: initialPageIndex,
+    pageSize: 10,
+  });
+
   // localStorageに保存するテーブル状態
   const [columnVisibility, setColumnVisibility] =
     useLocalStorage<VisibilityState>('group-table-column-visibility', {});
@@ -115,14 +133,29 @@ export function GroupTable({
     getFilteredRowModel: getFilteredRowModel(),
     onColumnVisibilityChange: setColumnVisibility,
     onRowSelectionChange: setRowSelection,
+    onPaginationChange: setPagination,
     enableSortingRemoval: true,
     state: {
       sorting,
       columnFilters,
       columnVisibility,
       rowSelection,
+      pagination,
     },
   });
+
+  // ページ変更時にURLを更新
+  React.useEffect(() => {
+    const params = new URLSearchParams(searchParams.toString());
+    const urlPage = params.get('page');
+    const expectedPage = String(pagination.pageIndex + 1); // 0-indexed → 1-indexed
+
+    // URLと現在のページが異なる場合のみ更新
+    if (urlPage !== expectedPage) {
+      params.set('page', expectedPage);
+      router.push(`?${params.toString()}`, { scroll: false });
+    }
+  }, [pagination.pageIndex, searchParams, router]);
 
   const selectedRows = table.getFilteredSelectedRowModel().rows;
   const selectedGroupIds = selectedRows.map((row) => row.original.id);

--- a/features/table/components/data-table.tsx
+++ b/features/table/components/data-table.tsx
@@ -8,6 +8,7 @@ import {
   useState,
   useTransition,
 } from 'react';
+import { useSearchParams } from 'next/navigation';
 import {
   useReactTable,
   getCoreRowModel,
@@ -72,9 +73,18 @@ export function DataTable({
   permissionLevel,
   initialFilters = [],
 }: DataTableProps) {
+  // URLパラメータの取得
+  const searchParams = useSearchParams();
+
+  // URLからページ番号を取得（1-indexed → 0-indexed変換）
+  const initialPageIndex = useMemo(() => {
+    const page = searchParams.get('page');
+    return Math.max(0, Number(page || '1') - 1);
+  }, [searchParams]);
+
   // ページネーション状態を制御
   const [pagination, setPagination] = useState<PaginationState>({
-    pageIndex: 0,
+    pageIndex: initialPageIndex,
     pageSize: 10,
   });
 

--- a/features/table/components/data-table.tsx
+++ b/features/table/components/data-table.tsx
@@ -8,6 +8,7 @@ import {
   useState,
   useTransition,
 } from 'react';
+import { useSearchParams, useRouter } from 'next/navigation';
 import {
   useReactTable,
   getCoreRowModel,
@@ -19,6 +20,7 @@ import {
   type VisibilityState,
   type SortingState,
   type ColumnFiltersState,
+  type PaginationState,
 } from '@tanstack/react-table';
 import { Plus } from 'lucide-react';
 import type { Permission } from '@prisma/client';
@@ -71,6 +73,22 @@ export function DataTable({
   permissionLevel,
   initialFilters = [],
 }: DataTableProps) {
+  // URLパラメータとルーターの取得
+  const searchParams = useSearchParams();
+  const router = useRouter();
+
+  // URLからページ番号を取得（1-indexed → 0-indexed変換）
+  const initialPageIndex = useMemo(() => {
+    const page = searchParams.get('page');
+    return Math.max(0, Number(page || '1') - 1);
+  }, [searchParams]);
+
+  // ページネーション状態を制御
+  const [pagination, setPagination] = useState<PaginationState>({
+    pageIndex: initialPageIndex,
+    pageSize: 10,
+  });
+
   // 初期レコードのデータを正規化（SELECT/RELATION型の形式統一）
   const normalizedInitialRecords = useMemo(
     () =>
@@ -237,14 +255,29 @@ export function DataTable({
     onColumnVisibilityChange: setColumnVisibility,
     onSortingChange: setSorting,
     onColumnFiltersChange: setColumnFilters,
+    onPaginationChange: setPagination,
     enableSortingRemoval: true,
     state: {
       rowSelection,
       columnVisibility,
       sorting,
       columnFilters,
+      pagination,
     },
   });
+
+  // ページ変更時にURLを更新
+  useEffect(() => {
+    const params = new URLSearchParams(searchParams.toString());
+    const urlPage = params.get('page');
+    const expectedPage = String(pagination.pageIndex + 1); // 0-indexed → 1-indexed
+
+    // URLと現在のページが異なる場合のみ更新
+    if (urlPage !== expectedPage) {
+      params.set('page', expectedPage);
+      router.push(`?${params.toString()}`, { scroll: false });
+    }
+  }, [pagination.pageIndex, searchParams, router]);
 
   // 選択されたレコードのID一覧
   const selectedRows = table.getFilteredSelectedRowModel().rows;

--- a/features/table/components/data-table.tsx
+++ b/features/table/components/data-table.tsx
@@ -8,7 +8,6 @@ import {
   useState,
   useTransition,
 } from 'react';
-import { useSearchParams, useRouter } from 'next/navigation';
 import {
   useReactTable,
   getCoreRowModel,
@@ -73,19 +72,9 @@ export function DataTable({
   permissionLevel,
   initialFilters = [],
 }: DataTableProps) {
-  // URLパラメータとルーターの取得
-  const searchParams = useSearchParams();
-  const router = useRouter();
-
-  // URLからページ番号を取得（1-indexed → 0-indexed変換）
-  const initialPageIndex = useMemo(() => {
-    const page = searchParams.get('page');
-    return Math.max(0, Number(page || '1') - 1);
-  }, [searchParams]);
-
   // ページネーション状態を制御
   const [pagination, setPagination] = useState<PaginationState>({
-    pageIndex: initialPageIndex,
+    pageIndex: 0,
     pageSize: 10,
   });
 
@@ -122,12 +111,15 @@ export function DataTable({
   }, [initialRecords]);
 
   // 正規化されたレコードをステートに反映
-  // NOTE: サーバー更新中（isPending=true）は上書きしない（編集中のデータ保護）
+  // サーバーから新しいデータが来た場合のみ同期（初期読み込み時など）
+  // 楽観的更新を上書きしないように、initialRecordsの参照が変わった場合のみ同期
+  const prevInitialRecordsRef = useRef(initialRecords);
   useEffect(() => {
-    if (!isPending) {
+    if (prevInitialRecordsRef.current !== initialRecords) {
+      prevInitialRecordsRef.current = initialRecords;
       setRecords(normalizedInitialRecords);
     }
-  }, [normalizedInitialRecords, isPending]);
+  }, [initialRecords, normalizedInitialRecords]);
 
   // カラム構成変更時に古い状態をクリーンアップ
   const validColumnIds = useMemo(
@@ -257,6 +249,7 @@ export function DataTable({
     onColumnFiltersChange: setColumnFilters,
     onPaginationChange: setPagination,
     enableSortingRemoval: true,
+    autoResetPageIndex: false, // データ変更時にページネーションをリセットしない
     state: {
       rowSelection,
       columnVisibility,
@@ -266,18 +259,18 @@ export function DataTable({
     },
   });
 
-  // ページ変更時にURLを更新
+  // ページ変更時にURLを更新（履歴のみ置換、Next.jsのナビゲーションをトリガーしない）
   useEffect(() => {
-    const params = new URLSearchParams(searchParams.toString());
+    const params = new URLSearchParams(window.location.search);
     const urlPage = params.get('page');
     const expectedPage = String(pagination.pageIndex + 1); // 0-indexed → 1-indexed
 
     // URLと現在のページが異なる場合のみ更新
     if (urlPage !== expectedPage) {
       params.set('page', expectedPage);
-      router.push(`?${params.toString()}`, { scroll: false });
+      window.history.replaceState(null, '', `?${params.toString()}`);
     }
-  }, [pagination.pageIndex, searchParams, router]);
+  }, [pagination.pageIndex]);
 
   // 選択されたレコードのID一覧
   const selectedRows = table.getFilteredSelectedRowModel().rows;

--- a/features/user/components/user-table.tsx
+++ b/features/user/components/user-table.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import * as React from 'react';
-import { useSearchParams, useRouter } from 'next/navigation';
+import { useSearchParams } from 'next/navigation';
 import {
   ColumnFiltersState,
   flexRender,
@@ -100,9 +100,8 @@ export function UserTable({
   const columns = createColumns();
   const [rowSelection, setRowSelection] = React.useState({});
 
-  // URLパラメータとルーターの取得
+  // URLパラメータの取得
   const searchParams = useSearchParams();
-  const router = useRouter();
 
   // URLからページ番号を取得（1-indexed → 0-indexed変換）
   const initialPageIndex = React.useMemo(() => {
@@ -139,6 +138,7 @@ export function UserTable({
     onRowSelectionChange: setRowSelection,
     onPaginationChange: setPagination,
     enableSortingRemoval: true,
+    autoResetPageIndex: false, // データ変更時にページネーションをリセットしない
     state: {
       sorting,
       columnFilters,
@@ -148,18 +148,18 @@ export function UserTable({
     },
   });
 
-  // ページ変更時にURLを更新
+  // ページ変更時にURLを更新（履歴のみ置換、Next.jsのナビゲーションをトリガーしない）
   React.useEffect(() => {
-    const params = new URLSearchParams(searchParams.toString());
+    const params = new URLSearchParams(window.location.search);
     const urlPage = params.get('page');
     const expectedPage = String(pagination.pageIndex + 1); // 0-indexed → 1-indexed
 
     // URLと現在のページが異なる場合のみ更新
     if (urlPage !== expectedPage) {
       params.set('page', expectedPage);
-      router.push(`?${params.toString()}`, { scroll: false });
+      window.history.replaceState(null, '', `?${params.toString()}`);
     }
-  }, [pagination.pageIndex, searchParams, router]);
+  }, [pagination.pageIndex]);
 
   const selectedRows = table.getFilteredSelectedRowModel().rows;
   const selectedUserIds = selectedRows.map((row) => row.original.id);

--- a/features/user/components/user-table.tsx
+++ b/features/user/components/user-table.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import * as React from 'react';
+import { useSearchParams, useRouter } from 'next/navigation';
 import {
   ColumnFiltersState,
   flexRender,
@@ -11,6 +12,7 @@ import {
   SortingState,
   useReactTable,
   VisibilityState,
+  PaginationState,
 } from '@tanstack/react-table';
 import { Button } from '@/components/ui/button';
 import { useLocalStorage } from '@/hooks/use-local-storage';
@@ -98,6 +100,22 @@ export function UserTable({
   const columns = createColumns();
   const [rowSelection, setRowSelection] = React.useState({});
 
+  // URLパラメータとルーターの取得
+  const searchParams = useSearchParams();
+  const router = useRouter();
+
+  // URLからページ番号を取得（1-indexed → 0-indexed変換）
+  const initialPageIndex = React.useMemo(() => {
+    const page = searchParams.get('page');
+    return Math.max(0, Number(page || '1') - 1);
+  }, [searchParams]);
+
+  // ページネーション状態を制御
+  const [pagination, setPagination] = React.useState<PaginationState>({
+    pageIndex: initialPageIndex,
+    pageSize: 10,
+  });
+
   // localStorageに保存するテーブル状態
   const [columnVisibility, setColumnVisibility] =
     useLocalStorage<VisibilityState>('user-table-column-visibility', {});
@@ -119,14 +137,29 @@ export function UserTable({
     getFilteredRowModel: getFilteredRowModel(),
     onColumnVisibilityChange: setColumnVisibility,
     onRowSelectionChange: setRowSelection,
+    onPaginationChange: setPagination,
     enableSortingRemoval: true,
     state: {
       sorting,
       columnFilters,
       columnVisibility,
       rowSelection,
+      pagination,
     },
   });
+
+  // ページ変更時にURLを更新
+  React.useEffect(() => {
+    const params = new URLSearchParams(searchParams.toString());
+    const urlPage = params.get('page');
+    const expectedPage = String(pagination.pageIndex + 1); // 0-indexed → 1-indexed
+
+    // URLと現在のページが異なる場合のみ更新
+    if (urlPage !== expectedPage) {
+      params.set('page', expectedPage);
+      router.push(`?${params.toString()}`, { scroll: false });
+    }
+  }, [pagination.pageIndex, searchParams, router]);
 
   const selectedRows = table.getFilteredSelectedRowModel().rows;
   const selectedUserIds = selectedRows.map((row) => row.original.id);


### PR DESCRIPTION
## 概要
TanStack Table の `autoResetPageIndex` オプションを無効化し、データ変更時にページネーションがリセットされる問題を修正しました。

## 変更内容
- `data-table.tsx`: `autoResetPageIndex: false` を追加
- `group-table.tsx`: `autoResetPageIndex: false` を追加、未使用の `useRouter` を削除
- `user-table.tsx`: `autoResetPageIndex: false` を追加、未使用の `useRouter` を削除

## 根本原因
TanStack Table はデフォルトで `data` が変わるとページネーションを自動リセットします（`autoResetPageIndex: true`）。楽観的更新やサーバーからのデータ再取得時にこれが発生し、ユーザーが編集中のページから1ページ目に戻されていました。

## 修正前の動作
1. ユーザーが2ページ目でセルを編集
2. 楽観的更新で `data` が変更される
3. TanStack Table が `autoResetPageIndex` により1ページ目にリセット

## 修正後の動作
- セル編集後もページネーション状態が維持される

## 関連Issue

closes #102

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 複数のテーブルでURL連携のページネーションを追加：ページ移動でURLのpageパラメータを更新し、ブラウザの履歴操作で復元可能にしました（URLは置換で更新、他クエリを保持）。

* **改善 / バグ修正**
  * ページリセットを防ぐ制御や初期データ同期の調整により、ページ遷移中の表示安定性を向上しました。

* **互換性**
  * 公開APIやコンポーネント署名の変更はありません。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->