### PR TITLE
ユーザー・グループインポート機能の改善

### DIFF
--- a/features/group/actions/import-groups.ts
+++ b/features/group/actions/import-groups.ts
@@ -10,9 +10,43 @@ import type {
 } from '@/features/table/types/import';
 
 /**
- * グループインポート用のCSVヘッダー定義
+ * ヘッダー名のエイリアス定義（大文字小文字無視）
  */
-const REQUIRED_HEADERS = ['ID', 'グループ名', '説明', '親グループ'];
+const HEADER_ALIASES = {
+  id: ['id'],
+  name: ['name', 'グループ名', '名前'],
+  description: ['description', '説明'],
+  parent: ['parent', 'parentgroup', '親グループ'],
+} as const;
+
+/**
+ * ヘッダー名を正規化してフィールド名を取得
+ */
+function normalizeHeader(header: string): keyof typeof HEADER_ALIASES | null {
+  const normalized = header.trim().toLowerCase();
+  for (const [field, aliases] of Object.entries(HEADER_ALIASES)) {
+    if (aliases.some((alias) => alias.toLowerCase() === normalized)) {
+      return field as keyof typeof HEADER_ALIASES;
+    }
+  }
+  return null;
+}
+
+/**
+ * ヘッダーからカラムインデックスマッピングを作成
+ */
+function createHeaderMapping(
+  headers: string[]
+): Map<keyof typeof HEADER_ALIASES, number> {
+  const mapping = new Map<keyof typeof HEADER_ALIASES, number>();
+  headers.forEach((header, index) => {
+    const field = normalizeHeader(header);
+    if (field && !mapping.has(field)) {
+      mapping.set(field, index);
+    }
+  });
+  return mapping;
+}
 
 /**
  * グループデータをCSVインポートするServer Action
@@ -68,10 +102,13 @@ export async function importGroupsAction(
       };
     }
 
+    // ヘッダーマッピングを作成
+    const headerMapping = createHeaderMapping(parsed.headers);
+
     // データ検証
     const validationErrors: ValidationError[] = [];
     const validRows: Array<{
-      id: string;
+      id: string | null;
       name: string;
       description: string | null;
       parentName: string | null;
@@ -84,24 +121,28 @@ export async function importGroupsAction(
     const existingIds = new Set(existingGroups.map((g) => g.id));
     const groupNameToId = new Map(existingGroups.map((g) => [g.name, g.id]));
 
+    // インデックスを取得（IDは任意なのでundefinedの可能性あり）
+    const idIndex = headerMapping.get('id');
+    const nameIndex = headerMapping.get('name')!;
+    const descriptionIndex = headerMapping.get('description');
+    const parentIndex = headerMapping.get('parent');
+
     for (let i = 0; i < parsed.rows.length; i++) {
       const row = parsed.rows[i];
       const rowNum = i + 2; // ヘッダー行 + 1行目からのインデックス
 
-      if (row.length !== REQUIRED_HEADERS.length) {
-        validationErrors.push({
-          type: 'INVALID_TYPE',
-          row: i,
-          column: '',
-          message: `${rowNum}行目: カラム数が正しくありません`,
-        });
-        continue;
-      }
-
-      const [id, name, description, parentName] = row;
+      // 各フィールドを取得（順序に依存しない）
+      const id = idIndex !== undefined ? row[idIndex]?.trim() || null : null;
+      const name = row[nameIndex]?.trim() || '';
+      const description =
+        descriptionIndex !== undefined
+          ? row[descriptionIndex]?.trim() || null
+          : null;
+      const parentName =
+        parentIndex !== undefined ? row[parentIndex]?.trim() || null : null;
 
       // グループ名の必須チェック
-      if (!name || name.trim() === '') {
+      if (!name) {
         validationErrors.push({
           type: 'REQUIRED_FIELD',
           row: i,
@@ -112,10 +153,10 @@ export async function importGroupsAction(
       }
 
       validRows.push({
-        id: id.trim(),
-        name: name.trim(),
-        description: description.trim() || null,
-        parentName: parentName.trim() || null,
+        id,
+        name,
+        description,
+        parentName,
       });
     }
 
@@ -156,7 +197,7 @@ export async function importGroupsAction(
           }
         }
 
-        // IDが存在する場合は更新、存在しない場合は新規作成
+        // ID値がある + 既存IDと一致 → 更新
         if (row.id && existingIds.has(row.id)) {
           await tx.group.update({
             where: { id: row.id },
@@ -168,8 +209,12 @@ export async function importGroupsAction(
           });
           updatedCount++;
         } else {
+          // 新規作成（ID指定またはUUID自動生成）
           const created = await tx.group.create({
             data: {
+              // ID値がある + 既存IDと不一致 → ID指定で新規作成
+              // ID値が空 → UUID自動生成（idフィールドを省略）
+              ...(row.id ? { id: row.id } : {}),
               name: row.name,
               description: row.description,
               parentId,
@@ -209,19 +254,20 @@ export async function importGroupsAction(
 
 /**
  * CSVヘッダーを検証
+ * 必須: name（ID、説明、親グループは任意）
  */
 function validateHeaders(headers: string[]): ValidationError[] {
   const errors: ValidationError[] = [];
+  const mapping = createHeaderMapping(headers);
 
-  for (const required of REQUIRED_HEADERS) {
-    if (!headers.includes(required)) {
-      errors.push({
-        type: 'MISSING_HEADER',
-        row: -1,
-        column: required,
-        message: `必須ヘッダー "${required}" がありません`,
-      });
-    }
+  // 必須フィールドのチェック（グループ名のみ必須）
+  if (!mapping.has('name')) {
+    errors.push({
+      type: 'MISSING_HEADER',
+      row: -1,
+      column: 'グループ名',
+      message: `必須ヘッダー「グループ名」がありません（許容: ${HEADER_ALIASES.name.join(', ')}）`,
+    });
   }
 
   return errors;

--- a/features/user/actions/import-users.ts
+++ b/features/user/actions/import-users.ts
@@ -12,14 +12,48 @@ import type {
 } from '@/features/table/types/import';
 
 /**
- * ユーザーインポート用のCSVヘッダー定義
+ * ヘッダー名のエイリアス定義（大文字小文字無視）
  */
-const REQUIRED_HEADERS = ['ID', 'メールアドレス', '名前', 'ロール'];
+const HEADER_ALIASES = {
+  id: ['id'],
+  email: ['email', 'mail', 'メールアドレス'],
+  name: ['name', '氏名', '名前'],
+  role: ['role', '権限', 'ロール'],
+} as const;
 
 /**
  * 有効なUserRole
  */
 const VALID_ROLES: UserRole[] = ['ADMIN', 'DEVELOPER', 'MEMBER'];
+
+/**
+ * ヘッダー名を正規化してフィールド名を取得
+ */
+function normalizeHeader(header: string): keyof typeof HEADER_ALIASES | null {
+  const normalized = header.trim().toLowerCase();
+  for (const [field, aliases] of Object.entries(HEADER_ALIASES)) {
+    if (aliases.some((alias) => alias.toLowerCase() === normalized)) {
+      return field as keyof typeof HEADER_ALIASES;
+    }
+  }
+  return null;
+}
+
+/**
+ * ヘッダーからカラムインデックスマッピングを作成
+ */
+function createHeaderMapping(
+  headers: string[]
+): Map<keyof typeof HEADER_ALIASES, number> {
+  const mapping = new Map<keyof typeof HEADER_ALIASES, number>();
+  headers.forEach((header, index) => {
+    const field = normalizeHeader(header);
+    if (field && !mapping.has(field)) {
+      mapping.set(field, index);
+    }
+  });
+  return mapping;
+}
 
 /**
  * CSVインポートで作成されるユーザーのデフォルトパスワード
@@ -81,10 +115,13 @@ export async function importUsersAction(
       };
     }
 
+    // ヘッダーマッピングを作成
+    const headerMapping = createHeaderMapping(parsed.headers);
+
     // データ検証
     const validationErrors: ValidationError[] = [];
     const validRows: Array<{
-      id: string;
+      id: string | null;
       email: string;
       name: string;
       role: UserRole;
@@ -97,24 +134,24 @@ export async function importUsersAction(
     const existingIds = new Set(existingUsers.map((u) => u.id));
     const existingEmails = new Set(existingUsers.map((u) => u.email));
 
+    // インデックスを取得（IDは任意なのでundefinedの可能性あり）
+    const idIndex = headerMapping.get('id');
+    const emailIndex = headerMapping.get('email')!;
+    const nameIndex = headerMapping.get('name')!;
+    const roleIndex = headerMapping.get('role')!;
+
     for (let i = 0; i < parsed.rows.length; i++) {
       const row = parsed.rows[i];
       const rowNum = i + 2; // ヘッダー行 + 1行目からのインデックス
 
-      if (row.length !== REQUIRED_HEADERS.length) {
-        validationErrors.push({
-          type: 'INVALID_TYPE',
-          row: i,
-          column: '',
-          message: `${rowNum}行目: カラム数が正しくありません`,
-        });
-        continue;
-      }
-
-      const [id, email, name, role] = row;
+      // 各フィールドを取得（順序に依存しない）
+      const id = idIndex !== undefined ? row[idIndex]?.trim() || null : null;
+      const email = row[emailIndex]?.trim() || '';
+      const name = row[nameIndex]?.trim() || '';
+      const role = row[roleIndex]?.trim() || '';
 
       // メールアドレスの必須チェック
-      if (!email || email.trim() === '') {
+      if (!email) {
         validationErrors.push({
           type: 'REQUIRED_FIELD',
           row: i,
@@ -126,7 +163,7 @@ export async function importUsersAction(
 
       // メールアドレスの形式チェック
       const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-      if (!emailRegex.test(email.trim())) {
+      if (!emailRegex.test(email)) {
         validationErrors.push({
           type: 'INVALID_TYPE',
           row: i,
@@ -137,7 +174,7 @@ export async function importUsersAction(
       }
 
       // 名前の必須チェック
-      if (!name || name.trim() === '') {
+      if (!name) {
         validationErrors.push({
           type: 'REQUIRED_FIELD',
           row: i,
@@ -159,9 +196,9 @@ export async function importUsersAction(
       }
 
       validRows.push({
-        id: id.trim(),
-        email: email.trim(),
-        name: name.trim(),
+        id,
+        email,
+        name,
         role: role as UserRole,
       });
     }
@@ -189,7 +226,7 @@ export async function importUsersAction(
 
     await prisma.$transaction(async (tx) => {
       for (const row of validRows) {
-        // IDが存在する場合は更新
+        // ID値がある + 既存IDと一致 → 更新
         if (row.id && existingIds.has(row.id)) {
           await tx.user.update({
             where: { id: row.id },
@@ -201,7 +238,7 @@ export async function importUsersAction(
           });
           updatedCount++;
         }
-        // メールアドレスが既に存在する場合はスキップ
+        // メールアドレスが既に存在する場合はスキップ（新規作成のみ）
         else if (existingEmails.has(row.email)) {
           skippedCount++;
         }
@@ -210,6 +247,9 @@ export async function importUsersAction(
           try {
             await tx.user.create({
               data: {
+                // ID値がある + 既存IDと不一致 → ID指定で新規作成
+                // ID値が空 → UUID自動生成（idフィールドを省略）
+                ...(row.id ? { id: row.id } : {}),
                 name: row.name,
                 email: row.email,
                 password: hashedPassword,
@@ -252,17 +292,29 @@ export async function importUsersAction(
 
 /**
  * CSVヘッダーを検証
+ * 必須: email, name, role（IDは任意）
  */
 function validateHeaders(headers: string[]): ValidationError[] {
   const errors: ValidationError[] = [];
+  const mapping = createHeaderMapping(headers);
 
-  for (const required of REQUIRED_HEADERS) {
-    if (!headers.includes(required)) {
+  // 必須フィールドのチェック（IDは任意なので含まない）
+  const requiredFields: Array<{
+    field: keyof typeof HEADER_ALIASES;
+    displayName: string;
+  }> = [
+    { field: 'email', displayName: 'メールアドレス' },
+    { field: 'name', displayName: '名前' },
+    { field: 'role', displayName: 'ロール' },
+  ];
+
+  for (const { field, displayName } of requiredFields) {
+    if (!mapping.has(field)) {
       errors.push({
         type: 'MISSING_HEADER',
         row: -1,
-        column: required,
-        message: `必須ヘッダー "${required}" がありません`,
+        column: displayName,
+        message: `必須ヘッダー「${displayName}」がありません（許容: ${HEADER_ALIASES[field].join(', ')}）`,
       });
     }
   }


### PR DESCRIPTION
## Summary
- ユーザー・グループインポートのCSVヘッダー認識を柔軟化（順序依存の撤廃、表記ゆれ・英語ヘッダー対応）
- IDカラムを任意項目とし、IDの有無による更新/新規作成の自動判定ロジックを `import-table.ts` と統一

## 変更内容

### ヘッダー認識の柔軟化
ヘッダー名からカラムを自動判定するエイリアス方式を導入（大文字小文字無視）:

**ユーザー:**
| フィールド | 許容ヘッダー |
|---|---|
| ID | `id` |
| メールアドレス | `email`, `mail`, `メールアドレス` |
| 名前 | `name`, `氏名`, `名前` |
| ロール | `role`, `権限`, `ロール` |

**グループ:**
| フィールド | 許容ヘッダー |
|---|---|
| ID | `id` |
| グループ名 | `name`, `グループ名`, `名前` |
| 説明 | `description`, `説明` |
| 親グループ | `parent`, `parentgroup`, `親グループ` |

### IDカラムの任意化と更新/新規判定ロジック
- IDカラムなし → 全て新規追加（UUID自動生成）
- ID値あり + 既存ID一致 → 更新
- ID値あり + 既存ID不一致 → ID指定で新規作成
- ID値が空 → UUID自動生成で新規作成

Closes #124

## Test plan
- [x] ビルド成功
- [x] テスト全件（425件）パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * CSVインポート機能の柔軟性向上：ヘッダー順序の制約を廃止し、大文字小文字を区別しない照合に対応しました。
  * 複数の別名によるヘッダー認識：同一フィールドに対して複数の有効なカラム名に対応しました。
  * オプショナルIDフィールド：グループおよびユーザーインポート時にID指定を任意化しました。

* **改善**
  * ヘッダー検証エラーメッセージを改善し、許可された別名情報を表示するようにしました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->