### PR TITLE
REST API: ユーザー管理エンドポイントの実装

### DIFF
--- a/app/api/v1/__tests__/users-api.test.ts
+++ b/app/api/v1/__tests__/users-api.test.ts
@@ -1,0 +1,497 @@
+import { NextRequest } from 'next/server';
+import { GET as getUsers, POST as createUser } from '../users/route';
+import {
+  GET as getUserById,
+  PATCH as updateUser,
+  DELETE as deleteUser,
+} from '../users/[userId]/route';
+import { prisma } from '@/lib/prisma';
+import { authenticateApiKey } from '@/lib/api-auth';
+import bcrypt from 'bcryptjs';
+
+// API認証をモック化
+jest.mock('@/lib/api-auth', () => ({
+  authenticateApiKey: jest.fn(),
+}));
+
+// Prismaクライアントをモック化
+jest.mock('@/lib/prisma', () => ({
+  prisma: {
+    user: {
+      findMany: jest.fn(),
+      findUnique: jest.fn(),
+      findFirst: jest.fn(),
+      create: jest.fn(),
+      update: jest.fn(),
+      delete: jest.fn(),
+    },
+  },
+}));
+
+// bcryptをモック化
+jest.mock('bcryptjs', () => ({
+  hash: jest.fn().mockResolvedValue('hashed_password'),
+}));
+
+const mockAdminUser = {
+  id: 'admin-1',
+  email: 'admin@example.com',
+  name: 'Admin User',
+  role: 'ADMIN' as const,
+};
+
+const mockMemberUser = {
+  id: 'member-1',
+  email: 'member@example.com',
+  name: 'Member User',
+  role: 'MEMBER' as const,
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  (authenticateApiKey as jest.Mock).mockResolvedValue(mockAdminUser);
+});
+
+// ========================
+// GET /api/v1/users
+// ========================
+describe('GET /api/v1/users', () => {
+  function createRequest(): NextRequest {
+    return new NextRequest('http://localhost:3000/api/v1/users', {
+      headers: { Authorization: 'Bearer mk_test' },
+    });
+  }
+
+  it('ユーザー一覧を { data: [...] } 形式で返す', async () => {
+    const users = [
+      {
+        id: 'user-1',
+        email: 'user1@example.com',
+        name: 'User 1',
+        role: 'MEMBER',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+    ];
+    (prisma.user.findMany as jest.Mock).mockResolvedValue(users);
+
+    const response = await getUsers(createRequest());
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.data).toHaveLength(1);
+    expect(body.data[0].id).toBe('user-1');
+  });
+
+  it('パスワードフィールドはレスポンスに含まれない', async () => {
+    const users = [
+      {
+        id: 'user-1',
+        email: 'user1@example.com',
+        name: 'User 1',
+        role: 'MEMBER',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+    ];
+    (prisma.user.findMany as jest.Mock).mockResolvedValue(users);
+
+    const response = await getUsers(createRequest());
+    const body = await response.json();
+
+    expect(body.data[0].password).toBeUndefined();
+  });
+
+  it('Admin以外は403を返す', async () => {
+    (authenticateApiKey as jest.Mock).mockResolvedValue(mockMemberUser);
+
+    const response = await getUsers(createRequest());
+    const body = await response.json();
+
+    expect(response.status).toBe(403);
+    expect(body.error.code).toBe('FORBIDDEN');
+  });
+
+  it('未認証の場合は401を返す', async () => {
+    const { NextResponse } = await import('next/server');
+    (authenticateApiKey as jest.Mock).mockResolvedValue(
+      NextResponse.json(
+        { error: { message: 'APIキーが必要です', code: 'UNAUTHORIZED' } },
+        { status: 401 }
+      )
+    );
+
+    const response = await getUsers(createRequest());
+
+    expect(response.status).toBe(401);
+  });
+});
+
+// ========================
+// POST /api/v1/users
+// ========================
+describe('POST /api/v1/users', () => {
+  function createRequest(body: Record<string, unknown>): NextRequest {
+    return new NextRequest('http://localhost:3000/api/v1/users', {
+      method: 'POST',
+      headers: {
+        Authorization: 'Bearer mk_test',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(body),
+    });
+  }
+
+  const validBody = {
+    name: 'New User',
+    email: 'new@example.com',
+    password: 'password123',
+    role: 'MEMBER',
+  };
+
+  it('ユーザーを作成して201を返す', async () => {
+    (prisma.user.findUnique as jest.Mock).mockResolvedValue(null);
+    const createdUser = {
+      id: 'new-user-1',
+      email: validBody.email,
+      name: validBody.name,
+      role: 'MEMBER',
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+    (prisma.user.create as jest.Mock).mockResolvedValue(createdUser);
+
+    const response = await createUser(createRequest(validBody));
+    const body = await response.json();
+
+    expect(response.status).toBe(201);
+    expect(body.data.email).toBe(validBody.email);
+    expect(body.data.password).toBeUndefined();
+  });
+
+  it('パスワードがハッシュ化される', async () => {
+    (prisma.user.findUnique as jest.Mock).mockResolvedValue(null);
+    (prisma.user.create as jest.Mock).mockResolvedValue({
+      id: 'new-user-1',
+      email: validBody.email,
+      name: validBody.name,
+      role: 'MEMBER',
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+
+    await createUser(createRequest(validBody));
+
+    expect(bcrypt.hash).toHaveBeenCalledWith('password123', 10);
+    expect(prisma.user.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ password: 'hashed_password' }),
+      })
+    );
+  });
+
+  it('メールアドレスが重複している場合は400を返す', async () => {
+    (prisma.user.findUnique as jest.Mock).mockResolvedValue({ id: 'existing' });
+
+    const response = await createUser(createRequest(validBody));
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.error.code).toBe('BAD_REQUEST');
+  });
+
+  it('nameが未入力の場合は422を返す', async () => {
+    const response = await createUser(
+      createRequest({ ...validBody, name: '' })
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(422);
+    expect(body.error.code).toBe('VALIDATION_ERROR');
+  });
+
+  it('emailが不正な場合は422を返す', async () => {
+    const response = await createUser(
+      createRequest({ ...validBody, email: 'invalid-email' })
+    );
+
+    expect(response.status).toBe(422);
+  });
+
+  it('passwordが6文字未満の場合は422を返す', async () => {
+    const response = await createUser(
+      createRequest({ ...validBody, password: 'abc' })
+    );
+
+    expect(response.status).toBe(422);
+  });
+
+  it('無効なroleの場合は422を返す', async () => {
+    const response = await createUser(
+      createRequest({ ...validBody, role: 'SUPERUSER' })
+    );
+
+    expect(response.status).toBe(422);
+  });
+
+  it('Admin以外は403を返す', async () => {
+    (authenticateApiKey as jest.Mock).mockResolvedValue(mockMemberUser);
+
+    const response = await createUser(createRequest(validBody));
+    const body = await response.json();
+
+    expect(response.status).toBe(403);
+    expect(body.error.code).toBe('FORBIDDEN');
+  });
+});
+
+// ========================
+// GET /api/v1/users/[userId]
+// ========================
+describe('GET /api/v1/users/[userId]', () => {
+  const params = Promise.resolve({ userId: 'user-1' });
+
+  function createRequest(
+    overrideHeaders?: Record<string, string>
+  ): NextRequest {
+    return new NextRequest('http://localhost:3000/api/v1/users/user-1', {
+      headers: { Authorization: 'Bearer mk_test', ...overrideHeaders },
+    });
+  }
+
+  it('Adminは任意のユーザー詳細を取得できる', async () => {
+    const targetUser = {
+      id: 'user-1',
+      email: 'user1@example.com',
+      name: 'User 1',
+      role: 'MEMBER',
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+    (prisma.user.findUnique as jest.Mock).mockResolvedValue(targetUser);
+
+    const response = await getUserById(createRequest(), { params });
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.data.id).toBe('user-1');
+  });
+
+  it('自分自身の情報はMemberでも取得できる', async () => {
+    const selfParams = Promise.resolve({ userId: mockMemberUser.id });
+    (authenticateApiKey as jest.Mock).mockResolvedValue(mockMemberUser);
+    const targetUser = {
+      id: mockMemberUser.id,
+      email: mockMemberUser.email,
+      name: mockMemberUser.name,
+      role: mockMemberUser.role,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+    (prisma.user.findUnique as jest.Mock).mockResolvedValue(targetUser);
+
+    const response = await getUserById(createRequest(), { params: selfParams });
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.data.id).toBe(mockMemberUser.id);
+  });
+
+  it('他ユーザーの情報はMemberが取得しようとすると403を返す', async () => {
+    (authenticateApiKey as jest.Mock).mockResolvedValue(mockMemberUser);
+
+    const response = await getUserById(createRequest(), { params });
+    const body = await response.json();
+
+    expect(response.status).toBe(403);
+    expect(body.error.code).toBe('FORBIDDEN');
+  });
+
+  it('存在しないユーザーは404を返す', async () => {
+    (prisma.user.findUnique as jest.Mock).mockResolvedValue(null);
+
+    const response = await getUserById(createRequest(), { params });
+    const body = await response.json();
+
+    expect(response.status).toBe(404);
+    expect(body.error.code).toBe('NOT_FOUND');
+  });
+});
+
+// ========================
+// PATCH /api/v1/users/[userId]
+// ========================
+describe('PATCH /api/v1/users/[userId]', () => {
+  const params = Promise.resolve({ userId: 'user-1' });
+
+  function createRequest(body: Record<string, unknown>): NextRequest {
+    return new NextRequest('http://localhost:3000/api/v1/users/user-1', {
+      method: 'PATCH',
+      headers: {
+        Authorization: 'Bearer mk_test',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(body),
+    });
+  }
+
+  it('Adminはユーザー名を更新できる', async () => {
+    const existingUser = {
+      id: 'user-1',
+      email: 'user1@example.com',
+      name: 'Old Name',
+      role: 'MEMBER',
+    };
+    const updatedUser = {
+      ...existingUser,
+      name: 'New Name',
+      updatedAt: new Date(),
+    };
+    (prisma.user.findUnique as jest.Mock).mockResolvedValue(existingUser);
+    (prisma.user.update as jest.Mock).mockResolvedValue(updatedUser);
+
+    const response = await updateUser(createRequest({ name: 'New Name' }), {
+      params,
+    });
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.data.name).toBe('New Name');
+  });
+
+  it('Adminはroleを変更できる', async () => {
+    const existingUser = {
+      id: 'user-1',
+      email: 'user1@example.com',
+      name: 'User',
+      role: 'MEMBER',
+    };
+    const updatedUser = {
+      ...existingUser,
+      role: 'DEVELOPER',
+      updatedAt: new Date(),
+    };
+    (prisma.user.findUnique as jest.Mock).mockResolvedValue(existingUser);
+    (prisma.user.update as jest.Mock).mockResolvedValue(updatedUser);
+
+    const response = await updateUser(createRequest({ role: 'DEVELOPER' }), {
+      params,
+    });
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.data.role).toBe('DEVELOPER');
+  });
+
+  it('自分自身のrole変更は400を返す', async () => {
+    const selfParams = Promise.resolve({ userId: mockAdminUser.id });
+
+    const response = await updateUser(createRequest({ role: 'MEMBER' }), {
+      params: selfParams,
+    });
+
+    expect(response.status).toBe(400);
+  });
+
+  it('Memberはrole変更できない（403）', async () => {
+    (authenticateApiKey as jest.Mock).mockResolvedValue(mockMemberUser);
+    const selfParams = Promise.resolve({ userId: mockMemberUser.id });
+
+    const response = await updateUser(createRequest({ role: 'ADMIN' }), {
+      params: selfParams,
+    });
+    const body = await response.json();
+
+    expect(response.status).toBe(403);
+    expect(body.error.code).toBe('FORBIDDEN');
+  });
+
+  it('更新フィールドが空の場合は400を返す', async () => {
+    const response = await updateUser(createRequest({}), { params });
+
+    expect(response.status).toBe(400);
+  });
+
+  it('他ユーザーの更新をMemberが試みると403を返す', async () => {
+    (authenticateApiKey as jest.Mock).mockResolvedValue(mockMemberUser);
+
+    const response = await updateUser(createRequest({ name: 'Hack' }), {
+      params,
+    });
+    const body = await response.json();
+
+    expect(response.status).toBe(403);
+    expect(body.error.code).toBe('FORBIDDEN');
+  });
+
+  it('存在しないユーザーは404を返す', async () => {
+    (prisma.user.findUnique as jest.Mock).mockResolvedValue(null);
+
+    const response = await updateUser(createRequest({ name: 'Test' }), {
+      params,
+    });
+    const body = await response.json();
+
+    expect(response.status).toBe(404);
+    expect(body.error.code).toBe('NOT_FOUND');
+  });
+});
+
+// ========================
+// DELETE /api/v1/users/[userId]
+// ========================
+describe('DELETE /api/v1/users/[userId]', () => {
+  const params = Promise.resolve({ userId: 'user-1' });
+
+  function createRequest(): NextRequest {
+    return new NextRequest('http://localhost:3000/api/v1/users/user-1', {
+      method: 'DELETE',
+      headers: { Authorization: 'Bearer mk_test' },
+    });
+  }
+
+  it('Adminはユーザーを削除できる', async () => {
+    const targetUser = {
+      id: 'user-1',
+      email: 'user1@example.com',
+      name: 'User 1',
+      role: 'MEMBER',
+    };
+    (prisma.user.findUnique as jest.Mock).mockResolvedValue(targetUser);
+    (prisma.user.delete as jest.Mock).mockResolvedValue(targetUser);
+
+    const response = await deleteUser(createRequest(), { params });
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.data.message).toBe('ユーザーを削除しました');
+  });
+
+  it('自分自身を削除しようとすると400を返す', async () => {
+    const selfParams = Promise.resolve({ userId: mockAdminUser.id });
+
+    const response = await deleteUser(createRequest(), { params: selfParams });
+
+    expect(response.status).toBe(400);
+  });
+
+  it('Admin以外は403を返す', async () => {
+    (authenticateApiKey as jest.Mock).mockResolvedValue(mockMemberUser);
+
+    const response = await deleteUser(createRequest(), { params });
+    const body = await response.json();
+
+    expect(response.status).toBe(403);
+    expect(body.error.code).toBe('FORBIDDEN');
+  });
+
+  it('存在しないユーザーは404を返す', async () => {
+    (prisma.user.findUnique as jest.Mock).mockResolvedValue(null);
+
+    const response = await deleteUser(createRequest(), { params });
+    const body = await response.json();
+
+    expect(response.status).toBe(404);
+    expect(body.error.code).toBe('NOT_FOUND');
+  });
+});

