### PR TITLE
REST API: グループ管理エンドポイントの実装

### DIFF
--- a/app/api/v1/__tests__/groups-api.test.ts
+++ b/app/api/v1/__tests__/groups-api.test.ts
@@ -1,0 +1,522 @@
+import { NextRequest } from 'next/server';
+import { GET as getGroups, POST as createGroup } from '../groups/route';
+import {
+  GET as getGroupById,
+  PATCH as updateGroup,
+  DELETE as deleteGroup,
+} from '../groups/[groupId]/route';
+import {
+  GET as getMembers,
+  POST as addMembers,
+} from '../groups/[groupId]/members/route';
+import { DELETE as removeMember } from '../groups/[groupId]/members/[userId]/route';
+import { prisma } from '@/lib/prisma';
+import { authenticateApiKey } from '@/lib/api-auth';
+
+// API認証をモック化
+jest.mock('@/lib/api-auth', () => ({
+  authenticateApiKey: jest.fn(),
+}));
+
+// Prismaクライアントをモック化
+jest.mock('@/lib/prisma', () => ({
+  prisma: {
+    group: {
+      findMany: jest.fn(),
+      findUnique: jest.fn(),
+      count: jest.fn(),
+      create: jest.fn(),
+      update: jest.fn(),
+      delete: jest.fn(),
+    },
+    groupMember: {
+      findMany: jest.fn(),
+      findUnique: jest.fn(),
+      create: jest.fn(),
+      delete: jest.fn(),
+      deleteMany: jest.fn(),
+    },
+    $transaction: jest.fn(),
+  },
+}));
+
+const mockAdminUser = {
+  id: 'admin-1',
+  email: 'admin@example.com',
+  name: 'Admin User',
+  role: 'ADMIN' as const,
+};
+
+const mockMemberUser = {
+  id: 'member-1',
+  email: 'member@example.com',
+  name: 'Member User',
+  role: 'MEMBER' as const,
+};
+
+const mockGroup = {
+  id: 'group-1',
+  name: 'テストグループ',
+  description: 'テスト用グループ',
+  parentId: null,
+  parent: null,
+  _count: { members: 2 },
+  createdAt: new Date(),
+  updatedAt: new Date(),
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  (authenticateApiKey as jest.Mock).mockResolvedValue(mockAdminUser);
+});
+
+// ========================
+// GET /api/v1/groups
+// ========================
+describe('GET /api/v1/groups', () => {
+  function createRequest(): NextRequest {
+    return new NextRequest('http://localhost:3000/api/v1/groups', {
+      headers: { Authorization: 'Bearer mk_test' },
+    });
+  }
+
+  it('グループ一覧を返す', async () => {
+    (prisma.group.findMany as jest.Mock).mockResolvedValue([mockGroup]);
+
+    const response = await getGroups(createRequest());
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.data).toHaveLength(1);
+    expect(body.data[0].id).toBe('group-1');
+  });
+
+  it('認証失敗は401を返す', async () => {
+    const { NextResponse } = await import('next/server');
+    (authenticateApiKey as jest.Mock).mockResolvedValue(
+      NextResponse.json(
+        { error: { message: '認証失敗', code: 'UNAUTHORIZED' } },
+        { status: 401 }
+      )
+    );
+
+    const response = await getGroups(createRequest());
+    expect(response.status).toBe(401);
+  });
+});
+
+// ========================
+// POST /api/v1/groups
+// ========================
+describe('POST /api/v1/groups', () => {
+  function createRequest(body: object): NextRequest {
+    return new NextRequest('http://localhost:3000/api/v1/groups', {
+      method: 'POST',
+      headers: {
+        Authorization: 'Bearer mk_test',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(body),
+    });
+  }
+
+  it('Adminはグループを作成できる', async () => {
+    (prisma.group.findUnique as jest.Mock).mockResolvedValue(null);
+    (prisma.group.create as jest.Mock).mockResolvedValue(mockGroup);
+
+    const response = await createGroup(
+      createRequest({ name: 'テストグループ' })
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(201);
+    expect(body.data.id).toBe('group-1');
+  });
+
+  it('nameが空の場合は422を返す', async () => {
+    const response = await createGroup(createRequest({ name: '' }));
+    const body = await response.json();
+
+    expect(response.status).toBe(422);
+    expect(body.error.code).toBe('VALIDATION_ERROR');
+  });
+
+  it('Admin以外は403を返す', async () => {
+    (authenticateApiKey as jest.Mock).mockResolvedValue(mockMemberUser);
+
+    const response = await createGroup(
+      createRequest({ name: 'テストグループ' })
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(403);
+    expect(body.error.code).toBe('FORBIDDEN');
+  });
+
+  it('存在しないparentIdを指定すると404を返す', async () => {
+    (prisma.group.findUnique as jest.Mock).mockResolvedValue(null);
+
+    const response = await createGroup(
+      createRequest({ name: 'テストグループ', parentId: 'nonexistent' })
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(404);
+    expect(body.error.code).toBe('NOT_FOUND');
+  });
+});
+
+// ========================
+// GET /api/v1/groups/:groupId
+// ========================
+describe('GET /api/v1/groups/:groupId', () => {
+  const params = Promise.resolve({ groupId: 'group-1' });
+
+  function createRequest(): NextRequest {
+    return new NextRequest('http://localhost:3000/api/v1/groups/group-1', {
+      headers: { Authorization: 'Bearer mk_test' },
+    });
+  }
+
+  it('グループ詳細を返す', async () => {
+    (prisma.group.findUnique as jest.Mock).mockResolvedValue(mockGroup);
+
+    const response = await getGroupById(createRequest(), { params });
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.data.id).toBe('group-1');
+  });
+
+  it('存在しないグループは404を返す', async () => {
+    (prisma.group.findUnique as jest.Mock).mockResolvedValue(null);
+
+    const response = await getGroupById(createRequest(), { params });
+    const body = await response.json();
+
+    expect(response.status).toBe(404);
+    expect(body.error.code).toBe('NOT_FOUND');
+  });
+});
+
+// ========================
+// PATCH /api/v1/groups/:groupId
+// ========================
+describe('PATCH /api/v1/groups/:groupId', () => {
+  const params = Promise.resolve({ groupId: 'group-1' });
+
+  function createRequest(body: object): NextRequest {
+    return new NextRequest('http://localhost:3000/api/v1/groups/group-1', {
+      method: 'PATCH',
+      headers: {
+        Authorization: 'Bearer mk_test',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(body),
+    });
+  }
+
+  it('Adminはグループを更新できる', async () => {
+    (prisma.group.findUnique as jest.Mock).mockResolvedValue(mockGroup);
+    (prisma.group.update as jest.Mock).mockResolvedValue({
+      ...mockGroup,
+      name: '更新後グループ',
+    });
+
+    const response = await updateGroup(
+      createRequest({ name: '更新後グループ' }),
+      { params }
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.data.name).toBe('更新後グループ');
+  });
+
+  it('Admin以外は403を返す', async () => {
+    (authenticateApiKey as jest.Mock).mockResolvedValue(mockMemberUser);
+
+    const response = await updateGroup(
+      createRequest({ name: '更新後グループ' }),
+      { params }
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(403);
+    expect(body.error.code).toBe('FORBIDDEN');
+  });
+
+  it('自分自身を親に設定しようとすると400を返す', async () => {
+    (prisma.group.findUnique as jest.Mock).mockResolvedValue(mockGroup);
+
+    const response = await updateGroup(createRequest({ parentId: 'group-1' }), {
+      params,
+    });
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.error.code).toBe('BAD_REQUEST');
+  });
+
+  it('更新フィールドがない場合は400を返す', async () => {
+    const response = await updateGroup(createRequest({}), { params });
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.error.code).toBe('BAD_REQUEST');
+  });
+
+  it('存在しないグループは404を返す', async () => {
+    (prisma.group.findUnique as jest.Mock).mockResolvedValue(null);
+
+    const response = await updateGroup(createRequest({ name: '更新' }), {
+      params,
+    });
+    const body = await response.json();
+
+    expect(response.status).toBe(404);
+    expect(body.error.code).toBe('NOT_FOUND');
+  });
+});
+
+// ========================
+// DELETE /api/v1/groups/:groupId
+// ========================
+describe('DELETE /api/v1/groups/:groupId', () => {
+  const params = Promise.resolve({ groupId: 'group-1' });
+
+  function createRequest(): NextRequest {
+    return new NextRequest('http://localhost:3000/api/v1/groups/group-1', {
+      method: 'DELETE',
+      headers: { Authorization: 'Bearer mk_test' },
+    });
+  }
+
+  it('Adminはグループを削除できる', async () => {
+    (prisma.group.findUnique as jest.Mock).mockResolvedValue(mockGroup);
+    (prisma.group.count as jest.Mock).mockResolvedValue(0);
+    (prisma.group.delete as jest.Mock).mockResolvedValue(mockGroup);
+
+    const response = await deleteGroup(createRequest(), { params });
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.data.message).toBe('グループを削除しました');
+  });
+
+  it('子グループが存在する場合は400を返す', async () => {
+    (prisma.group.findUnique as jest.Mock).mockResolvedValue(mockGroup);
+    (prisma.group.count as jest.Mock).mockResolvedValue(2);
+
+    const response = await deleteGroup(createRequest(), { params });
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.error.code).toBe('BAD_REQUEST');
+  });
+
+  it('Admin以外は403を返す', async () => {
+    (authenticateApiKey as jest.Mock).mockResolvedValue(mockMemberUser);
+
+    const response = await deleteGroup(createRequest(), { params });
+    const body = await response.json();
+
+    expect(response.status).toBe(403);
+    expect(body.error.code).toBe('FORBIDDEN');
+  });
+
+  it('存在しないグループは404を返す', async () => {
+    (prisma.group.findUnique as jest.Mock).mockResolvedValue(null);
+
+    const response = await deleteGroup(createRequest(), { params });
+    const body = await response.json();
+
+    expect(response.status).toBe(404);
+    expect(body.error.code).toBe('NOT_FOUND');
+  });
+});
+
+// ========================
+// GET /api/v1/groups/:groupId/members
+// ========================
+describe('GET /api/v1/groups/:groupId/members', () => {
+  const params = Promise.resolve({ groupId: 'group-1' });
+
+  function createRequest(): NextRequest {
+    return new NextRequest(
+      'http://localhost:3000/api/v1/groups/group-1/members',
+      {
+        headers: { Authorization: 'Bearer mk_test' },
+      }
+    );
+  }
+
+  it('メンバー一覧を返す', async () => {
+    (prisma.group.findUnique as jest.Mock).mockResolvedValue(mockGroup);
+    (prisma.groupMember.findMany as jest.Mock).mockResolvedValue([
+      {
+        user: {
+          id: 'user-1',
+          email: 'user1@example.com',
+          name: 'User 1',
+          role: 'MEMBER',
+        },
+        createdAt: new Date(),
+      },
+    ]);
+
+    const response = await getMembers(createRequest(), { params });
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.data).toHaveLength(1);
+    expect(body.data[0].id).toBe('user-1');
+    expect(body.data[0].joinedAt).toBeDefined();
+  });
+
+  it('存在しないグループは404を返す', async () => {
+    (prisma.group.findUnique as jest.Mock).mockResolvedValue(null);
+
+    const response = await getMembers(createRequest(), { params });
+    const body = await response.json();
+
+    expect(response.status).toBe(404);
+    expect(body.error.code).toBe('NOT_FOUND');
+  });
+});
+
+// ========================
+// POST /api/v1/groups/:groupId/members
+// ========================
+describe('POST /api/v1/groups/:groupId/members', () => {
+  const params = Promise.resolve({ groupId: 'group-1' });
+
+  function createRequest(body: object): NextRequest {
+    return new NextRequest(
+      'http://localhost:3000/api/v1/groups/group-1/members',
+      {
+        method: 'POST',
+        headers: {
+          Authorization: 'Bearer mk_test',
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(body),
+      }
+    );
+  }
+
+  it('Adminはメンバーを追加できる', async () => {
+    (prisma.group.findUnique as jest.Mock).mockResolvedValue(mockGroup);
+    (prisma.groupMember.findMany as jest.Mock).mockResolvedValue([]);
+    (prisma.$transaction as jest.Mock).mockResolvedValue([]);
+
+    const response = await addMembers(
+      createRequest({ userIds: ['user-1', 'user-2'] }),
+      { params }
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(201);
+    expect(body.data.addedCount).toBe(2);
+  });
+
+  it('userIdsが空配列の場合は422を返す', async () => {
+    const response = await addMembers(createRequest({ userIds: [] }), {
+      params,
+    });
+    const body = await response.json();
+
+    expect(response.status).toBe(422);
+    expect(body.error.code).toBe('VALIDATION_ERROR');
+  });
+
+  it('全員が既にメンバーの場合は400を返す', async () => {
+    (prisma.group.findUnique as jest.Mock).mockResolvedValue(mockGroup);
+    (prisma.groupMember.findMany as jest.Mock).mockResolvedValue([
+      { userId: 'user-1' },
+    ]);
+
+    const response = await addMembers(createRequest({ userIds: ['user-1'] }), {
+      params,
+    });
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.error.code).toBe('BAD_REQUEST');
+  });
+
+  it('Admin以外は403を返す', async () => {
+    (authenticateApiKey as jest.Mock).mockResolvedValue(mockMemberUser);
+
+    const response = await addMembers(createRequest({ userIds: ['user-1'] }), {
+      params,
+    });
+    const body = await response.json();
+
+    expect(response.status).toBe(403);
+    expect(body.error.code).toBe('FORBIDDEN');
+  });
+});
+
+// ========================
+// DELETE /api/v1/groups/:groupId/members/:userId
+// ========================
+describe('DELETE /api/v1/groups/:groupId/members/:userId', () => {
+  const params = Promise.resolve({ groupId: 'group-1', userId: 'user-1' });
+
+  function createRequest(): NextRequest {
+    return new NextRequest(
+      'http://localhost:3000/api/v1/groups/group-1/members/user-1',
+      {
+        method: 'DELETE',
+        headers: { Authorization: 'Bearer mk_test' },
+      }
+    );
+  }
+
+  it('Adminはメンバーを削除できる', async () => {
+    (prisma.group.findUnique as jest.Mock).mockResolvedValue(mockGroup);
+    (prisma.groupMember.findUnique as jest.Mock).mockResolvedValue({
+      userId: 'user-1',
+      groupId: 'group-1',
+    });
+    (prisma.groupMember.delete as jest.Mock).mockResolvedValue({});
+
+    const response = await removeMember(createRequest(), { params });
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.data.message).toBe('メンバーを削除しました');
+  });
+
+  it('メンバーでないユーザーは404を返す', async () => {
+    (prisma.group.findUnique as jest.Mock).mockResolvedValue(mockGroup);
+    (prisma.groupMember.findUnique as jest.Mock).mockResolvedValue(null);
+
+    const response = await removeMember(createRequest(), { params });
+    const body = await response.json();
+
+    expect(response.status).toBe(404);
+    expect(body.error.code).toBe('NOT_FOUND');
+  });
+
+  it('Admin以外は403を返す', async () => {
+    (authenticateApiKey as jest.Mock).mockResolvedValue(mockMemberUser);
+
+    const response = await removeMember(createRequest(), { params });
+    const body = await response.json();
+
+    expect(response.status).toBe(403);
+    expect(body.error.code).toBe('FORBIDDEN');
+  });
+
+  it('存在しないグループは404を返す', async () => {
+    (prisma.group.findUnique as jest.Mock).mockResolvedValue(null);
+
+    const response = await removeMember(createRequest(), { params });
+    const body = await response.json();
+
+    expect(response.status).toBe(404);
+    expect(body.error.code).toBe('NOT_FOUND');
+  });
+});

