### PR TITLE
OSS公開に向けたMITライセンスの追加

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 ymtdir
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 ![CI](https://github.com/ymtdir/muku/workflows/CI/badge.svg)
 [![codecov](https://codecov.io/gh/ymtdir/muku/graph/badge.svg?token=B0Z8GTSYQK)](https://codecov.io/gh/ymtdir/muku)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 Next.js製の業務アプリケーションプラットフォーム
 
@@ -109,8 +110,8 @@ docker compose up --build
 
 起動後、以下のURLでアクセスできます:
 
-| サービス         | URL                       |
-| ---------------- | ------------------------- |
+| サービス         | URL                         |
+| ---------------- | --------------------------- |
 | アプリケーション | <http://localhost>          |
 | pgAdmin          | <http://localhost/pgadmin/> |
 
@@ -185,3 +186,7 @@ docker compose up --build
 - **ディレクトリ構成**: [directory-structure.md](.docs/architecture/directory-structure.md)
 - **開発ガイド**: [development/](.docs/development/)
 - **機能仕様**: [features/](.docs/features/)
+
+## License
+
+This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "muku",
   "version": "0.1.0",
+  "license": "MIT",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## 概要

OSSとして広く利用してもらうために、MITライセンスを追加しました。

- LICENSEファイルの作成
- package.jsonへのライセンス追記
- READMEへのバッジとライセンスセクションの追加

## 関連Issue

closes #128

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* プロジェクトに MIT ライセンスを正式に追加しました。
* ライセンス情報がドキュメントおよびパッケージメタデータに含められるようになりました。
* ライセンスバッジと詳細情報がプロジェクト概要に表示されるようになりました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->