--- a/app/api/v1/users/[userId]/route.ts
+++ b/app/api/v1/users/[userId]/route.ts
@@ -1,0 +1,202 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma';
+import { authenticateApiKey } from '@/lib/api-auth';
+import { apiSuccess, apiError } from '@/lib/api-response';
+import { canManageUsers } from '@/lib/permissions';
+
+/**
+ * GET /api/v1/users/[userId]
+ * ユーザー詳細を取得する
+ * 権限: 自身またはAdmin
+ */
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ userId: string }> }
+) {
+  const authResult = await authenticateApiKey(request);
+  if (authResult instanceof NextResponse) return authResult;
+  const user = authResult;
+
+  const { userId } = await params;
+
+  // 権限チェック: 自身またはAdmin
+  if (user.id !== userId && !canManageUsers(user.role)) {
+    return apiError('この操作にはAdmin権限が必要です', 'FORBIDDEN', 403);
+  }
+
+  try {
+    const targetUser = await prisma.user.findUnique({
+      where: { id: userId },
+      select: {
+        id: true,
+        email: true,
+        name: true,
+        role: true,
+        createdAt: true,
+        updatedAt: true,
+      },
+    });
+
+    if (!targetUser) {
+      return apiError('ユーザーが見つかりません', 'NOT_FOUND', 404);
+    }
+
+    return apiSuccess(targetUser);
+  } catch {
+    return apiError('ユーザーの取得に失敗しました', 'INTERNAL_ERROR', 500);
+  }
+}
+
+/**
+ * PATCH /api/v1/users/[userId]
+ * ユーザー情報を部分更新する
+ * 権限: 自身またはAdmin
+ * ※ パスワードはこのエンドポイントで変更不可（セキュリティ考慮）
+ * ※ ロール変更はAdminのみ
+ */
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ userId: string }> }
+) {
+  const authResult = await authenticateApiKey(request);
+  if (authResult instanceof NextResponse) return authResult;
+  const user = authResult;
+
+  const { userId } = await params;
+
+  // 権限チェック: 自身またはAdmin
+  if (user.id !== userId && !canManageUsers(user.role)) {
+    return apiError('この操作にはAdmin権限が必要です', 'FORBIDDEN', 403);
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return apiError('リクエストボディが不正です', 'BAD_REQUEST', 400);
+  }
+
+  const { name, email, role } = body as {
+    name?: unknown;
+    email?: unknown;
+    role?: unknown;
+  };
+
+  // バリデーション
+  if (name !== undefined) {
+    if (typeof name !== 'string' || name.trim() === '') {
+      return apiError('nameは空にできません', 'VALIDATION_ERROR', 422);
+    }
+  }
+  if (email !== undefined) {
+    if (typeof email !== 'string' || !email.includes('@')) {
+      return apiError('有効なemailを入力してください', 'VALIDATION_ERROR', 422);
+    }
+  }
+  if (role !== undefined) {
+    if (!['ADMIN', 'DEVELOPER', 'MEMBER'].includes(role as string)) {
+      return apiError(
+        'roleはADMIN、DEVELOPER、MEMBERのいずれかを指定してください',
+        'VALIDATION_ERROR',
+        422
+      );
+    }
+    // ロール変更はAdminのみ
+    if (!canManageUsers(user.role)) {
+      return apiError('ロールの変更にはAdmin権限が必要です', 'FORBIDDEN', 403);
+    }
+    // 自分自身のロールは変更不可
+    if (user.id === userId) {
+      return apiError('自分自身のロールは変更できません', 'BAD_REQUEST', 400);
+    }
+  }
+
+  // 更新フィールドが何もない場合
+  if (name === undefined && email === undefined && role === undefined) {
+    return apiError('更新するフィールドがありません', 'BAD_REQUEST', 400);
+  }
+
+  try {
+    // ユーザーの存在チェック
+    const targetUser = await prisma.user.findUnique({ where: { id: userId } });
+    if (!targetUser) {
+      return apiError('ユーザーが見つかりません', 'NOT_FOUND', 404);
+    }
+
+    // メールアドレスの重複チェック
+    if (email) {
+      const existingUser = await prisma.user.findFirst({
+        where: { email, NOT: { id: userId } },
+      });
+      if (existingUser) {
+        return apiError(
+          'このメールアドレスは既に使用されています',
+          'BAD_REQUEST',
+          400
+        );
+      }
+    }
+
+    const updatedUser = await prisma.user.update({
+      where: { id: userId },
+      data: {
+        ...(name !== undefined && { name: (name as string).trim() }),
+        ...(email !== undefined && { email: email as string }),
+        ...(role !== undefined && {
+          role: role as 'ADMIN' | 'DEVELOPER' | 'MEMBER',
+        }),
+      },
+      select: {
+        id: true,
+        email: true,
+        name: true,
+        role: true,
+        createdAt: true,
+        updatedAt: true,
+      },
+    });
+
+    return apiSuccess(updatedUser);
+  } catch {
+    return apiError('ユーザーの更新に失敗しました', 'INTERNAL_ERROR', 500);
+  }
+}
+
+/**
+ * DELETE /api/v1/users/[userId]
+ * ユーザーを削除する
+ * 権限: Adminのみ
+ */
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: Promise<{ userId: string }> }
+) {
+  const authResult = await authenticateApiKey(request);
+  if (authResult instanceof NextResponse) return authResult;
+  const user = authResult;
+
+  // Admin権限チェック
+  if (!canManageUsers(user.role)) {
+    return apiError('この操作にはAdmin権限が必要です', 'FORBIDDEN', 403);
+  }
+
+  const { userId } = await params;
+
+  // 自分自身は削除不可
+  if (user.id === userId) {
+    return apiError('自分自身を削除することはできません', 'BAD_REQUEST', 400);
+  }
+
+  try {
+    const targetUser = await prisma.user.findUnique({ where: { id: userId } });
+    if (!targetUser) {
+      return apiError('ユーザーが見つかりません', 'NOT_FOUND', 404);
+    }
+
+    await prisma.user.delete({ where: { id: userId } });
+
+    return apiSuccess({ message: 'ユーザーを削除しました' });
+  } catch {
+    return apiError('ユーザーの削除に失敗しました', 'INTERNAL_ERROR', 500);
+  }
+}