--- a/app/api/v1/groups/[groupId]/members/[userId]/route.ts
+++ b/app/api/v1/groups/[groupId]/members/[userId]/route.ts
@@ -1,0 +1,67 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { Prisma } from '@prisma/client';
+import { prisma } from '@/lib/prisma';
+import { authenticateApiKey } from '@/lib/api-auth';
+import { apiSuccess, apiError } from '@/lib/api-response';
+import { canManageGroups } from '@/lib/permissions';
+
+type Params = { groupId: string; userId: string };
+
+/**
+ * DELETE /api/v1/groups/:groupId/members/:userId
+ * グループからメンバーを削除する
+ * 権限: Admin
+ */
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: Promise<Params> }
+) {
+  const authResult = await authenticateApiKey(request);
+  if (authResult instanceof NextResponse) return authResult;
+  const user = authResult;
+
+  // Admin権限チェック
+  if (!canManageGroups(user.role)) {
+    return apiError('この操作にはAdmin権限が必要です', 'FORBIDDEN', 403);
+  }
+
+  const { groupId, userId } = await params;
+
+  try {
+    // グループの存在チェック
+    const group = await prisma.group.findUnique({ where: { id: groupId } });
+    if (!group) {
+      return apiError('グループが見つかりません', 'NOT_FOUND', 404);
+    }
+
+    // メンバーシップの存在チェック
+    const membership = await prisma.groupMember.findUnique({
+      where: { userId_groupId: { userId, groupId } },
+    });
+    if (!membership) {
+      return apiError(
+        '指定されたユーザーはこのグループのメンバーではありません',
+        'NOT_FOUND',
+        404
+      );
+    }
+
+    await prisma.groupMember.delete({
+      where: { userId_groupId: { userId, groupId } },
+    });
+
+    return apiSuccess({ message: 'メンバーを削除しました' });
+  } catch (error) {
+    if (
+      error instanceof Prisma.PrismaClientKnownRequestError &&
+      error.code === 'P2025'
+    ) {
+      return apiError(
+        '指定されたユーザーはこのグループのメンバーではありません',
+        'NOT_FOUND',
+        404
+      );
+    }
+    return apiError('メンバーの削除に失敗しました', 'INTERNAL_ERROR', 500);
+  }
+}

