### PR TITLE
認証ミドルウェアが機能せず未認証でもアクセス可能になっている問題を修正

### DIFF
--- a/lib/auth-edge-config.ts
+++ b/lib/auth-edge-config.ts
@@ -1,4 +1,4 @@
-import type { NextAuthConfig } from 'next-auth';
+import NextAuth, { type NextAuthConfig } from 'next-auth';
 import type { UserRole } from '@prisma/client';
 
 export const authEdgeConfig = {
@@ -26,3 +26,6 @@ export const authEdgeConfig = {
   },
   providers: [],
 } satisfies NextAuthConfig;
+
+// Edge Runtime用のauth関数（middleware専用）
+export const { auth: authEdge } = NextAuth(authEdgeConfig);

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,5 +1,5 @@
 import { NextResponse, type NextRequest } from 'next/server';
-import { auth } from '@/lib/auth-config';
+import { authEdge } from '@/lib/auth-edge-config';
 
 // 認証不要なパス
 const publicPaths = ['/login', '/register', '/api/auth'];
@@ -13,7 +13,7 @@ export async function middleware(request: NextRequest) {
   }
 
   // セッションを確認
-  const session = await auth();
+  const session = await authEdge();
 
   // 未認証の場合はログインページにリダイレクト
   if (!session?.user) {

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,8 +1,5 @@
 import { NextResponse, type NextRequest } from 'next/server';
-import NextAuth from 'next-auth';
-import { authEdgeConfig } from '@/lib/auth-edge-config';
-
-const { auth } = NextAuth(authEdgeConfig);
+import { auth } from '@/lib/auth-config';
 
 // 認証不要なパス
 const publicPaths = ['/login', '/register', '/api/auth'];
@@ -19,7 +16,7 @@ export async function middleware(request: NextRequest) {
   const session = await auth();
 
   // 未認証の場合はログインページにリダイレクト
-  if (!session) {
+  if (!session?.user) {
     const loginUrl = new URL('/login', request.url);
     loginUrl.searchParams.set('callbackUrl', pathname);
     return NextResponse.redirect(loginUrl);


### PR DESCRIPTION
## 概要

ログインしていない状態でも保護されたページにアクセスできてしまう問題を修正しました。

## 問題

未認証ユーザーが `/login` にリダイレクトされず、保護されたページ（ダッシュボードなど）にアクセスできてしまっていました。

## 原因

`middleware.ts` が `authEdgeConfig`（providers が空配列）を使用して独自に NextAuth インスタンスを作成していたため、認証チェックが正しく機能していませんでした。

## 修正内容

`auth-config.ts` から正しい `auth` 関数を直接 import するように変更しました。

**変更箇所**: `middleware.ts`

```typescript
// Before
import NextAuth from 'next-auth';
import { authEdgeConfig } from '@/lib/auth-edge-config';

const { auth } = NextAuth(authEdgeConfig);

// After
import { auth } from '@/lib/auth-config';
```

また、より堅牢なチェックのため `session?.user` で確認するようにしました。

## 確認方法

1. 開発サーバーを起動
2. ログアウト状態で `/` にアクセス
3. `/login?callbackUrl=/` にリダイレクトされることを確認

## 関連Issue

Closes #119

## テスト

- [ ] ログアウト状態で保護されたページにアクセスすると `/login` にリダイレクトされる
- [ ] ログイン後は正常にアクセスできる
- [ ] `/login`, `/register`, `/api/auth/*` は認証なしでアクセスできる

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **リファクタ**
  * 認証処理を新しいエッジ対応の認証フックに切り替えました。
  * セッション判定ロジックを調整し、ユーザー情報の有無に基づいて認証状態を判定するように改善しました。これにより、認証状態の検出精度が向上します。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->