--- a/app/api/v1/users/[userId]/route.ts
+++ b/app/api/v1/users/[userId]/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
+import { Prisma } from '@prisma/client';
 import { prisma } from '@/lib/prisma';
 import { authenticateApiKey } from '@/lib/api-auth';
 import { apiSuccess, apiError } from '@/lib/api-response';
@@ -157,7 +158,22 @@ export async function PATCH(
     });
 
     return apiSuccess(updatedUser);
-  } catch {
+  } catch (error) {
+    // TOCTOU競合などによるPrismaエラーを個別ハンドリング
+    if (error instanceof Prisma.PrismaClientKnownRequestError) {
+      // P2002: メールアドレスの一意制約違反（並行リクエストによる競合）
+      if (error.code === 'P2002') {
+        return apiError(
+          'このメールアドレスは既に使用されています',
+          'BAD_REQUEST',
+          400
+        );
+      }
+      // P2025: 存在チェック後に対象ユーザーが削除された場合
+      if (error.code === 'P2025') {
+        return apiError('ユーザーが見つかりません', 'NOT_FOUND', 404);
+      }
+    }
     return apiError('ユーザーの更新に失敗しました', 'INTERNAL_ERROR', 500);
   }
 }
@@ -196,7 +212,14 @@ export async function DELETE(
     await prisma.user.delete({ where: { id: userId } });
 
     return apiSuccess({ message: 'ユーザーを削除しました' });
-  } catch {
+  } catch (error) {
+    // P2025: 存在チェック後に対象ユーザーが削除された場合
+    if (
+      error instanceof Prisma.PrismaClientKnownRequestError &&
+      error.code === 'P2025'
+    ) {
+      return apiError('ユーザーが見つかりません', 'NOT_FOUND', 404);
+    }
     return apiError('ユーザーの削除に失敗しました', 'INTERNAL_ERROR', 500);
   }
 }