--- a/app/api/v1/groups/[groupId]/members/route.ts
+++ b/app/api/v1/groups/[groupId]/members/route.ts
@@ -1,0 +1,150 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { Prisma } from '@prisma/client';
+import { prisma } from '@/lib/prisma';
+import { authenticateApiKey } from '@/lib/api-auth';
+import { apiSuccess, apiError } from '@/lib/api-response';
+import { canManageGroups } from '@/lib/permissions';
+
+type Params = { groupId: string };
+
+/**
+ * GET /api/v1/groups/:groupId/members
+ * グループのメンバー一覧を取得する
+ * 権限: 認証済み
+ */
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<Params> }
+) {
+  const authResult = await authenticateApiKey(request);
+  if (authResult instanceof NextResponse) return authResult;
+
+  const { groupId } = await params;
+
+  try {
+    // グループの存在チェック
+    const group = await prisma.group.findUnique({ where: { id: groupId } });
+    if (!group) {
+      return apiError('グループが見つかりません', 'NOT_FOUND', 404);
+    }
+
+    const members = await prisma.groupMember.findMany({
+      where: { groupId },
+      orderBy: { createdAt: 'asc' },
+      select: {
+        user: {
+          select: {
+            id: true,
+            email: true,
+            name: true,
+            role: true,
+          },
+        },
+        createdAt: true,
+      },
+    });
+
+    // { user: {...}, createdAt } をフラット化して返す
+    const result = members.map((m) => ({
+      ...m.user,
+      joinedAt: m.createdAt,
+    }));
+
+    return apiSuccess(result);
+  } catch {
+    return apiError('メンバー一覧の取得に失敗しました', 'INTERNAL_ERROR', 500);
+  }
+}
+
+/**
+ * POST /api/v1/groups/:groupId/members
+ * グループにメンバーを追加する
+ * 権限: Admin
+ */
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<Params> }
+) {
+  const authResult = await authenticateApiKey(request);
+  if (authResult instanceof NextResponse) return authResult;
+  const user = authResult;
+
+  // Admin権限チェック
+  if (!canManageGroups(user.role)) {
+    return apiError('この操作にはAdmin権限が必要です', 'FORBIDDEN', 403);
+  }
+
+  const { groupId } = await params;
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return apiError('リクエストボディが不正です', 'BAD_REQUEST', 400);
+  }
+
+  const { userIds } = body as { userIds?: unknown };
+
+  // バリデーション
+  if (
+    !Array.isArray(userIds) ||
+    userIds.length === 0 ||
+    !userIds.every((id) => typeof id === 'string')
+  ) {
+    return apiError(
+      'userIdsは1件以上の文字列配列で指定してください',
+      'VALIDATION_ERROR',
+      422
+    );
+  }
+
+  try {
+    // グループの存在チェック
+    const group = await prisma.group.findUnique({ where: { id: groupId } });
+    if (!group) {
+      return apiError('グループが見つかりません', 'NOT_FOUND', 404);
+    }
+
+    // 既存メンバーをチェックして重複をスキップ
+    const existingMembers = await prisma.groupMember.findMany({
+      where: { groupId, userId: { in: userIds as string[] } },
+      select: { userId: true },
+    });
+    const existingUserIds = new Set(existingMembers.map((m) => m.userId));
+    const newUserIds = (userIds as string[]).filter(
+      (id) => !existingUserIds.has(id)
+    );
+
+    if (newUserIds.length === 0) {
+      return apiError(
+        '指定されたユーザーは既にすべてメンバーです',
+        'BAD_REQUEST',
+        400
+      );
+    }
+
+    // トランザクションで一括追加
+    await prisma.$transaction(
+      newUserIds.map((userId) =>
+        prisma.groupMember.create({ data: { userId, groupId } })
+      )
+    );
+
+    return apiSuccess(
+      {
+        addedCount: newUserIds.length,
+        skippedCount: existingUserIds.size,
+      },
+      201
+    );
+  } catch (error) {
+    if (
+      error instanceof Prisma.PrismaClientKnownRequestError &&
+      error.code === 'P2003'
+    ) {
+      // 外部キー制約違反: 存在しないuserId
+      return apiError('指定されたユーザーが存在しません', 'BAD_REQUEST', 400);
+    }
+    return apiError('メンバーの追加に失敗しました', 'INTERNAL_ERROR', 500);
+  }
+}

