### PR TITLE
Safari での IME 入力中 Enter キー誤動作を修正

### DIFF
--- a/features/table/components/cells/number-cell.tsx
+++ b/features/table/components/cells/number-cell.tsx
@@ -33,6 +33,7 @@ export function NumberCell({
 }: NumberCellProps) {
   const [isEditing, setIsEditing] = useState(false);
   const [editValue, setEditValue] = useState('');
+  const [isComposing, setIsComposing] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
 
   // 編集開始時にpropsの値をローカルステートにコピー
@@ -58,7 +59,9 @@ export function NumberCell({
   };
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
-    if (e.nativeEvent.isComposing) return;
+    // Safari対応: compositionstart/compositionendで管理するstate と keyCode 229 をチェック
+    // keyCode 229 は IME が入力を処理中であることを示す
+    if (isComposing || e.keyCode === 229) return;
 
     if (e.key === 'Enter') {
       handleSave();
@@ -102,6 +105,8 @@ export function NumberCell({
         onChange={(e) => setEditValue(e.target.value)}
         onBlur={handleSave}
         onKeyDown={handleKeyDown}
+        onCompositionStart={() => setIsComposing(true)}
+        onCompositionEnd={() => setIsComposing(false)}
         min={min}
         max={max}
         step={step}

--- a/features/table/components/cells/text-cell.tsx
+++ b/features/table/components/cells/text-cell.tsx
@@ -21,6 +21,7 @@ export function TextCell({
 }: TextCellProps) {
   const [isEditing, setIsEditing] = useState(false);
   const [editValue, setEditValue] = useState('');
+  const [isComposing, setIsComposing] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
 
   // 編集開始時にpropsの値をローカルステートにコピー
@@ -45,7 +46,9 @@ export function TextCell({
   };
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
-    if (e.nativeEvent.isComposing) return;
+    // Safari対応: compositionstart/compositionendで管理するstate と keyCode 229 をチェック
+    // keyCode 229 は IME が入力を処理中であることを示す
+    if (isComposing || e.keyCode === 229) return;
 
     if (e.key === 'Enter') {
       handleSave();
@@ -63,6 +66,8 @@ export function TextCell({
         onChange={(e) => setEditValue(e.target.value)}
         onBlur={handleSave}
         onKeyDown={handleKeyDown}
+        onCompositionStart={() => setIsComposing(true)}
+        onCompositionEnd={() => setIsComposing(false)}
         placeholder={placeholder}
         className="h-8 w-full border-0 bg-transparent focus-visible:ring-0 shadow-none"
       />

--- a/features/table/components/cells/textarea-cell.tsx
+++ b/features/table/components/cells/textarea-cell.tsx
@@ -21,6 +21,7 @@ export function TextareaCell({
 }: TextareaCellProps) {
   const [isEditing, setIsEditing] = useState(false);
   const [editValue, setEditValue] = useState('');
+  const [isComposing, setIsComposing] = useState(false);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
   // 編集開始時にpropsの値をローカルステートにコピー
@@ -45,7 +46,9 @@ export function TextareaCell({
   };
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
-    if (e.nativeEvent.isComposing) return;
+    // Safari対応: compositionstart/compositionendで管理するstate と keyCode 229 をチェック
+    // keyCode 229 は IME が入力を処理中であることを示す
+    if (isComposing || e.keyCode === 229) return;
 
     if (e.key === 'Enter' && e.metaKey) {
       handleSave();
@@ -63,6 +66,8 @@ export function TextareaCell({
         onChange={(e) => setEditValue(e.target.value)}
         onBlur={handleSave}
         onKeyDown={handleKeyDown}
+        onCompositionStart={() => setIsComposing(true)}
+        onCompositionEnd={() => setIsComposing(false)}
         placeholder={placeholder}
         rows={3}
         className="min-h-[60px] w-full border-0 bg-transparent focus-visible:ring-0 shadow-none resize-none"


### PR DESCRIPTION
## 概要
Safari ブラウザで日本語入力時、変換確定の Enter キーでセルの編集が完了してしまう問題を修正しました。

## 実装内容
- `compositionstart` / `compositionend` イベントで独自に IME 状態を追跡する state を追加
- `keyCode === 229` チェックを追加（IME が入力を処理中であることを示す）

**変更ファイル:**
- `features/table/components/cells/text-cell.tsx`
- `features/table/components/cells/textarea-cell.tsx`
- `features/table/components/cells/number-cell.tsx`

## 関連Issue
closes #107

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## バグ修正
* テーブルセルのIME入力対応を改善しました。IME変換中にEnterキーを押しても入力が誤って保存されないようになります。複数のセルタイプで同様の改善を実施しています。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->