--- a/app/api/v1/users/route.ts
+++ b/app/api/v1/users/route.ts
@@ -1,0 +1,131 @@
+import { NextRequest, NextResponse } from 'next/server';
+import bcrypt from 'bcryptjs';
+import { prisma } from '@/lib/prisma';
+import { authenticateApiKey } from '@/lib/api-auth';
+import { apiSuccess, apiError } from '@/lib/api-response';
+import { canManageUsers } from '@/lib/permissions';
+
+/**
+ * GET /api/v1/users
+ * ユーザー一覧を取得する
+ * 権限: Adminのみ
+ */
+export async function GET(request: NextRequest) {
+  const authResult = await authenticateApiKey(request);
+  if (authResult instanceof NextResponse) return authResult;
+  const user = authResult;
+
+  // Admin権限チェック
+  if (!canManageUsers(user.role)) {
+    return apiError('この操作にはAdmin権限が必要です', 'FORBIDDEN', 403);
+  }
+
+  try {
+    const users = await prisma.user.findMany({
+      orderBy: { createdAt: 'desc' },
+      select: {
+        id: true,
+        email: true,
+        name: true,
+        role: true,
+        createdAt: true,
+        updatedAt: true,
+      },
+    });
+
+    return apiSuccess(users);
+  } catch {
+    return apiError('ユーザー一覧の取得に失敗しました', 'INTERNAL_ERROR', 500);
+  }
+}
+
+/**
+ * POST /api/v1/users
+ * ユーザーを作成する
+ * 権限: Adminのみ
+ */
+export async function POST(request: NextRequest) {
+  const authResult = await authenticateApiKey(request);
+  if (authResult instanceof NextResponse) return authResult;
+  const user = authResult;
+
+  // Admin権限チェック
+  if (!canManageUsers(user.role)) {
+    return apiError('この操作にはAdmin権限が必要です', 'FORBIDDEN', 403);
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return apiError('リクエストボディが不正です', 'BAD_REQUEST', 400);
+  }
+
+  const { name, email, password, role } = body as {
+    name?: unknown;
+    email?: unknown;
+    password?: unknown;
+    role?: unknown;
+  };
+
+  // バリデーション
+  if (!name || typeof name !== 'string' || name.trim() === '') {
+    return apiError('nameは必須です', 'VALIDATION_ERROR', 422);
+  }
+  if (!email || typeof email !== 'string' || !email.includes('@')) {
+    return apiError('有効なemailを入力してください', 'VALIDATION_ERROR', 422);
+  }
+  if (!password || typeof password !== 'string' || password.length < 6) {
+    return apiError(
+      'passwordは6文字以上で入力してください',
+      'VALIDATION_ERROR',
+      422
+    );
+  }
+  if (
+    role !== undefined &&
+    !['ADMIN', 'DEVELOPER', 'MEMBER'].includes(role as string)
+  ) {
+    return apiError(
+      'roleはADMIN、DEVELOPER、MEMBERのいずれかを指定してください',
+      'VALIDATION_ERROR',
+      422
+    );
+  }
+
+  try {
+    // メールアドレスの重複チェック
+    const existingUser = await prisma.user.findUnique({ where: { email } });
+    if (existingUser) {
+      return apiError(
+        'このメールアドレスは既に使用されています',
+        'BAD_REQUEST',
+        400
+      );
+    }
+
+    // パスワードをハッシュ化
+    const hashedPassword = await bcrypt.hash(password, 10);
+
+    const newUser = await prisma.user.create({
+      data: {
+        name: name.trim(),
+        email,
+        password: hashedPassword,
+        role: (role as 'ADMIN' | 'DEVELOPER' | 'MEMBER') || 'MEMBER',
+      },
+      select: {
+        id: true,
+        email: true,
+        name: true,
+        role: true,
+        createdAt: true,
+        updatedAt: true,
+      },
+    });
+
+    return apiSuccess(newUser, 201);
+  } catch {
+    return apiError('ユーザーの作成に失敗しました', 'INTERNAL_ERROR', 500);
+  }
+}

