### PR TITLE
アイテムのJSON形式エクスポート機能を追加

### DIFF
--- a/features/item/actions/export-item.ts
+++ b/features/item/actions/export-item.ts
@@ -6,6 +6,7 @@ import { getItemById } from '@/features/item/api';
 import { getStyles } from '@/features/style/api/get-styles';
 import { getScripts } from '@/features/script/api/get-scripts';
 import { getRecords } from '@/features/record/api/get-records';
+import type { UserRole } from '@prisma/client';
 import type {
   ItemExportData,
   ItemExportFile,
@@ -17,7 +18,9 @@ import type {
  */
 async function buildItemExportData(
   itemId: string,
-  options: ItemExportOptions
+  options: ItemExportOptions,
+  userId: string,
+  userRole: UserRole
 ): Promise<ItemExportData | null> {
   const item = await getItemById(itemId);
   if (!item) return null;
@@ -58,7 +61,15 @@ async function buildItemExportData(
   if (options.includeChildren && item.type === 'FOLDER' && item.children) {
     const children: ItemExportData[] = [];
     for (const child of item.children) {
-      const childData = await buildItemExportData(child.id, options);
+      const { canAccess } = await canAccessItem(child.id, userId, userRole);
+      if (!canAccess) continue;
+
+      const childData = await buildItemExportData(
+        child.id,
+        options,
+        userId,
+        userRole
+      );
       if (childData) {
         children.push(childData);
       }
@@ -94,7 +105,12 @@ export async function exportItemAction(
       return { error: 'このアイテムへのアクセス権限がありません' };
     }
 
-    const exportData = await buildItemExportData(itemId, options);
+    const exportData = await buildItemExportData(
+      itemId,
+      options,
+      currentUser.id,
+      currentUser.role
+    );
     if (!exportData) {
       return { error: 'アイテムが見つかりません' };
     }

--- a/features/item/actions/export-item.ts
+++ b/features/item/actions/export-item.ts
@@ -1,0 +1,111 @@
+'use server';
+
+import { getItemById } from '@/features/item/api';
+import { getStyles } from '@/features/style/api/get-styles';
+import { getScripts } from '@/features/script/api/get-scripts';
+import { getRecords } from '@/features/record/api/get-records';
+import type {
+  ItemExportData,
+  ItemExportFile,
+  ItemExportOptions,
+} from '@/features/item/types';
+
+/**
+ * 単一アイテムのエクスポートデータを構築する
+ */
+async function buildItemExportData(
+  itemId: string,
+  options: ItemExportOptions
+): Promise<ItemExportData | null> {
+  const item = await getItemById(itemId);
+  if (!item) return null;
+
+  // スタイル・スクリプトを取得
+  const stylesResult = await getStyles(itemId);
+  const scriptsResult = await getScripts(itemId);
+
+  const styles = stylesResult.styles.map((s) => ({
+    name: s.name,
+    content: s.content,
+    order: s.order,
+  }));
+
+  const scripts = scriptsResult.scripts.map((s) => ({
+    name: s.name,
+    content: s.content,
+    order: s.order,
+  }));
+
+  const exportData: ItemExportData = {
+    name: item.name,
+    type: item.type,
+    icon: item.icon,
+    order: item.order,
+    meta: item.meta,
+    styles,
+    scripts,
+  };
+
+  // レコードを含める（TABLE型の場合のみ）
+  if (options.includeRecords && item.type === 'TABLE') {
+    const records = await getRecords(itemId);
+    exportData.records = records.map((r) => ({ data: r.data }));
+  }
+
+  // 子アイテムを含める（FOLDER型の場合のみ）
+  if (options.includeChildren && item.type === 'FOLDER' && item.children) {
+    const children: ItemExportData[] = [];
+    for (const child of item.children) {
+      const childData = await buildItemExportData(child.id, options);
+      if (childData) {
+        children.push(childData);
+      }
+    }
+    if (children.length > 0) {
+      exportData.children = children;
+    }
+  }
+
+  return exportData;
+}
+
+/**
+ * アイテムをJSON形式でエクスポートするServer Action
+ */
+export async function exportItemAction(
+  itemId: string,
+  options: ItemExportOptions
+): Promise<{ json?: string; filename?: string; error?: string }> {
+  try {
+    const exportData = await buildItemExportData(itemId, options);
+    if (!exportData) {
+      return { error: 'アイテムが見つかりません' };
+    }
+
+    const exportFile: ItemExportFile = {
+      version: 1,
+      exportedAt: new Date().toISOString(),
+      items: [exportData],
+    };
+
+    const json = JSON.stringify(exportFile, null, 2);
+
+    // タイムスタンプ付きファイル名を生成
+    const timestamp = new Date()
+      .toLocaleString('ja-JP', {
+        year: 'numeric',
+        month: '2-digit',
+        day: '2-digit',
+        hour: '2-digit',
+        minute: '2-digit',
+        second: '2-digit',
+      })
+      .replace(/[/:\s]/g, '-');
+    const filename = `${exportData.name}_${timestamp}.json`;
+
+    return { json, filename };
+  } catch (error) {
+    console.error('アイテムのエクスポートに失敗しました:', error);
+    return { error: 'アイテムのエクスポートに失敗しました' };
+  }
+}

--- a/features/item/actions/export-item.ts
+++ b/features/item/actions/export-item.ts
@@ -118,7 +118,8 @@ export async function exportItemAction(
         second: '2-digit',
       })
       .replace(/[/:\s]/g, '-');
-    const filename = `${exportData.name}_${timestamp}.json`;
+    const safeName = exportData.name.replace(/[\\/:*?"<>|]/g, '_');
+    const filename = `${safeName}_${timestamp}.json`;
 
     return { json, filename };
   } catch (error) {

--- a/features/item/actions/export-item.ts
+++ b/features/item/actions/export-item.ts
@@ -1,5 +1,7 @@
 'use server';
 
+import { requireAuth } from '@/lib/auth';
+import { canAccessItem } from '@/lib/permissions';
 import { getItemById } from '@/features/item/api';
 import { getStyles } from '@/features/style/api/get-styles';
 import { getScripts } from '@/features/script/api/get-scripts';
@@ -77,6 +79,21 @@ export async function exportItemAction(
   options: ItemExportOptions
 ): Promise<{ json?: string; filename?: string; error?: string }> {
   try {
+    // 認証・権限チェック
+    const currentUser = await requireAuth().catch(() => null);
+    if (!currentUser) {
+      return { error: '認証が必要です' };
+    }
+
+    const { canAccess } = await canAccessItem(
+      itemId,
+      currentUser.id,
+      currentUser.role
+    );
+    if (!canAccess) {
+      return { error: 'このアイテムへのアクセス権限がありません' };
+    }
+
     const exportData = await buildItemExportData(itemId, options);
     if (!exportData) {
       return { error: 'アイテムが見つかりません' };

--- a/features/item/components/export-item-dialog.tsx
+++ b/features/item/components/export-item-dialog.tsx
@@ -1,0 +1,133 @@
+'use client';
+
+import { useState } from 'react';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Label } from '@/components/ui/label';
+import { toast } from 'sonner';
+import { exportItemAction } from '@/features/item/actions/export-item';
+import { downloadJSON } from '@/lib/download';
+import type { ItemExportOptions } from '@/features/item/types';
+
+/**
+ * エクスポートダイアログのProps型
+ */
+type ExportItemDialogProps = {
+  itemId: string;
+  itemName: string;
+  itemType: 'TABLE' | 'FOLDER';
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+};
+
+/**
+ * アイテムエクスポートオプションダイアログ
+ */
+export function ExportItemDialog({
+  itemId,
+  itemName,
+  itemType,
+  open,
+  onOpenChange,
+}: ExportItemDialogProps) {
+  const [includeChildren, setIncludeChildren] = useState(true);
+  const [includeRecords, setIncludeRecords] = useState(false);
+  const [isExporting, setIsExporting] = useState(false);
+
+  const handleExport = async () => {
+    setIsExporting(true);
+
+    try {
+      const options: ItemExportOptions = {
+        includeChildren,
+        includeRecords,
+      };
+
+      const result = await exportItemAction(itemId, options);
+
+      if (result.error) {
+        toast.error('エクスポートに失敗しました', {
+          description: result.error,
+        });
+        return;
+      }
+
+      if (result.json && result.filename) {
+        downloadJSON(result.json, result.filename);
+        toast.success('エクスポートが完了しました');
+        onOpenChange(false);
+      }
+    } catch {
+      toast.error('エクスポートに失敗しました');
+    } finally {
+      setIsExporting(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>{itemName} をエクスポート</DialogTitle>
+          <DialogDescription>
+            アイテムの定義をJSON形式でエクスポートします
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="grid gap-4 py-4">
+          {itemType === 'FOLDER' && (
+            <div className="flex items-center space-x-2">
+              <Checkbox
+                id="includeChildren"
+                checked={includeChildren}
+                onCheckedChange={(checked) =>
+                  setIncludeChildren(checked === true)
+                }
+              />
+              <Label htmlFor="includeChildren" className="font-normal">
+                子アイテムを含める
+              </Label>
+            </div>
+          )}
+
+          <div className="flex items-center space-x-2">
+            <Checkbox
+              id="includeRecords"
+              checked={includeRecords}
+              onCheckedChange={(checked) => setIncludeRecords(checked === true)}
+            />
+            <Label htmlFor="includeRecords" className="font-normal">
+              レコードを含める
+            </Label>
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button
+            variant="outline"
+            className="cursor-pointer"
+            onClick={() => onOpenChange(false)}
+            disabled={isExporting}
+          >
+            キャンセル
+          </Button>
+          <Button
+            className="cursor-pointer"
+            onClick={handleExport}
+            disabled={isExporting}
+          >
+            {isExporting ? 'エクスポート中...' : 'エクスポート'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/features/item/types/export.ts
+++ b/features/item/types/export.ts
@@ -1,0 +1,31 @@
+/**
+ * アイテムエクスポートのデータ構造
+ */
+export type ItemExportData = {
+  name: string;
+  type: 'TABLE' | 'FOLDER';
+  icon: string | null;
+  order: number;
+  meta: unknown;
+  styles: { name: string; content: string; order: number }[];
+  scripts: { name: string; content: string; order: number }[];
+  records?: { data: unknown }[];
+  children?: ItemExportData[];
+};
+
+/**
+ * エクスポートファイルのルート構造
+ */
+export type ItemExportFile = {
+  version: number;
+  exportedAt: string;
+  items: ItemExportData[];
+};
+
+/**
+ * エクスポートオプション
+ */
+export type ItemExportOptions = {
+  includeChildren: boolean;
+  includeRecords: boolean;
+};

--- a/features/item/types/index.ts
+++ b/features/item/types/index.ts
@@ -1,1 +1,2 @@
 export * from './item';
+export * from './export';

--- a/features/layout/components/item-options-button/index.tsx
+++ b/features/layout/components/item-options-button/index.tsx
@@ -163,12 +163,15 @@ export function ItemOptionsButton({
     }
 
     if (result.error) {
-      console.error('Export error:', result.error);
+      toast.error('エクスポートに失敗しました', {
+        description: result.error,
+      });
       return;
     }
 
     if (result.csv && result.filename) {
       downloadCSV(result.csv, result.filename);
+      toast.success('エクスポートが完了しました');
     }
   };
 

--- a/features/layout/components/item-options-button/index.tsx
+++ b/features/layout/components/item-options-button/index.tsx
@@ -43,7 +43,7 @@ import { importTableAction } from '@/features/table/actions/import-table';
 import { importGroupsAction } from '@/features/group/actions/import-groups';
 import { importUsersAction } from '@/features/user/actions/import-users';
 import { getItemById } from '@/features/item/api';
-import { downloadCSV } from '@/lib/csv';
+import { downloadCSV } from '@/lib/download';
 import { ImportDialog } from '@/components/shared/import-dialog';
 import { ExportItemDialog } from '@/features/item/components/export-item-dialog';
 

--- a/features/layout/components/item-options-button/index.tsx
+++ b/features/layout/components/item-options-button/index.tsx
@@ -11,6 +11,8 @@ import {
   AlertCircle,
 } from 'lucide-react';
 import Link from 'next/link';
+import type { ItemType } from '@prisma/client';
+import { RenameItemOption } from '@/features/layout/components/workspace-menu/edit-item-button/rename-item-option';
 import type { PageType } from './container';
 import type { ExportColumnFilter } from '@/features/table/types/export';
 import {
@@ -61,6 +63,7 @@ export function ItemOptionsButton({
 }: ItemOptionsButtonProps) {
   const router = useRouter();
   const searchParams = useSearchParams();
+  const [dropdownOpen, setDropdownOpen] = useState(false);
   const [importDialogOpen, setImportDialogOpen] = useState(false);
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
@@ -168,7 +171,7 @@ export function ItemOptionsButton({
 
   return (
     <>
-      <DropdownMenu>
+      <DropdownMenu open={dropdownOpen} onOpenChange={setDropdownOpen}>
         <DropdownMenuTrigger asChild>
           <Button variant="ghost" size="icon">
             <Ellipsis />
@@ -178,6 +181,12 @@ export function ItemOptionsButton({
         <DropdownMenuContent align="end">
           {pageType === 'TABLE' && itemId && (
             <>
+              <RenameItemOption
+                itemId={itemId}
+                itemType={'TABLE' as ItemType}
+                currentName={itemName}
+                onOpenChange={setDropdownOpen}
+              />
               <DropdownMenuItem asChild>
                 <Link href={`/${itemId}/edit`} className="cursor-pointer">
                   <Settings />
@@ -199,6 +208,12 @@ export function ItemOptionsButton({
           )}
           {pageType === 'FOLDER' && itemId && (
             <>
+              <RenameItemOption
+                itemId={itemId}
+                itemType={'FOLDER' as ItemType}
+                currentName={itemName}
+                onOpenChange={setDropdownOpen}
+              />
               <DropdownMenuItem asChild>
                 <Link href={`/${itemId}/edit`} className="cursor-pointer">
                   <Settings />
@@ -221,11 +236,11 @@ export function ItemOptionsButton({
             <>
               <DropdownMenuItem onSelect={() => setImportDialogOpen(true)}>
                 <FileInput />
-                インポート
+                レコードのインポート
               </DropdownMenuItem>
               <DropdownMenuItem onSelect={handleExport}>
                 <FileOutput />
-                エクスポート
+                レコードのエクスポート
               </DropdownMenuItem>
             </>
           )}

--- a/features/layout/components/item-options-button/index.tsx
+++ b/features/layout/components/item-options-button/index.tsx
@@ -6,6 +6,7 @@ import {
   Ellipsis,
   FileOutput,
   FileInput,
+  Package,
   Settings,
   Trash2,
   AlertCircle,
@@ -44,6 +45,7 @@ import { importUsersAction } from '@/features/user/actions/import-users';
 import { getItemById } from '@/features/item/api';
 import { downloadCSV } from '@/lib/csv';
 import { ImportDialog } from '@/components/shared/import-dialog';
+import { ExportItemDialog } from '@/features/item/components/export-item-dialog';
 
 /**
  * アイテムオプションボタンのProps型
@@ -65,6 +67,7 @@ export function ItemOptionsButton({
   const searchParams = useSearchParams();
   const [dropdownOpen, setDropdownOpen] = useState(false);
   const [importDialogOpen, setImportDialogOpen] = useState(false);
+  const [exportItemDialogOpen, setExportItemDialogOpen] = useState(false);
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
   const [itemName, setItemName] = useState<string>('');
@@ -230,7 +233,19 @@ export function ItemOptionsButton({
                 <Trash2 className="text-destructive" />
                 削除
               </DropdownMenuItem>
+              <DropdownMenuSeparator />
             </>
+          )}
+          {(pageType === 'TABLE' || pageType === 'FOLDER') && itemId && (
+            <DropdownMenuItem
+              onSelect={(e) => {
+                e.preventDefault();
+                setExportItemDialogOpen(true);
+              }}
+            >
+              <Package />
+              アイテムのエクスポート
+            </DropdownMenuItem>
           )}
           {exportableTypes.includes(pageType) && (
             <>
@@ -282,6 +297,17 @@ export function ItemOptionsButton({
             </AlertDialogFooter>
           </AlertDialogContent>
         </AlertDialog>
+      )}
+
+      {/* アイテムエクスポートダイアログ */}
+      {(pageType === 'TABLE' || pageType === 'FOLDER') && itemId && (
+        <ExportItemDialog
+          itemId={itemId}
+          itemName={itemName}
+          itemType={pageType}
+          open={exportItemDialogOpen}
+          onOpenChange={setExportItemDialogOpen}
+        />
       )}
 
       {/* インポートダイアログ */}

--- a/features/table/actions/export-table.ts
+++ b/features/table/actions/export-table.ts
@@ -137,7 +137,8 @@ export async function exportTableAction(
       second: '2-digit',
     })
     .replace(/[/:\s]/g, '-');
-  const filename = `${item.name}_${timestamp}.csv`;
+  const safeName = item.name.replace(/[\\/:*?"<>|]/g, '_');
+  const filename = `${safeName}_${timestamp}.csv`;
 
   return { csv, filename };
 }

--- a/lib/csv.ts
+++ b/lib/csv.ts
@@ -46,32 +46,6 @@ export function convertToCSV(
 }
 
 /**
- * CSVファイルをダウンロードする
- * @param csv - CSV形式の文字列
- * @param filename - ダウンロードするファイル名
- */
-export function downloadCSV(csv: string, filename: string): void {
-  // BOM付きUTF-8でエンコード（Excelで正しく開けるようにするため）
-  const bom = '\uFEFF';
-  const blob = new Blob([bom + csv], { type: 'text/csv;charset=utf-8;' });
-
-  // ダウンロード用のリンクを作成
-  const link = document.createElement('a');
-  const url = URL.createObjectURL(blob);
-
-  link.setAttribute('href', url);
-  link.setAttribute('download', filename);
-  link.style.visibility = 'hidden';
-
-  document.body.appendChild(link);
-  link.click();
-  document.body.removeChild(link);
-
-  // メモリリークを防ぐためURLを解放
-  URL.revokeObjectURL(url);
-}
-
-/**
  * CSVセルの値をアンエスケープする
  * @param cell - エスケープされたCSVセル値
  * @returns アンエスケープされた値

--- a/lib/download.ts
+++ b/lib/download.ts
@@ -1,0 +1,46 @@
+/**
+ * ファイルダウンロード用のユーティリティ関数
+ */
+
+/**
+ * CSVファイルをダウンロードする
+ * @param csv - CSV形式の文字列
+ * @param filename - ダウンロードするファイル名
+ */
+export function downloadCSV(csv: string, filename: string): void {
+  // BOM付きUTF-8でエンコード（Excelで正しく開けるようにするため）
+  const bom = '\uFEFF';
+  const blob = new Blob([bom + csv], { type: 'text/csv;charset=utf-8;' });
+
+  downloadBlob(blob, filename);
+}
+
+/**
+ * JSONファイルをダウンロードする
+ * @param json - JSON形式の文字列
+ * @param filename - ダウンロードするファイル名
+ */
+export function downloadJSON(json: string, filename: string): void {
+  const blob = new Blob([json], { type: 'application/json;charset=utf-8;' });
+
+  downloadBlob(blob, filename);
+}
+
+/**
+ * Blobをファイルとしてダウンロードする
+ */
+function downloadBlob(blob: Blob, filename: string): void {
+  const link = document.createElement('a');
+  const url = URL.createObjectURL(blob);
+
+  link.setAttribute('href', url);
+  link.setAttribute('download', filename);
+  link.style.visibility = 'hidden';
+
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+
+  // メモリリークを防ぐためURLを解放
+  URL.revokeObjectURL(url);
+}

--- a/lib/table-export.ts
+++ b/lib/table-export.ts
@@ -51,6 +51,7 @@ export function exportTableToCSV<TData>(
       second: '2-digit',
     })
     .replace(/[/:\s]/g, '-');
-  const filename = `${tableName}_${timestamp}.csv`;
+  const safeName = tableName.replace(/[\\/:*?"<>|]/g, '_');
+  const filename = `${safeName}_${timestamp}.csv`;
   downloadCSV(csv, filename);
 }

--- a/lib/table-export.ts
+++ b/lib/table-export.ts
@@ -1,5 +1,6 @@
 import type { Table } from '@tanstack/react-table';
-import { convertToCSV, downloadCSV } from './csv';
+import { convertToCSV } from './csv';
+import { downloadCSV } from './download';
 
 /**
  * TanStack Tableからフィルター・ソート済みのデータをCSVエクスポートする


### PR DESCRIPTION
## 概要

テーブル/フォルダのアイテム定義をJSON形式でエクスポートする機能を実装しました。
オプションで子アイテム（フォルダ配下の再帰）やレコードデータも含められます。

併せて、ヘッダー右上メニューの整備も行いました。

## 変更内容

### アイテムエクスポート機能
- `features/item/types/export.ts`: エクスポート用型定義（`ItemExportData`, `ItemExportFile`, `ItemExportOptions`）
- `features/item/actions/export-item.ts`: Server Action（子アイテムの再帰的な構築に対応）
- `features/item/components/export-item-dialog.tsx`: オプション選択ダイアログ（子アイテム/レコード含むチェックボックス）

### ヘッダー右上メニューの整備
- 「インポート」「エクスポート」→「レコードのインポート」「レコードのエクスポート」にラベル変更
- TABLE/FOLDERのメニューに「名前を変更」を追加し、サイドバーのコンテキストメニューと統一
- 「アイテムのエクスポート」メニュー項目を追加
- レコードエクスポートの成功/失敗時にトースト通知を追加

### リファクタリング
- `lib/download.ts`: ダウンロード関数を`lib/csv.ts`から分離（`downloadCSV`, `downloadJSON`）
- 共通の`downloadBlob`ヘルパーで重複を解消

## 関連Issue

Closes #130

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * アイテムをJSONでエクスポートする対話式ダイアログを追加しました（フォルダーの子要素・テーブルのレコードを選択可能）。
  * アイテムのオプションメニューからエクスポートを起動できるようになりました。

* **改善**
  * ブラウザ向けダウンロード処理を共通化し、CSV/JSONのダウンロード互換性を向上しました。
  * 出力ファイル名を安全な形式に正規化するようになりました。

* **修正**
  * エクスポート中のエラー表示と完了通知をユーザ向けに改善しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->