### PR TITLE
アイテムのJSON形式インポート機能を追加

### DIFF
--- a/features/item/actions/import-item.ts
+++ b/features/item/actions/import-item.ts
@@ -233,18 +233,21 @@ export async function importItemAction(
     // トランザクションでアイテムを一括作成
     let insertedCount = 0;
 
-    await prisma.$transaction(async (tx) => {
-      for (let i = 0; i < exportFile.items.length; i++) {
-        const count = await createItemFromExport(
-          tx,
-          exportFile.items[i],
-          parentId,
-          currentUser.id,
-          startOrder + i
-        );
-        insertedCount += count;
-      }
-    });
+    await prisma.$transaction(
+      async (tx) => {
+        for (let i = 0; i < exportFile.items.length; i++) {
+          const count = await createItemFromExport(
+            tx,
+            exportFile.items[i],
+            parentId,
+            currentUser.id,
+            startOrder + i
+          );
+          insertedCount += count;
+        }
+      },
+      { timeout: 60000 }
+    );
 
     revalidatePath('/', 'layout');
 

--- a/features/item/actions/import-item.ts
+++ b/features/item/actions/import-item.ts
@@ -77,7 +77,7 @@ async function createItemFromExport(
   }
 
   // 子アイテムを再帰的に作成（FOLDER型の場合のみ）
-  if (itemData.children && itemData.children.length > 0) {
+  if (itemData.children && itemData.children.length > 0 && itemData.type === 'FOLDER') {
     for (let i = 0; i < itemData.children.length; i++) {
       const childCount = await createItemFromExport(
         tx,

--- a/features/item/actions/import-item.ts
+++ b/features/item/actions/import-item.ts
@@ -28,7 +28,10 @@ async function createItemFromExport(
       icon: itemData.icon,
       parentId,
       order: baseOrder,
-      meta: itemData.meta === null ? Prisma.JsonNull : (itemData.meta as Prisma.InputJsonValue),
+      meta:
+        itemData.meta === null
+          ? Prisma.JsonNull
+          : (itemData.meta as Prisma.InputJsonValue),
       createdById,
     },
   });
@@ -59,7 +62,11 @@ async function createItemFromExport(
   }
 
   // レコードを作成（TABLE型の場合のみ）
-  if (itemData.records && itemData.records.length > 0 && itemData.type === 'TABLE') {
+  if (
+    itemData.records &&
+    itemData.records.length > 0 &&
+    itemData.type === 'TABLE'
+  ) {
     await tx.record.createMany({
       data: itemData.records.map((r) => ({
         tableId: item.id,
@@ -189,7 +196,8 @@ export async function importItemAction(
         updatedCount: 0,
         skippedCount: 0,
         totalCount: 0,
-        message: 'インポートファイルの形式が不正です。エクスポートしたファイルを使用してください。',
+        message:
+          'インポートファイルの形式が不正です。エクスポートしたファイルを使用してください。',
       };
     }
 

--- a/features/item/actions/import-item.ts
+++ b/features/item/actions/import-item.ts
@@ -1,0 +1,265 @@
+'use server';
+
+import { revalidatePath } from 'next/cache';
+import { prisma } from '@/lib/prisma';
+import { requireAuth } from '@/lib/auth';
+import { canManageStructure } from '@/lib/permissions';
+import { Prisma } from '@prisma/client';
+import type { ImportResult } from '@/features/table/types/import';
+import type { ItemExportData, ItemExportFile } from '@/features/item/types';
+
+/**
+ * エクスポートデータからアイテムを再帰的に作成する
+ */
+async function createItemFromExport(
+  tx: Prisma.TransactionClient,
+  itemData: ItemExportData,
+  parentId: string | null,
+  createdById: string,
+  baseOrder: number
+): Promise<number> {
+  let createdCount = 0;
+
+  // アイテムを作成
+  const item = await tx.item.create({
+    data: {
+      type: itemData.type,
+      name: itemData.name,
+      icon: itemData.icon,
+      parentId,
+      order: baseOrder,
+      meta: itemData.meta === null ? Prisma.JsonNull : (itemData.meta as Prisma.InputJsonValue),
+      createdById,
+    },
+  });
+  createdCount++;
+
+  // スタイルを作成
+  if (itemData.styles.length > 0) {
+    await tx.style.createMany({
+      data: itemData.styles.map((s) => ({
+        itemId: item.id,
+        name: s.name,
+        content: s.content,
+        order: s.order,
+      })),
+    });
+  }
+
+  // スクリプトを作成
+  if (itemData.scripts.length > 0) {
+    await tx.script.createMany({
+      data: itemData.scripts.map((s) => ({
+        itemId: item.id,
+        name: s.name,
+        content: s.content,
+        order: s.order,
+      })),
+    });
+  }
+
+  // レコードを作成（TABLE型の場合のみ）
+  if (itemData.records && itemData.records.length > 0 && itemData.type === 'TABLE') {
+    await tx.record.createMany({
+      data: itemData.records.map((r) => ({
+        tableId: item.id,
+        data: r.data as Prisma.InputJsonValue,
+        createdById,
+      })),
+    });
+  }
+
+  // 子アイテムを再帰的に作成（FOLDER型の場合のみ）
+  if (itemData.children && itemData.children.length > 0) {
+    for (let i = 0; i < itemData.children.length; i++) {
+      const childCount = await createItemFromExport(
+        tx,
+        itemData.children[i],
+        item.id,
+        createdById,
+        i
+      );
+      createdCount += childCount;
+    }
+  }
+
+  return createdCount;
+}
+
+/**
+ * JSONバリデーション
+ */
+function validateExportFile(data: unknown): data is ItemExportFile {
+  if (!data || typeof data !== 'object') return false;
+
+  const file = data as Record<string, unknown>;
+  if (typeof file.version !== 'number') return false;
+  if (!Array.isArray(file.items)) return false;
+  if (file.items.length === 0) return false;
+
+  // 各アイテムの基本構造チェック
+  for (const item of file.items) {
+    if (!validateExportItem(item)) return false;
+  }
+
+  return true;
+}
+
+/**
+ * アイテムデータのバリデーション（再帰）
+ */
+function validateExportItem(data: unknown): data is ItemExportData {
+  if (!data || typeof data !== 'object') return false;
+
+  const item = data as Record<string, unknown>;
+  if (typeof item.name !== 'string' || item.name.trim() === '') return false;
+  if (item.type !== 'TABLE' && item.type !== 'FOLDER') return false;
+  if (!Array.isArray(item.styles)) return false;
+  if (!Array.isArray(item.scripts)) return false;
+
+  // 子アイテムのバリデーション（再帰）
+  if (item.children) {
+    if (!Array.isArray(item.children)) return false;
+    for (const child of item.children) {
+      if (!validateExportItem(child)) return false;
+    }
+  }
+
+  return true;
+}
+
+/**
+ * アイテム数を再帰的にカウント
+ */
+function countItems(items: ItemExportData[]): number {
+  let count = items.length;
+  for (const item of items) {
+    if (item.children) {
+      count += countItems(item.children);
+    }
+  }
+  return count;
+}
+
+/**
+ * アイテムをJSON形式でインポートするServer Action
+ * @param jsonContent - JSON形式の文字列
+ * @param parentId - インポート先の親アイテムID（null の場合はルート）
+ */
+export async function importItemAction(
+  jsonContent: string,
+  parentId: string | null
+): Promise<ImportResult> {
+  try {
+    // 認証チェック
+    const currentUser = await requireAuth();
+
+    // 権限チェック（ADMIN/DEVELOPERのみ）
+    if (!canManageStructure(currentUser.role)) {
+      return {
+        success: false,
+        insertedCount: 0,
+        updatedCount: 0,
+        skippedCount: 0,
+        totalCount: 0,
+        message: 'この操作を行う権限がありません',
+      };
+    }
+
+    // JSONパース
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(jsonContent);
+    } catch {
+      return {
+        success: false,
+        insertedCount: 0,
+        updatedCount: 0,
+        skippedCount: 0,
+        totalCount: 0,
+        message: 'JSONの形式が不正です',
+      };
+    }
+
+    // バリデーション
+    if (!validateExportFile(parsed)) {
+      return {
+        success: false,
+        insertedCount: 0,
+        updatedCount: 0,
+        skippedCount: 0,
+        totalCount: 0,
+        message: 'インポートファイルの形式が不正です。エクスポートしたファイルを使用してください。',
+      };
+    }
+
+    const exportFile = parsed;
+    const totalItemCount = countItems(exportFile.items);
+
+    // 親アイテムの存在チェック（parentId が指定されている場合）
+    if (parentId) {
+      const parentItem = await prisma.item.findUnique({
+        where: { id: parentId },
+        select: { id: true, type: true },
+      });
+      if (!parentItem) {
+        return {
+          success: false,
+          insertedCount: 0,
+          updatedCount: 0,
+          skippedCount: 0,
+          totalCount: totalItemCount,
+          message: 'インポート先のフォルダが見つかりません',
+        };
+      }
+    }
+
+    // 同じ親の最大order値を取得
+    const maxOrderItem = await prisma.item.findFirst({
+      where: { parentId: parentId || null },
+      orderBy: { order: 'desc' },
+      select: { order: true },
+    });
+    const startOrder = maxOrderItem ? maxOrderItem.order + 1 : 0;
+
+    // トランザクションでアイテムを一括作成
+    let insertedCount = 0;
+
+    await prisma.$transaction(async (tx) => {
+      for (let i = 0; i < exportFile.items.length; i++) {
+        const count = await createItemFromExport(
+          tx,
+          exportFile.items[i],
+          parentId,
+          currentUser.id,
+          startOrder + i
+        );
+        insertedCount += count;
+      }
+    });
+
+    revalidatePath('/', 'layout');
+
+    return {
+      success: true,
+      insertedCount,
+      updatedCount: 0,
+      skippedCount: 0,
+      totalCount: totalItemCount,
+      message: `${insertedCount}件のアイテムをインポートしました`,
+    };
+  } catch (error) {
+    console.error('アイテムインポートエラー:', error);
+    return {
+      success: false,
+      insertedCount: 0,
+      updatedCount: 0,
+      skippedCount: 0,
+      totalCount: 0,
+      message:
+        error instanceof Error
+          ? error.message
+          : 'インポート中にエラーが発生しました',
+    };
+  }
+}

--- a/features/item/actions/import-item.ts
+++ b/features/item/actions/import-item.ts
@@ -226,37 +226,30 @@ export async function importItemAction(
     const exportFile = parsed;
     const totalItemCount = countItems(exportFile.items);
 
-    // 親アイテムの存在チェック（parentId が指定されている場合）
-    if (parentId) {
-      const parentItem = await prisma.item.findUnique({
-        where: { id: parentId },
-        select: { id: true, type: true },
-      });
-      if (!parentItem) {
-        return {
-          success: false,
-          insertedCount: 0,
-          updatedCount: 0,
-          skippedCount: 0,
-          totalCount: totalItemCount,
-          message: 'インポート先のフォルダが見つかりません',
-        };
-      }
-    }
-
-    // 同じ親の最大order値を取得
-    const maxOrderItem = await prisma.item.findFirst({
-      where: { parentId: parentId || null },
-      orderBy: { order: 'desc' },
-      select: { order: true },
-    });
-    const startOrder = maxOrderItem ? maxOrderItem.order + 1 : 0;
-
     // トランザクションでアイテムを一括作成
     let insertedCount = 0;
 
     await prisma.$transaction(
       async (tx) => {
+        // 親アイテムの存在チェック（parentId が指定されている場合）
+        if (parentId) {
+          const parentItem = await tx.item.findUnique({
+            where: { id: parentId },
+            select: { id: true, type: true },
+          });
+          if (!parentItem) {
+            throw new Error('インポート先のフォルダが見つかりません');
+          }
+        }
+
+        // 同じ親の最大order値を取得
+        const maxOrderItem = await tx.item.findFirst({
+          where: { parentId: parentId || null },
+          orderBy: { order: 'desc' },
+          select: { order: true },
+        });
+        const startOrder = maxOrderItem ? maxOrderItem.order + 1 : 0;
+
         for (let i = 0; i < exportFile.items.length; i++) {
           const count = await createItemFromExport(
             tx,

--- a/features/item/actions/import-item.ts
+++ b/features/item/actions/import-item.ts
@@ -77,7 +77,11 @@ async function createItemFromExport(
   }
 
   // 子アイテムを再帰的に作成（FOLDER型の場合のみ）
-  if (itemData.children && itemData.children.length > 0 && itemData.type === 'FOLDER') {
+  if (
+    itemData.children &&
+    itemData.children.length > 0 &&
+    itemData.type === 'FOLDER'
+  ) {
     for (let i = 0; i < itemData.children.length; i++) {
       const childCount = await createItemFromExport(
         tx,
@@ -128,14 +132,24 @@ function validateExportItem(data: unknown): data is ItemExportData {
   for (const s of item.styles) {
     if (!s || typeof s !== 'object') return false;
     const style = s as Record<string, unknown>;
-    if (typeof style.name !== 'string' || typeof style.content !== 'string' || typeof style.order !== 'number') return false;
+    if (
+      typeof style.name !== 'string' ||
+      typeof style.content !== 'string' ||
+      typeof style.order !== 'number'
+    )
+      return false;
   }
 
   // scripts の各要素を検証
   for (const s of item.scripts) {
     if (!s || typeof s !== 'object') return false;
     const script = s as Record<string, unknown>;
-    if (typeof script.name !== 'string' || typeof script.content !== 'string' || typeof script.order !== 'number') return false;
+    if (
+      typeof script.name !== 'string' ||
+      typeof script.content !== 'string' ||
+      typeof script.order !== 'number'
+    )
+      return false;
   }
 
   // records の各要素を検証（存在する場合）
@@ -239,6 +253,9 @@ export async function importItemAction(
           });
           if (!parentItem) {
             throw new Error('インポート先のフォルダが見つかりません');
+          }
+          if (parentItem.type !== 'FOLDER') {
+            throw new Error('インポート先はフォルダである必要があります');
           }
         }
 

--- a/features/item/actions/import-item.ts
+++ b/features/item/actions/import-item.ts
@@ -124,6 +124,28 @@ function validateExportItem(data: unknown): data is ItemExportData {
   if (!Array.isArray(item.styles)) return false;
   if (!Array.isArray(item.scripts)) return false;
 
+  // styles の各要素を検証
+  for (const s of item.styles) {
+    if (!s || typeof s !== 'object') return false;
+    const style = s as Record<string, unknown>;
+    if (typeof style.name !== 'string' || typeof style.content !== 'string' || typeof style.order !== 'number') return false;
+  }
+
+  // scripts の各要素を検証
+  for (const s of item.scripts) {
+    if (!s || typeof s !== 'object') return false;
+    const script = s as Record<string, unknown>;
+    if (typeof script.name !== 'string' || typeof script.content !== 'string' || typeof script.order !== 'number') return false;
+  }
+
+  // records の各要素を検証（存在する場合）
+  if (item.records) {
+    if (!Array.isArray(item.records)) return false;
+    for (const r of item.records) {
+      if (!r || typeof r !== 'object' || !('data' in r)) return false;
+    }
+  }
+
   // 子アイテムのバリデーション（再帰）
   if (item.children) {
     if (!Array.isArray(item.children)) return false;

--- a/features/item/components/import-item-dialog.tsx
+++ b/features/item/components/import-item-dialog.tsx
@@ -194,7 +194,7 @@ export function ImportItemDialog({
     onDrop,
     onDropRejected,
     accept: { 'application/json': ['.json'] },
-    maxSize: 50 * 1024 * 1024, // 50MB制限
+    maxSize: 10 * 1024 * 1024, // 10MB制限
     multiple: false,
   });
 
@@ -279,7 +279,7 @@ export function ImportItemDialog({
                     </span>
                   </p>
                   <p className="text-xs text-muted-foreground">
-                    JSON形式のファイル（最大50MB）
+                    JSON形式のファイル（最大10MB）
                   </p>
                 </div>
               </div>

--- a/features/item/components/import-item-dialog.tsx
+++ b/features/item/components/import-item-dialog.tsx
@@ -234,12 +234,15 @@ export function ImportItemDialog({
   // ダイアログを閉じる際のリセット
   const handleOpenChange = useCallback(
     (newOpen: boolean) => {
+      if (!newOpen && state.type === 'importing') {
+        return;
+      }
       onOpenChange(newOpen);
       if (!newOpen) {
         setState({ type: 'idle' });
       }
     },
-    [onOpenChange]
+    [onOpenChange, state.type]
   );
 
   return (

--- a/features/item/components/import-item-dialog.tsx
+++ b/features/item/components/import-item-dialog.tsx
@@ -31,7 +31,12 @@ type ImportItemDialogProps = {
  */
 type ImportState =
   | { type: 'idle' }
-  | { type: 'preview'; fileName: string; jsonContent: string; summary: ImportSummary }
+  | {
+      type: 'preview';
+      fileName: string;
+      jsonContent: string;
+      summary: ImportSummary;
+    }
   | { type: 'importing' }
   | { type: 'success'; result: ImportResult }
   | { type: 'error'; message: string };
@@ -87,7 +92,9 @@ function buildSummary(items: ItemExportData[]): ImportSummary {
 /**
  * JSONバリデーション（クライアント側の簡易チェック）
  */
-function parseAndValidate(jsonContent: string): { exportFile: ItemExportFile } | { error: string } {
+function parseAndValidate(
+  jsonContent: string
+): { exportFile: ItemExportFile } | { error: string } {
   let parsed: unknown;
   try {
     parsed = JSON.parse(jsonContent);
@@ -296,23 +303,31 @@ export function ImportItemDialog({
                 </div>
                 <div className="grid grid-cols-2 gap-1 text-sm text-muted-foreground">
                   <div>アイテム数:</div>
-                  <div className="font-semibold">{state.summary.itemCount}件</div>
+                  <div className="font-semibold">
+                    {state.summary.itemCount}件
+                  </div>
                   {state.summary.folderCount > 0 && (
                     <>
                       <div>フォルダ:</div>
-                      <div className="font-semibold">{state.summary.folderCount}件</div>
+                      <div className="font-semibold">
+                        {state.summary.folderCount}件
+                      </div>
                     </>
                   )}
                   {state.summary.tableCount > 0 && (
                     <>
                       <div>テーブル:</div>
-                      <div className="font-semibold">{state.summary.tableCount}件</div>
+                      <div className="font-semibold">
+                        {state.summary.tableCount}件
+                      </div>
                     </>
                   )}
                   {state.summary.hasRecords && (
                     <>
                       <div>レコード:</div>
-                      <div className="font-semibold">{state.summary.recordCount}件</div>
+                      <div className="font-semibold">
+                        {state.summary.recordCount}件
+                      </div>
                     </>
                   )}
                 </div>

--- a/features/item/components/import-item-dialog.tsx
+++ b/features/item/components/import-item-dialog.tsx
@@ -1,0 +1,378 @@
+'use client';
+
+import { useState, useCallback, useEffect } from 'react';
+import { useDropzone } from 'react-dropzone';
+import { Upload, FileText, AlertCircle, CheckCircle2 } from 'lucide-react';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import { Progress } from '@/components/ui/progress';
+import { importItemAction } from '@/features/item/actions/import-item';
+import type { ImportResult } from '@/features/table/types/import';
+import type { ItemExportData, ItemExportFile } from '@/features/item/types';
+
+/**
+ * インポートダイアログのProps型
+ */
+type ImportItemDialogProps = {
+  parentId: string | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+};
+
+/**
+ * インポート状態
+ */
+type ImportState =
+  | { type: 'idle' }
+  | { type: 'preview'; fileName: string; jsonContent: string; summary: ImportSummary }
+  | { type: 'importing' }
+  | { type: 'success'; result: ImportResult }
+  | { type: 'error'; message: string };
+
+/**
+ * プレビュー用サマリー
+ */
+type ImportSummary = {
+  itemCount: number;
+  tableCount: number;
+  folderCount: number;
+  hasRecords: boolean;
+  recordCount: number;
+};
+
+/**
+ * エクスポートデータからサマリーを生成する
+ */
+function buildSummary(items: ItemExportData[]): ImportSummary {
+  let itemCount = 0;
+  let tableCount = 0;
+  let folderCount = 0;
+  let recordCount = 0;
+
+  function countRecursive(list: ItemExportData[]) {
+    for (const item of list) {
+      itemCount++;
+      if (item.type === 'TABLE') {
+        tableCount++;
+        if (item.records) {
+          recordCount += item.records.length;
+        }
+      } else {
+        folderCount++;
+      }
+      if (item.children) {
+        countRecursive(item.children);
+      }
+    }
+  }
+
+  countRecursive(items);
+
+  return {
+    itemCount,
+    tableCount,
+    folderCount,
+    hasRecords: recordCount > 0,
+    recordCount,
+  };
+}
+
+/**
+ * JSONバリデーション（クライアント側の簡易チェック）
+ */
+function parseAndValidate(jsonContent: string): { exportFile: ItemExportFile } | { error: string } {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(jsonContent);
+  } catch {
+    return { error: 'JSONの形式が不正です' };
+  }
+
+  if (!parsed || typeof parsed !== 'object') {
+    return { error: 'JSONの形式が不正です' };
+  }
+
+  const file = parsed as Record<string, unknown>;
+  if (typeof file.version !== 'number') {
+    return { error: 'バージョン情報がありません' };
+  }
+  if (!Array.isArray(file.items) || file.items.length === 0) {
+    return { error: 'インポートするアイテムがありません' };
+  }
+
+  return { exportFile: parsed as ItemExportFile };
+}
+
+/**
+ * アイテムインポートダイアログ
+ */
+export function ImportItemDialog({
+  parentId,
+  open,
+  onOpenChange,
+}: ImportItemDialogProps) {
+  const [state, setState] = useState<ImportState>({ type: 'idle' });
+  const [progress, setProgress] = useState(0);
+
+  // インポート中のプログレスバーアニメーション
+  useEffect(() => {
+    if (state.type !== 'importing') {
+      return;
+    }
+
+    const timer0 = setTimeout(() => setProgress(0), 0);
+    const timer1 = setTimeout(() => setProgress(10), 100);
+    const timer2 = setTimeout(() => setProgress(30), 400);
+    const timer3 = setTimeout(() => setProgress(50), 700);
+    const timer4 = setTimeout(() => setProgress(70), 1100);
+    const timer5 = setTimeout(() => setProgress(90), 1600);
+
+    return () => {
+      clearTimeout(timer0);
+      clearTimeout(timer1);
+      clearTimeout(timer2);
+      clearTimeout(timer3);
+      clearTimeout(timer4);
+      clearTimeout(timer5);
+    };
+  }, [state.type]);
+
+  // ファイルドロップハンドラー
+  const onDrop = useCallback(async (acceptedFiles: File[]) => {
+    const file = acceptedFiles[0];
+    if (!file) return;
+
+    try {
+      const text = await file.text();
+      const result = parseAndValidate(text);
+
+      if ('error' in result) {
+        setState({ type: 'error', message: result.error });
+        return;
+      }
+
+      const summary = buildSummary(result.exportFile.items);
+
+      setState({
+        type: 'preview',
+        fileName: file.name,
+        jsonContent: text,
+        summary,
+      });
+    } catch {
+      setState({
+        type: 'error',
+        message: 'ファイルの読み込みに失敗しました',
+      });
+    }
+  }, []);
+
+  // ファイル拒否ハンドラー
+  const onDropRejected = useCallback(() => {
+    setState({
+      type: 'error',
+      message: 'JSONファイルを選択してください',
+    });
+  }, []);
+
+  // react-dropzone設定
+  const { getRootProps, getInputProps, isDragActive } = useDropzone({
+    onDrop,
+    onDropRejected,
+    accept: { 'application/json': ['.json'] },
+    maxSize: 50 * 1024 * 1024, // 50MB制限
+    multiple: false,
+  });
+
+  // インポート実行ハンドラー
+  const handleImport = useCallback(async () => {
+    if (state.type !== 'preview') return;
+
+    setState({ type: 'importing' });
+
+    try {
+      const result = await importItemAction(state.jsonContent, parentId);
+
+      if (result.success) {
+        setState({ type: 'success', result });
+        setTimeout(() => {
+          onOpenChange(false);
+          setState({ type: 'idle' });
+          window.location.reload();
+        }, 3000);
+      } else {
+        setState({
+          type: 'error',
+          message: result.message,
+        });
+      }
+    } catch (error) {
+      setState({
+        type: 'error',
+        message:
+          error instanceof Error
+            ? error.message
+            : 'インポート中にエラーが発生しました',
+      });
+    }
+  }, [state, parentId, onOpenChange]);
+
+  // ダイアログを閉じる際のリセット
+  const handleOpenChange = useCallback(
+    (newOpen: boolean) => {
+      onOpenChange(newOpen);
+      if (!newOpen) {
+        setState({ type: 'idle' });
+      }
+    },
+    [onOpenChange]
+  );
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent className="max-w-2xl">
+        <DialogHeader>
+          <DialogTitle>アイテムのインポート</DialogTitle>
+          <DialogDescription>
+            エクスポートしたJSONファイルからアイテムをインポートします
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          {/* ファイル選択 */}
+          {(state.type === 'idle' || state.type === 'error') && (
+            <div className="space-y-4">
+              <div
+                {...getRootProps()}
+                className={`flex flex-col items-center justify-center w-full h-32 border-2 border-dashed rounded-lg cursor-pointer transition-colors ${
+                  isDragActive
+                    ? 'bg-primary/10 border-primary'
+                    : 'hover:bg-muted/50'
+                }`}
+              >
+                <input {...getInputProps()} />
+                <div className="flex flex-col items-center justify-center pt-5 pb-6">
+                  {isDragActive ? (
+                    <Upload className="w-8 h-8 mb-2 text-primary animate-bounce" />
+                  ) : (
+                    <FileText className="w-8 h-8 mb-2 text-muted-foreground" />
+                  )}
+                  <p className="mb-2 text-sm text-muted-foreground">
+                    <span className="font-semibold">
+                      {isDragActive
+                        ? 'ここにドロップ'
+                        : 'クリックまたはドラッグ&ドロップ'}
+                    </span>
+                  </p>
+                  <p className="text-xs text-muted-foreground">
+                    JSON形式のファイル（最大50MB）
+                  </p>
+                </div>
+              </div>
+
+              {state.type === 'error' && (
+                <Alert variant="destructive">
+                  <AlertCircle className="h-4 w-4" />
+                  <AlertDescription>{state.message}</AlertDescription>
+                </Alert>
+              )}
+            </div>
+          )}
+
+          {/* プレビュー */}
+          {state.type === 'preview' && (
+            <div className="space-y-4">
+              <div className="bg-muted p-4 rounded-lg space-y-2">
+                <div className="flex items-center gap-2">
+                  <FileText className="h-4 w-4" />
+                  <span className="font-semibold">{state.fileName}</span>
+                </div>
+                <div className="grid grid-cols-2 gap-1 text-sm text-muted-foreground">
+                  <div>アイテム数:</div>
+                  <div className="font-semibold">{state.summary.itemCount}件</div>
+                  {state.summary.folderCount > 0 && (
+                    <>
+                      <div>フォルダ:</div>
+                      <div className="font-semibold">{state.summary.folderCount}件</div>
+                    </>
+                  )}
+                  {state.summary.tableCount > 0 && (
+                    <>
+                      <div>テーブル:</div>
+                      <div className="font-semibold">{state.summary.tableCount}件</div>
+                    </>
+                  )}
+                  {state.summary.hasRecords && (
+                    <>
+                      <div>レコード:</div>
+                      <div className="font-semibold">{state.summary.recordCount}件</div>
+                    </>
+                  )}
+                </div>
+              </div>
+
+              <Alert>
+                <AlertCircle className="h-4 w-4" />
+                <AlertDescription>
+                  すべてのアイテムは新規作成されます。既存のアイテムとは別に追加されます。
+                </AlertDescription>
+              </Alert>
+
+              <div className="flex gap-2 justify-end">
+                <Button
+                  variant="outline"
+                  onClick={() => setState({ type: 'idle' })}
+                >
+                  キャンセル
+                </Button>
+                <Button onClick={handleImport}>インポート実行</Button>
+              </div>
+            </div>
+          )}
+
+          {/* インポート中 */}
+          {state.type === 'importing' && (
+            <div className="flex flex-col items-center justify-center py-8 space-y-4">
+              <div className="w-full max-w-md space-y-2">
+                <p className="text-sm text-center text-muted-foreground">
+                  インポート中です...
+                </p>
+                <Progress value={progress} className="w-full" />
+              </div>
+            </div>
+          )}
+
+          {/* 成功 */}
+          {state.type === 'success' && (
+            <div className="space-y-4">
+              <Alert>
+                <CheckCircle2 />
+                <AlertDescription>{state.result.message}</AlertDescription>
+              </Alert>
+
+              <div className="bg-muted p-4 rounded-lg space-y-2">
+                <div className="grid grid-cols-2 gap-2 text-sm">
+                  <div>作成されたアイテム:</div>
+                  <div className="font-semibold">
+                    {state.result.insertedCount}件
+                  </div>
+                </div>
+              </div>
+
+              <p className="text-xs text-center text-muted-foreground">
+                このダイアログは自動的に閉じます
+              </p>
+            </div>
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/features/layout/components/item-options-button/index.tsx
+++ b/features/layout/components/item-options-button/index.tsx
@@ -46,6 +46,7 @@ import { getItemById } from '@/features/item/api';
 import { downloadCSV } from '@/lib/download';
 import { ImportDialog } from '@/components/shared/import-dialog';
 import { ExportItemDialog } from '@/features/item/components/export-item-dialog';
+import { ImportItemDialog } from '@/features/item/components/import-item-dialog';
 
 /**
  * アイテムオプションボタンのProps型
@@ -68,6 +69,7 @@ export function ItemOptionsButton({
   const [dropdownOpen, setDropdownOpen] = useState(false);
   const [importDialogOpen, setImportDialogOpen] = useState(false);
   const [exportItemDialogOpen, setExportItemDialogOpen] = useState(false);
+  const [importItemDialogOpen, setImportItemDialogOpen] = useState(false);
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
   const [itemName, setItemName] = useState<string>('');
@@ -240,15 +242,26 @@ export function ItemOptionsButton({
             </>
           )}
           {(pageType === 'TABLE' || pageType === 'FOLDER') && itemId && (
-            <DropdownMenuItem
-              onSelect={(e) => {
-                e.preventDefault();
-                setExportItemDialogOpen(true);
-              }}
-            >
-              <Package />
-              アイテムのエクスポート
-            </DropdownMenuItem>
+            <>
+              <DropdownMenuItem
+                onSelect={(e) => {
+                  e.preventDefault();
+                  setExportItemDialogOpen(true);
+                }}
+              >
+                <Package />
+                アイテムのエクスポート
+              </DropdownMenuItem>
+              <DropdownMenuItem
+                onSelect={(e) => {
+                  e.preventDefault();
+                  setImportItemDialogOpen(true);
+                }}
+              >
+                <Package />
+                アイテムのインポート
+              </DropdownMenuItem>
+            </>
           )}
           {exportableTypes.includes(pageType) && (
             <>
@@ -310,6 +323,15 @@ export function ItemOptionsButton({
           itemType={pageType}
           open={exportItemDialogOpen}
           onOpenChange={setExportItemDialogOpen}
+        />
+      )}
+
+      {/* アイテムインポートダイアログ */}
+      {(pageType === 'TABLE' || pageType === 'FOLDER') && itemId && (
+        <ImportItemDialog
+          parentId={pageType === 'FOLDER' ? itemId : null}
+          open={importItemDialogOpen}
+          onOpenChange={setImportItemDialogOpen}
         />
       )}
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -3,6 +3,11 @@ import type { NextConfig } from 'next';
 const nextConfig: NextConfig = {
   output: 'standalone',
   serverExternalPackages: ['@prisma/client'],
+  experimental: {
+    serverActions: {
+      bodySizeLimit: '10mb',
+    },
+  },
   outputFileTracingIncludes: {
     '/**': ['node_modules/.prisma/client/**', 'node_modules/@prisma/client/**'],
   },


### PR DESCRIPTION
## 概要

#130 のエクスポート機能で出力したJSONファイルを読み込み、テーブル/フォルダをインポートできる機能を実装しました。
子アイテム・スタイル・スクリプト・レコードを含む再帰的なインポートに対応しています。

## 変更内容

### アイテムインポート Server Action
- `features/item/actions/import-item.ts`: JSONパース・バリデーション・再帰的アイテム作成
  - `requireAuth()` + `canManageStructure()` による認証・権限チェック（ADMIN/DEVELOPERのみ）
  - `prisma.$transaction()` によるアトミックな一括作成
  - スタイル・スクリプト・レコードの一括作成（`createMany`）
  - 子アイテムの再帰的な作成

### インポートダイアログUI
- `features/item/components/import-item-dialog.tsx`: JSONファイルのインポートダイアログ
  - ドラッグ&ドロップによるファイル選択（react-dropzone）
  - クライアント側のJSONバリデーション
  - プレビュー表示（アイテム数・テーブル数・フォルダ数・レコード数）
  - プログレスバー付きインポート処理

### メニュー統合
- `features/layout/components/item-options-button/index.tsx`: 「アイテムのインポート」メニュー項目を追加
  - FOLDERページ: フォルダ内にインポート
  - TABLEページ: ルートにインポート

## 関連Issue

Closes #131

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * JSON形式のアイテム一括インポートを追加しました
  * ドラッグ＆ドロップでJSONファイルを読み込み、内容のプレビュー（アイテム数・テーブル／フォルダ数・レコード数）を確認してから実行できます
  * インポート中の進捗表示、成功／失敗の通知、エラーメッセージを表示します
  * アイテムのオプションメニューから直接インポート可能です

* **Chores**
  * サーバー受信サイズ上限を引き上げ、約10MBまでのファイルをサポートしました
<!-- end of auto-generated comment: release notes by coderabbit.ai -->