--- a/app/api/v1/users/route.ts
+++ b/app/api/v1/users/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import bcrypt from 'bcryptjs';
+import { Prisma } from '@prisma/client';
 import { prisma } from '@/lib/prisma';
 import { authenticateApiKey } from '@/lib/api-auth';
 import { apiSuccess, apiError } from '@/lib/api-response';
@@ -125,7 +126,18 @@ export async function POST(request: NextRequest) {
     });
 
     return apiSuccess(newUser, 201);
-  } catch {
+  } catch (error) {
+    // TOCTOU競合などによるメールアドレスの一意制約違反
+    if (
+      error instanceof Prisma.PrismaClientKnownRequestError &&
+      error.code === 'P2002'
+    ) {
+      return apiError(
+        'このメールアドレスは既に使用されています',
+        'BAD_REQUEST',
+        400
+      );
+    }
     return apiError('ユーザーの作成に失敗しました', 'INTERNAL_ERROR', 500);
   }
 }


### PR DESCRIPTION
## 概要

ユーザー情報の参照・管理を行えるREST APIエンドポイントを追加しました。
既存の Server Actions（`features/user/api/`）のロジックを活用し、共通基盤（`lib/api-auth.ts` / `lib/api-response.ts`）に準拠しています。

## 変更内容

### REST APIエンドポイント