--- a/app/api/v1/groups/[groupId]/members/route.ts
+++ b/app/api/v1/groups/[groupId]/members/route.ts
@@ -98,6 +98,9 @@ export async function POST(
     );
   }
 
+  // 入力内の重複を排除
+  const uniqueUserIds = [...new Set(userIds as string[])];
+
   try {
     // グループの存在チェック
     const group = await prisma.group.findUnique({ where: { id: groupId } });
@@ -107,13 +110,11 @@ export async function POST(
 
     // 既存メンバーをチェックして重複をスキップ
     const existingMembers = await prisma.groupMember.findMany({
-      where: { groupId, userId: { in: userIds as string[] } },
+      where: { groupId, userId: { in: uniqueUserIds } },
       select: { userId: true },
     });
     const existingUserIds = new Set(existingMembers.map((m) => m.userId));
-    const newUserIds = (userIds as string[]).filter(
-      (id) => !existingUserIds.has(id)
-    );
+    const newUserIds = uniqueUserIds.filter((id) => !existingUserIds.has(id));
 
     if (newUserIds.length === 0) {
       return apiError(
@@ -138,12 +139,19 @@ export async function POST(
       201
     );
   } catch (error) {
-    if (
-      error instanceof Prisma.PrismaClientKnownRequestError &&
-      error.code === 'P2003'
-    ) {
-      // 外部キー制約違反: 存在しないuserId
-      return apiError('指定されたユーザーが存在しません', 'BAD_REQUEST', 400);
+    if (error instanceof Prisma.PrismaClientKnownRequestError) {
+      // P2003: 外部キー制約違反（存在しないuserIdが含まれている場合）
+      if (error.code === 'P2003') {
+        return apiError('指定されたユーザーが存在しません', 'BAD_REQUEST', 400);
+      }
+      // P2002: 一意制約違反（入力重複排除後も念のため）
+      if (error.code === 'P2002') {
+        return apiError(
+          '指定されたユーザーは既にメンバーです',
+          'BAD_REQUEST',
+          400
+        );
+      }
     }
     return apiError('メンバーの追加に失敗しました', 'INTERNAL_ERROR', 500);
   }

--- a/app/api/v1/groups/[groupId]/route.ts
+++ b/app/api/v1/groups/[groupId]/route.ts
@@ -1,0 +1,281 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { Prisma } from '@prisma/client';
+import { prisma } from '@/lib/prisma';
+import { authenticateApiKey } from '@/lib/api-auth';
+import { apiSuccess, apiError } from '@/lib/api-response';
+import { canManageGroups } from '@/lib/permissions';
+
+type Params = { groupId: string };
+
+/**
+ * グループ取得時の共通select
+ */
+const groupSelect = {
+  id: true,
+  name: true,
+  description: true,
+  parentId: true,
+  parent: {
+    select: { id: true, name: true },
+  },
+  _count: {
+    select: { members: true },
+  },
+  createdAt: true,
+  updatedAt: true,
+} as const;
+
+/**
+ * 循環参照をチェックするヘルパー関数
+ */
+async function checkCircularReference(
+  groupId: string,
+  newParentId: string
+): Promise<boolean> {
+  const visited = new Set<string>();
+  let currentId = newParentId;
+
+  while (currentId) {
+    if (visited.has(currentId)) return true;
+    if (currentId === groupId) return true;
+
+    visited.add(currentId);
+
+    const parent = await prisma.group.findUnique({
+      where: { id: currentId },
+      select: { parentId: true },
+    });
+
+    if (!parent || !parent.parentId) return false;
+    currentId = parent.parentId;
+  }
+
+  return false;
+}
+
+/**
+ * GET /api/v1/groups/:groupId
+ * グループ詳細を取得する
+ * 権限: 認証済み
+ */
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<Params> }
+) {
+  const authResult = await authenticateApiKey(request);
+  if (authResult instanceof NextResponse) return authResult;
+
+  const { groupId } = await params;
+
+  try {
+    const group = await prisma.group.findUnique({
+      where: { id: groupId },
+      select: groupSelect,
+    });
+
+    if (!group) {
+      return apiError('グループが見つかりません', 'NOT_FOUND', 404);
+    }
+
+    return apiSuccess(group);
+  } catch {
+    return apiError('グループの取得に失敗しました', 'INTERNAL_ERROR', 500);
+  }
+}
+
+/**
+ * PATCH /api/v1/groups/:groupId
+ * グループ情報を部分更新する
+ * 権限: Admin
+ */
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<Params> }
+) {
+  const authResult = await authenticateApiKey(request);
+  if (authResult instanceof NextResponse) return authResult;
+  const user = authResult;
+
+  // Admin権限チェック
+  if (!canManageGroups(user.role)) {
+    return apiError('この操作にはAdmin権限が必要です', 'FORBIDDEN', 403);
+  }
+
+  const { groupId } = await params;
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return apiError('リクエストボディが不正です', 'BAD_REQUEST', 400);
+  }
+
+  const { name, description, parentId } = body as {
+    name?: unknown;
+    description?: unknown;
+    parentId?: unknown;
+  };
+
+  // バリデーション
+  if (name !== undefined) {
+    if (typeof name !== 'string' || name.trim() === '') {
+      return apiError('nameは空にできません', 'VALIDATION_ERROR', 422);
+    }
+  }
+  if (
+    description !== undefined &&
+    description !== null &&
+    typeof description !== 'string'
+  ) {
+    return apiError(
+      'descriptionは文字列で入力してください',
+      'VALIDATION_ERROR',
+      422
+    );
+  }
+  if (
+    parentId !== undefined &&
+    parentId !== null &&
+    typeof parentId !== 'string'
+  ) {
+    return apiError(
+      'parentIdは文字列で入力してください',
+      'VALIDATION_ERROR',
+      422
+    );
+  }
+
+  // 更新フィールドが何もない場合
+  if (
+    name === undefined &&
+    description === undefined &&
+    parentId === undefined
+  ) {
+    return apiError('更新するフィールドがありません', 'BAD_REQUEST', 400);
+  }
+
+  try {
+    // グループの存在チェック
+    const targetGroup = await prisma.group.findUnique({
+      where: { id: groupId },
+    });
+    if (!targetGroup) {
+      return apiError('グループが見つかりません', 'NOT_FOUND', 404);
+    }
+
+    // parentId指定時のバリデーション
+    if (parentId) {
+      // 自分自身を親にしようとしている場合はエラー
+      if (parentId === groupId) {
+        return apiError(
+          '自分自身を親グループとして設定することはできません',
+          'BAD_REQUEST',
+          400
+        );
+      }
+
+      // 親グループの存在チェック
+      const parentGroup = await prisma.group.findUnique({
+        where: { id: parentId as string },
+      });
+      if (!parentGroup) {
+        return apiError('親グループが見つかりません', 'NOT_FOUND', 404);
+      }
+
+      // 循環参照チェック
+      const hasCircularRef = await checkCircularReference(
+        groupId,
+        parentId as string
+      );
+      if (hasCircularRef) {
+        return apiError(
+          '子グループを親として設定することはできません',
+          'BAD_REQUEST',
+          400
+        );
+      }
+    }
+
+    const updatedGroup = await prisma.group.update({
+      where: { id: groupId },
+      data: {
+        ...(name !== undefined && { name: (name as string).trim() }),
+        ...(description !== undefined && {
+          description:
+            description === null
+              ? null
+              : (description as string).trim() || null,
+        }),
+        ...(parentId !== undefined && {
+          parentId: parentId === null ? null : (parentId as string),
+        }),
+      },
+      select: groupSelect,
+    });
+
+    return apiSuccess(updatedGroup);
+  } catch (error) {
+    if (
+      error instanceof Prisma.PrismaClientKnownRequestError &&
+      error.code === 'P2025'
+    ) {
+      return apiError('グループが見つかりません', 'NOT_FOUND', 404);
+    }
+    return apiError('グループの更新に失敗しました', 'INTERNAL_ERROR', 500);
+  }
+}
+
+/**
+ * DELETE /api/v1/groups/:groupId
+ * グループを削除する
+ * 権限: Admin
+ */
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: Promise<Params> }
+) {
+  const authResult = await authenticateApiKey(request);
+  if (authResult instanceof NextResponse) return authResult;
+  const user = authResult;
+
+  // Admin権限チェック
+  if (!canManageGroups(user.role)) {
+    return apiError('この操作にはAdmin権限が必要です', 'FORBIDDEN', 403);
+  }
+
+  const { groupId } = await params;
+
+  try {
+    // グループの存在チェック
+    const targetGroup = await prisma.group.findUnique({
+      where: { id: groupId },
+    });
+    if (!targetGroup) {
+      return apiError('グループが見つかりません', 'NOT_FOUND', 404);
+    }
+
+    // 子グループが存在する場合は削除不可
+    const childCount = await prisma.group.count({
+      where: { parentId: groupId },
+    });
+    if (childCount > 0) {
+      return apiError(
+        '子グループが存在するため削除できません',
+        'BAD_REQUEST',
+        400
+      );
+    }
+
+    await prisma.group.delete({ where: { id: groupId } });
+
+    return apiSuccess({ message: 'グループを削除しました' });
+  } catch (error) {
+    if (
+      error instanceof Prisma.PrismaClientKnownRequestError &&
+      error.code === 'P2025'
+    ) {
+      return apiError('グループが見つかりません', 'NOT_FOUND', 404);
+    }
+    return apiError('グループの削除に失敗しました', 'INTERNAL_ERROR', 500);
+  }
+}

