### PR TITLE
日付ピッカーで過去の日付を選択できるように修正

### DIFF
--- a/components/shared/date-picker-calendar.tsx
+++ b/components/shared/date-picker-calendar.tsx
@@ -18,8 +18,8 @@ export function DatePickerCalendar({
   minDate,
   maxDate,
 }: DatePickerCalendarProps) {
-  // ドロップダウンの年範囲を設定（2025年〜現在+10年）
-  const startMonth = new Date(2025, 0);
+  // ドロップダウンの年範囲を設定（1900年〜現在+10年）
+  const startMonth = new Date(1900, 0);
   const endMonth = new Date(new Date().getFullYear() + 10, 11);
 
   return (


### PR DESCRIPTION
## 概要
日付ピッカーのドロップダウンで1990年など過去の日付を選択できない問題を修正しました。

## 実装内容
`components/shared/date-picker-calendar.tsx` の `startMonth` を `2025年` から `1900年` に変更しました。

## 関連Issue
closes #106

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **改善**
  * 日付ピッカーで選択可能な年の範囲を拡大しました。従来は2025年からの選択が可能でしたが、1900年からの選択に対応しました。これにより、より過去の日付を選択できるようになります。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->