- `GET /api/v1/users` — ユーザー一覧取得（Admin権限）
- `POST /api/v1/users` — ユーザー作成（Admin権限）
- `GET /api/v1/users/:userId` — ユーザー詳細取得（自身またはAdmin）
- `PATCH /api/v1/users/:userId` — ユーザー情報更新（自身またはAdmin、ロール変更はAdminのみ）
- `DELETE /api/v1/users/:userId` — ユーザー削除（Admin権限）

### セキュリティ考慮

- パスワードはレスポンスに含めない（`select`で明示的に除外）
- パスワード変更はAPIから操作不可
- ロール変更はAdminのみ、かつ自分自身のロール変更は禁止
- 自己削除は禁止

### テスト

- `app/api/v1/__tests__/users-api.test.ts`: 全エンドポイントの正常系・異常系・権限チェック（27件）

## 関連Issue

Closes #139

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **New Features**
  * 管理者向けユーザー管理APIを追加：一覧取得、作成（パスワードハッシュ化）、詳細取得、更新、削除を実装。
  * 認証・認可を強化：管理者限定操作、自己に対する権限制約（自身の役割変更や自己削除の制限）や適切なHTTPエラー対応を導入。
* **Tests**
  * 全エンドポイントと主要な検証項目（認可、バリデーション、重複、存在確認など）を網羅する包括的なテストスイートを追加。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->