--- a/app/api/v1/groups/[groupId]/route.ts
+++ b/app/api/v1/groups/[groupId]/route.ts
@@ -154,6 +154,14 @@ export async function PATCH(
     return apiError('更新するフィールドがありません', 'BAD_REQUEST', 400);
   }
 
+  // 空文字列のparentIdはnullとして扱う
+  const normalizedParentId =
+    parentId === undefined
+      ? undefined
+      : typeof parentId === 'string'
+        ? parentId.trim() || null
+        : null;
+
   try {
     // グループの存在チェック
     const targetGroup = await prisma.group.findUnique({
@@ -164,9 +172,9 @@ export async function PATCH(
     }
 
     // parentId指定時のバリデーション
-    if (parentId) {
+    if (normalizedParentId) {
       // 自分自身を親にしようとしている場合はエラー
-      if (parentId === groupId) {
+      if (normalizedParentId === groupId) {
         return apiError(
           '自分自身を親グループとして設定することはできません',
           'BAD_REQUEST',
@@ -176,7 +184,7 @@ export async function PATCH(
 
       // 親グループの存在チェック
       const parentGroup = await prisma.group.findUnique({
-        where: { id: parentId as string },
+        where: { id: normalizedParentId },
       });
       if (!parentGroup) {
         return apiError('親グループが見つかりません', 'NOT_FOUND', 404);
@@ -185,7 +193,7 @@ export async function PATCH(
       // 循環参照チェック
       const hasCircularRef = await checkCircularReference(
         groupId,
-        parentId as string
+        normalizedParentId
       );
       if (hasCircularRef) {
         return apiError(
@@ -207,7 +215,7 @@ export async function PATCH(
               : (description as string).trim() || null,
         }),
         ...(parentId !== undefined && {
-          parentId: parentId === null ? null : (parentId as string),
+          parentId: normalizedParentId,
         }),
       },
       select: groupSelect,

--- a/app/api/v1/groups/route.ts
+++ b/app/api/v1/groups/route.ts
@@ -93,11 +93,15 @@ export async function POST(request: NextRequest) {
     );
   }
 
+  // 空文字列のparentIdはnullとして扱う
+  const normalizedParentId =
+    typeof parentId === 'string' ? parentId.trim() || null : (parentId ?? null);
+
   try {
     // parentIdが指定された場合は存在チェック
-    if (parentId) {
+    if (normalizedParentId) {
       const parentGroup = await prisma.group.findUnique({
-        where: { id: parentId as string },
+        where: { id: normalizedParentId },
       });
       if (!parentGroup) {
         return apiError('親グループが見つかりません', 'NOT_FOUND', 404);
@@ -109,7 +113,7 @@ export async function POST(request: NextRequest) {
         name: name.trim(),
         description:
           typeof description === 'string' ? description.trim() || null : null,
-        parentId: (parentId as string) || null,
+        parentId: normalizedParentId,
       },
       select: groupSelect,
     });

--- a/app/api/v1/groups/route.ts
+++ b/app/api/v1/groups/route.ts
@@ -1,0 +1,127 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { Prisma } from '@prisma/client';
+import { prisma } from '@/lib/prisma';
+import { authenticateApiKey } from '@/lib/api-auth';
+import { apiSuccess, apiError } from '@/lib/api-response';
+import { canManageGroups } from '@/lib/permissions';
+
+/** グループ取得時の共通select */
+const groupSelect = {
+  id: true,
+  name: true,
+  description: true,
+  parentId: true,
+  parent: {
+    select: { id: true, name: true },
+  },
+  _count: {
+    select: { members: true },
+  },
+  createdAt: true,
+  updatedAt: true,
+} as const;
+
+/**
+ * GET /api/v1/groups
+ * グループ一覧を取得する
+ * 権限: 認証済み
+ */
+export async function GET(request: NextRequest) {
+  const authResult = await authenticateApiKey(request);
+  if (authResult instanceof NextResponse) return authResult;
+
+  try {
+    const groups = await prisma.group.findMany({
+      orderBy: { createdAt: 'desc' },
+      select: groupSelect,
+    });
+
+    return apiSuccess(groups);
+  } catch {
+    return apiError('グループ一覧の取得に失敗しました', 'INTERNAL_ERROR', 500);
+  }
+}
+
+/**
+ * POST /api/v1/groups
+ * グループを作成する
+ * 権限: Admin
+ */
+export async function POST(request: NextRequest) {
+  const authResult = await authenticateApiKey(request);
+  if (authResult instanceof NextResponse) return authResult;
+  const user = authResult;
+
+  // Admin権限チェック
+  if (!canManageGroups(user.role)) {
+    return apiError('この操作にはAdmin権限が必要です', 'FORBIDDEN', 403);
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return apiError('リクエストボディが不正です', 'BAD_REQUEST', 400);
+  }
+
+  const { name, description, parentId } = body as {
+    name?: unknown;
+    description?: unknown;
+    parentId?: unknown;
+  };
+
+  // バリデーション
+  if (!name || typeof name !== 'string' || name.trim() === '') {
+    return apiError('nameは必須です', 'VALIDATION_ERROR', 422);
+  }
+  if (description !== undefined && typeof description !== 'string') {
+    return apiError(
+      'descriptionは文字列で入力してください',
+      'VALIDATION_ERROR',
+      422
+    );
+  }
+  if (
+    parentId !== undefined &&
+    parentId !== null &&
+    typeof parentId !== 'string'
+  ) {
+    return apiError(
+      'parentIdは文字列で入力してください',
+      'VALIDATION_ERROR',
+      422
+    );
+  }
+
+  try {
+    // parentIdが指定された場合は存在チェック
+    if (parentId) {
+      const parentGroup = await prisma.group.findUnique({
+        where: { id: parentId as string },
+      });
+      if (!parentGroup) {
+        return apiError('親グループが見つかりません', 'NOT_FOUND', 404);
+      }
+    }
+
+    const newGroup = await prisma.group.create({
+      data: {
+        name: name.trim(),
+        description:
+          typeof description === 'string' ? description.trim() || null : null,
+        parentId: (parentId as string) || null,
+      },
+      select: groupSelect,
+    });
+
+    return apiSuccess(newGroup, 201);
+  } catch (error) {
+    if (
+      error instanceof Prisma.PrismaClientKnownRequestError &&
+      error.code === 'P2002'
+    ) {
+      return apiError('同名のグループが既に存在します', 'BAD_REQUEST', 400);
+    }
+    return apiError('グループの作成に失敗しました', 'INTERNAL_ERROR', 500);
+  }
+}


### PR DESCRIPTION
## 概要

グループの参照・管理およびメンバー操作を行えるREST APIエンドポイントを追加しました。
既存の Server Actions（`features/group/api/`）のロジックを活用し、共通基盤（`lib/api-auth.ts` / `lib/api-response.ts`）に準拠しています。

## 変更内容

### REST APIエンドポイント

**グループ**
- `GET /api/v1/groups` — グループ一覧取得（認証済み）
- `POST /api/v1/groups` — グループ作成（Admin）
- `GET /api/v1/groups/:groupId` — グループ詳細取得（認証済み）
- `PATCH /api/v1/groups/:groupId` — グループ更新（Admin）
- `DELETE /api/v1/groups/:groupId` — グループ削除（Admin）

**メンバー管理**
- `GET /api/v1/groups/:groupId/members` — メンバー一覧取得（認証済み）
- `POST /api/v1/groups/:groupId/members` — メンバー追加（Admin）
- `DELETE /api/v1/groups/:groupId/members/:userId` — メンバー削除（Admin）

### 実装上のポイント

- PATCH時に循環参照チェック・自己参照チェックを実装
- DELETE時に子グループ存在チェックを実装
- メンバー追加時は重複ユーザーをスキップし、追加件数・スキップ件数をレスポンスに含める
- P2002（一意制約違反）・P2003（外部キー制約違反）・P2025（レコード不存在）を個別ハンドリング

### テスト

- `app/api/v1/__tests__/groups-api.test.ts`: 全エンドポイントの正常系・異常系・権限チェック（27件）

## 関連Issue

Closes #140

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **新機能**
  * グループ管理API（作成、取得、更新、削除）を実装しました
  * グループメンバー管理機能（追加、削除、一覧表示、個別メンバー削除）を追加しました
  * 管理者権限の確認と循環参照チェック機能を導入しました
  * 入力検証と明確なエラー応答（存在確認、権限、バリデーション）を強化しました

* **テスト**
  * グループAPI全体の包括的なテストスイートを追加しました
<!-- end of auto-generated comment: release notes by coderabbit.ai -->