### PR TITLE
getItemById に認証・認可チェックを追加

### DIFF
--- a/features/item/api/__tests__/get-item-by-id.test.ts
+++ b/features/item/api/__tests__/get-item-by-id.test.ts
@@ -9,11 +9,36 @@ jest.mock('@/lib/prisma', () => ({
   },
 }));
 
+// lib/authをモック化
+jest.mock('@/lib/auth', () => ({
+  getCurrentUser: jest.fn(),
+}));
+
+// lib/permissionsをモック化
+jest.mock('@/lib/permissions', () => ({
+  canAccessItem: jest.fn(),
+}));
+
 import { prisma } from '@/lib/prisma';
+import { getCurrentUser } from '@/lib/auth';
+import { canAccessItem } from '@/lib/permissions';
+
+const mockUser = {
+  id: 'user-1',
+  email: 'test@example.com',
+  name: 'Test User',
+  role: 'MEMBER' as const,
+};
 
 describe('getItemById', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    // デフォルトで認証済み・アクセス可能に設定
+    (getCurrentUser as jest.Mock).mockResolvedValue(mockUser);
+    (canAccessItem as jest.Mock).mockResolvedValue({
+      canAccess: true,
+      level: 'READ',
+    });
   });
 
   it('アイテムを取得できる', async () => {
@@ -96,5 +121,43 @@ describe('getItemById', () => {
     const result = await getItemById(itemId);
 
     expect(result).toBeNull();
+  });
+
+  it('未認証の場合はnullを返す', async () => {
+    (getCurrentUser as jest.Mock).mockResolvedValue(null);
+
+    const result = await getItemById('folder-1');
+
+    expect(result).toBeNull();
+    expect(prisma.item.findUnique).not.toHaveBeenCalled();
+  });
+
+  it('権限がない場合はnullを返す', async () => {
+    const mockItem = {
+      id: 'folder-1',
+      name: 'テストアイテム',
+      parentId: null,
+      order: 0,
+      createdAt: new Date('2024-01-01'),
+      updatedAt: new Date('2024-01-01'),
+      createdById: 'user-2',
+      children: [],
+      _count: { children: 0 },
+    };
+
+    (prisma.item.findUnique as jest.Mock).mockResolvedValue(mockItem);
+    (canAccessItem as jest.Mock).mockResolvedValue({
+      canAccess: false,
+      level: 'NONE',
+    });
+
+    const result = await getItemById('folder-1');
+
+    expect(result).toBeNull();
+    expect(canAccessItem).toHaveBeenCalledWith(
+      'folder-1',
+      mockUser.id,
+      mockUser.role
+    );
   });
 });

--- a/features/item/api/get-item-by-id.ts
+++ b/features/item/api/get-item-by-id.ts
@@ -1,12 +1,18 @@
 'use server';
 
 import { prisma } from '@/lib/prisma';
+import { getCurrentUser } from '@/lib/auth';
+import { canAccessItem } from '@/lib/permissions';
 import type { Item } from '../types';
 
 /**
  * IDでアイテムを取得するServer Action
  */
 export async function getItemById(id: string): Promise<Item | null> {
+  // 認証チェック
+  const currentUser = await getCurrentUser();
+  if (!currentUser) return null;
+
   const item = await prisma.item.findUnique({
     where: { id },
     include: {
@@ -22,6 +28,15 @@ export async function getItemById(id: string): Promise<Item | null> {
       },
     },
   });
+  if (!item) return null;
+
+  // 権限チェック
+  const { canAccess } = await canAccessItem(
+    id,
+    currentUser.id,
+    currentUser.role
+  );
+  if (!canAccess) return null;
 
   return item as Item | null;
 }


### PR DESCRIPTION
## 概要

`getItemById` に `getCurrentUser()` + `canAccessItem()` による認証・認可チェックを追加しました。
未認証ユーザーやアクセス権限のないユーザーがアイテムを取得できないようにします。

## 変更内容

- `features/item/api/get-item-by-id.ts`: `getCurrentUser()` で認証チェック、`canAccessItem()` で権限チェックを追加
- `features/item/api/__tests__/get-item-by-id.test.ts`: 認証・権限モックの追加と、未認証・権限なしケースのテストを追加

## 関連Issue

Closes #133

🤖 Generated with [Claude Code](https://claude.com/claude-code)