### PR TITLE
コードエディタのテーマ設定機能を追加

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next';
 import { Geist, Geist_Mono } from 'next/font/google';
 import { ThemeProvider } from '@/features/theme/providers/theme-provider';
 import { ColorProvider } from '@/features/theme/providers/color-provider';
+import { EditorThemeProvider } from '@/features/theme/providers/editor-theme-provider';
 import { Toaster } from '@/components/ui/sonner';
 import { getSettings } from '@/features/setting/api';
 import { GlobalStyleInjector } from '@/components/shared/global-style-injector';
@@ -64,7 +65,9 @@ export default function RootLayout({
           enableSystem
           disableTransitionOnChange
         >
-          <ColorProvider>{children}</ColorProvider>
+          <ColorProvider>
+            <EditorThemeProvider>{children}</EditorThemeProvider>
+          </ColorProvider>
           <Toaster position="top-center" />
         </ThemeProvider>
       </body>

--- a/components/shared/code-editor.tsx
+++ b/components/shared/code-editor.tsx
@@ -3,6 +3,7 @@
 import { useRef } from 'react';
 import Editor, { OnMount, OnChange } from '@monaco-editor/react';
 import type { editor } from 'monaco-editor';
+import { useEditorTheme } from '@/features/theme/providers/editor-theme-provider';
 
 /**
  * コードエディタのProps型
@@ -26,6 +27,7 @@ export function CodeEditor({
   readOnly = false,
 }: CodeEditorProps) {
   const editorRef = useRef<editor.IStandaloneCodeEditor | null>(null);
+  const { editorTheme } = useEditorTheme();
 
   const handleEditorDidMount: OnMount = (editor) => {
     editorRef.current = editor;
@@ -40,7 +42,7 @@ export function CodeEditor({
       height={height}
       language={language}
       value={value}
-      theme="vs-dark"
+      theme={editorTheme}
       onChange={handleChange}
       onMount={handleEditorDidMount}
       options={{

--- a/features/layout/components/user-menu/account-settings-option.tsx
+++ b/features/layout/components/user-menu/account-settings-option.tsx
@@ -12,6 +12,7 @@ import { DropdownMenuItem } from '@/components/ui/dropdown-menu';
 import { Separator } from '@/components/ui/separator';
 import { ThemeSelector } from '@/features/theme/components/theme-selector';
 import { ColorSelector } from '@/features/theme/components/color-selector';
+import { EditorThemeSelector } from '@/features/theme/components/editor-theme-selector';
 
 /**
  * アカウント設定オプションコンポーネント
@@ -38,6 +39,10 @@ export function AccountSettingsOption() {
           <div className="flex items-center justify-between">
             <h3 className="text-sm font-medium">カラー</h3>
             <ColorSelector />
+          </div>
+          <div className="flex items-center justify-between">
+            <h3 className="text-sm font-medium">エディタカラー</h3>
+            <EditorThemeSelector />
           </div>
         </div>
       </DialogContent>

--- a/features/theme/components/editor-theme-selector.tsx
+++ b/features/theme/components/editor-theme-selector.tsx
@@ -1,0 +1,51 @@
+'use client';
+
+import { ChevronRight, Moon, Sun, SunMoon, MoonStar } from 'lucide-react';
+
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+
+import { useEditorTheme } from '../providers/editor-theme-provider';
+import type { EditorTheme } from '../types';
+
+/**
+ * エディタテーマ選択コンポーネント
+ */
+export function EditorThemeSelector() {
+  const { editorTheme, setEditorTheme } = useEditorTheme();
+
+  const themes = [
+    { value: 'vs', label: 'vs-light', icon: Sun },
+    { value: 'vs-dark', label: 'vs-dark', icon: Moon },
+    { value: 'hc-light', label: 'hc-light', icon: SunMoon },
+    { value: 'hc-black', label: 'hc-black', icon: MoonStar },
+  ] as const;
+
+  const currentTheme = themes.find((t) => t.value === editorTheme);
+  const CurrentIcon = currentTheme?.icon ?? Moon;
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger className="flex items-center bg-card gap-2 text-sm ">
+        <CurrentIcon className="h-4 w-4" />
+        <span>{currentTheme?.label ?? 'vs-dark'}</span>
+        <ChevronRight />
+      </DropdownMenuTrigger>
+      <DropdownMenuContent side="right">
+        {themes.map(({ value, label, icon: Icon }) => (
+          <DropdownMenuItem
+            key={value}
+            onClick={() => setEditorTheme(value as EditorTheme)}
+          >
+            <Icon className="h-4 w-4" />
+            <span>{label}</span>
+          </DropdownMenuItem>
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/features/theme/providers/editor-theme-provider.tsx
+++ b/features/theme/providers/editor-theme-provider.tsx
@@ -1,0 +1,65 @@
+'use client';
+
+import * as React from 'react';
+import { useLocalStorage } from '@/hooks/use-local-storage';
+import type { EditorTheme } from '../types';
+
+/**
+ * エディタテーマコンテキストの型
+ */
+type EditorThemeContextType = {
+  editorTheme: EditorTheme;
+  setEditorTheme: (theme: EditorTheme) => void;
+};
+
+const EditorThemeContext = React.createContext<
+  EditorThemeContextType | undefined
+>(undefined);
+
+const EDITOR_THEME_STORAGE_KEY = 'editor-theme';
+const DEFAULT_EDITOR_THEME: EditorTheme = 'vs-dark';
+
+/**
+ * エディタテーマプロバイダーコンポーネント
+ */
+export function EditorThemeProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const [editorTheme, setEditorTheme] = useLocalStorage<EditorTheme>(
+    EDITOR_THEME_STORAGE_KEY,
+    DEFAULT_EDITOR_THEME
+  );
+  const [isMounted, setIsMounted] = React.useState(false);
+
+  React.useEffect(() => {
+    setIsMounted(true);
+  }, []);
+
+  const value = React.useMemo(
+    () => ({ editorTheme, setEditorTheme }),
+    [editorTheme, setEditorTheme]
+  );
+
+  if (!isMounted) return null;
+
+  return (
+    <EditorThemeContext.Provider value={value}>
+      {children}
+    </EditorThemeContext.Provider>
+  );
+}
+
+/**
+ * エディタテーマコンテキストを使用するカスタムフック
+ */
+export function useEditorTheme() {
+  const context = React.useContext(EditorThemeContext);
+  if (!context) {
+    throw new Error(
+      'useEditorThemeはEditorThemeProvider内で使用する必要があります'
+    );
+  }
+  return context;
+}

--- a/features/theme/types/index.ts
+++ b/features/theme/types/index.ts
@@ -14,3 +14,8 @@ export type Color =
   | 'blue'
   | 'yellow'
   | 'violet';
+
+/**
+ * エディタテーマの型
+ */
+export type EditorTheme = 'vs' | 'vs-dark' | 'hc-black' | 'hc-light';


### PR DESCRIPTION
## 概要
- アカウント設定画面からコードエディタのテーマを選択できる機能を追加
- Monaco Editorの4種類のテーマ（vs-light, vs-dark, hc-light, hc-black）から選択可能
- 選択したテーマはLocalStorageに保存され、即時反映される

## 検証内容
- [x] アカウント設定を開き「エディタカラー」が表示されることを確認
- [x] 各テーマを選択し、コードエディタの表示が切り替わることを確認
- [x] ページをリロードしても選択したテーマが保持されることを確認

## 関連Issue
Closes #111

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * エディタテーマの選択機能を追加しました。アカウント設定からエディタの配色を「vs」「vs-dark」「hc-black」「hc-light」の4つから選択できるようになります。選択したテーマはコードエディタに自動で反映され、設定は保存されます。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->