### PR TITLE
REST API: レコード一覧のフィルタ機能を追加

### DIFF
--- a/app/api/v1/__tests__/records-api.test.ts
+++ b/app/api/v1/__tests__/records-api.test.ts
@@ -114,6 +114,122 @@ describe('GET /api/v1/items/[itemId]/records', () => {
 
     expect(response.status).toBe(404);
   });
+
+  // ── フィルタ関連 ────────────────────────────────────────────────────
+
+  it('filter=col1:eq:hello でeq条件のwhere句が生成される', async () => {
+    (prisma.item.findUnique as jest.Mock).mockResolvedValue({ id: 'table-1' });
+    (prisma.record.findMany as jest.Mock).mockResolvedValue([]);
+    (prisma.record.count as jest.Mock).mockResolvedValue(0);
+
+    await getRecords(createRequest('?filter=col1:eq:hello'), { params });
+
+    expect(prisma.record.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          tableId: 'table-1',
+          AND: [{ data: { path: ['$', 'col1'], equals: 'hello' } }],
+        },
+      })
+    );
+  });
+
+  it('filter=age:gt:20 で数値のgt条件が生成される', async () => {
+    (prisma.item.findUnique as jest.Mock).mockResolvedValue({ id: 'table-1' });
+    (prisma.record.findMany as jest.Mock).mockResolvedValue([]);
+    (prisma.record.count as jest.Mock).mockResolvedValue(0);
+
+    await getRecords(createRequest('?filter=age:gt:20'), { params });
+
+    expect(prisma.record.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          tableId: 'table-1',
+          AND: [{ data: { path: ['$', 'age'], gt: 20 } }],
+        },
+      })
+    );
+  });
+
+  it('filter=name:contains:%E7%94%B0 でcontains条件が生成される', async () => {
+    (prisma.item.findUnique as jest.Mock).mockResolvedValue({ id: 'table-1' });
+    (prisma.record.findMany as jest.Mock).mockResolvedValue([]);
+    (prisma.record.count as jest.Mock).mockResolvedValue(0);
+
+    await getRecords(createRequest('?filter=name:contains:%E7%94%B0'), {
+      params,
+    });
+
+    expect(prisma.record.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          AND: [{ data: { path: ['$', 'name'], string_contains: '田' } }],
+        }),
+      })
+    );
+  });
+
+  it('複数フィルタ条件をAND結合する', async () => {
+    (prisma.item.findUnique as jest.Mock).mockResolvedValue({ id: 'table-1' });
+    (prisma.record.findMany as jest.Mock).mockResolvedValue([]);
+    (prisma.record.count as jest.Mock).mockResolvedValue(0);
+
+    await getRecords(createRequest('?filter=status:eq:active,age:gte:18'), {
+      params,
+    });
+
+    expect(prisma.record.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          tableId: 'table-1',
+          AND: [
+            { data: { path: ['$', 'status'], equals: 'active' } },
+            { data: { path: ['$', 'age'], gte: 18 } },
+          ],
+        },
+      })
+    );
+  });
+
+  it('不正なフィルタ構文は422を返す', async () => {
+    (prisma.item.findUnique as jest.Mock).mockResolvedValue({ id: 'table-1' });
+
+    const response = await getRecords(
+      createRequest('?filter=invalid_no_operator'),
+      { params }
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(422);
+    expect(body.error.code).toBe('VALIDATION_ERROR');
+  });
+
+  it('未対応の演算子は422を返す', async () => {
+    (prisma.item.findUnique as jest.Mock).mockResolvedValue({ id: 'table-1' });
+
+    const response = await getRecords(
+      createRequest('?filter=col1:like:value'),
+      { params }
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(422);
+    expect(body.error.code).toBe('VALIDATION_ERROR');
+  });
+
+  it('filterパラメータなしの場合はフィルタなしで動作する', async () => {
+    (prisma.item.findUnique as jest.Mock).mockResolvedValue({ id: 'table-1' });
+    (prisma.record.findMany as jest.Mock).mockResolvedValue([]);
+    (prisma.record.count as jest.Mock).mockResolvedValue(0);
+
+    await getRecords(createRequest(), { params });
+
+    expect(prisma.record.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { tableId: 'table-1' },
+      })
+    );
+  });
 });
 
 describe('POST /api/v1/items/[itemId]/records', () => {

--- a/app/api/v1/__tests__/records-api.test.ts
+++ b/app/api/v1/__tests__/records-api.test.ts
@@ -128,7 +128,7 @@ describe('GET /api/v1/items/[itemId]/records', () => {
       expect.objectContaining({
         where: {
           tableId: 'table-1',
-          AND: [{ data: { path: ['$', 'col1'], equals: 'hello' } }],
+          AND: [{ data: { path: ['col1'], equals: 'hello' } }],
         },
       })
     );
@@ -145,7 +145,7 @@ describe('GET /api/v1/items/[itemId]/records', () => {
       expect.objectContaining({
         where: {
           tableId: 'table-1',
-          AND: [{ data: { path: ['$', 'age'], gt: 20 } }],
+          AND: [{ data: { path: ['age'], gt: 20 } }],
         },
       })
     );
@@ -163,7 +163,7 @@ describe('GET /api/v1/items/[itemId]/records', () => {
     expect(prisma.record.findMany).toHaveBeenCalledWith(
       expect.objectContaining({
         where: expect.objectContaining({
-          AND: [{ data: { path: ['$', 'name'], string_contains: '田' } }],
+          AND: [{ data: { path: ['name'], string_contains: '田' } }],
         }),
       })
     );
@@ -183,8 +183,8 @@ describe('GET /api/v1/items/[itemId]/records', () => {
         where: {
           tableId: 'table-1',
           AND: [
-            { data: { path: ['$', 'status'], equals: 'active' } },
-            { data: { path: ['$', 'age'], gte: 18 } },
+            { data: { path: ['status'], equals: 'active' } },
+            { data: { path: ['age'], gte: 18 } },
           ],
         },
       })

--- a/app/api/v1/__tests__/records-api.test.ts
+++ b/app/api/v1/__tests__/records-api.test.ts
@@ -230,6 +230,58 @@ describe('GET /api/v1/items/[itemId]/records', () => {
       })
     );
   });
+
+  it('filter=status:neq:deleted でNOTラッパーのwhere句が生成される', async () => {
+    (prisma.item.findUnique as jest.Mock).mockResolvedValue({ id: 'table-1' });
+    (prisma.record.findMany as jest.Mock).mockResolvedValue([]);
+    (prisma.record.count as jest.Mock).mockResolvedValue(0);
+
+    await getRecords(createRequest('?filter=status:neq:deleted'), { params });
+
+    expect(prisma.record.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          tableId: 'table-1',
+          AND: [{ NOT: { data: { path: ['status'], equals: 'deleted' } } }],
+        },
+      })
+    );
+  });
+
+  it('filter=age:lt:30 でlt条件が生成される', async () => {
+    (prisma.item.findUnique as jest.Mock).mockResolvedValue({ id: 'table-1' });
+    (prisma.record.findMany as jest.Mock).mockResolvedValue([]);
+    (prisma.record.count as jest.Mock).mockResolvedValue(0);
+
+    await getRecords(createRequest('?filter=age:lt:30'), { params });
+
+    expect(prisma.record.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          tableId: 'table-1',
+          AND: [{ data: { path: ['age'], lt: 30 } }],
+        },
+      })
+    );
+  });
+
+  it('filter=age:lte:65 でlte条件が生成される', async () => {
+    (prisma.item.findUnique as jest.Mock).mockResolvedValue({ id: 'table-1' });
+    (prisma.record.findMany as jest.Mock).mockResolvedValue([]);
+    (prisma.record.count as jest.Mock).mockResolvedValue(0);
+
+    await getRecords(createRequest('?filter=age:lte:65'), { params });
+
+    expect(prisma.record.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          tableId: 'table-1',
+          AND: [{ data: { path: ['age'], lte: 65 } }],
+        },
+      })
+    );
+  });
+
 });
 
 describe('POST /api/v1/items/[itemId]/records', () => {

--- a/app/api/v1/__tests__/records-api.test.ts
+++ b/app/api/v1/__tests__/records-api.test.ts
@@ -281,7 +281,6 @@ describe('GET /api/v1/items/[itemId]/records', () => {
       })
     );
   });
-
 });
 
 describe('POST /api/v1/items/[itemId]/records', () => {

--- a/app/api/v1/items/[itemId]/records/route.ts
+++ b/app/api/v1/items/[itemId]/records/route.ts
@@ -3,19 +3,21 @@ import { prisma } from '@/lib/prisma';
 import { authenticateApiKey } from '@/lib/api-auth';
 import { apiSuccess, apiSuccessList, apiError } from '@/lib/api-response';
 import { canAccessItem, hasPermission } from '@/lib/permissions';
+import { parseFilter, buildPrismaFilter } from '@/lib/api-filter';
 
 const DEFAULT_LIMIT = 50;
 const MAX_LIMIT = 100;
 
 /**
  * GET /api/v1/items/[itemId]/records
- * レコード一覧を取得する（ページネーション付き）
+ * レコード一覧を取得する（ページネーション・ソート・フィルタ付き）
  *
  * クエリパラメータ:
  * - page: number (デフォルト: 1)
  * - limit: number (デフォルト: 50, 最大: 100)
  * - sort: string (カラムIDまたは createdAt, updatedAt)
  * - order: asc | desc (デフォルト: desc)
+ * - filter: string (例: "col1:eq:value,col2:gt:100")
  */
 export async function GET(
   request: NextRequest,
@@ -50,12 +52,26 @@ export async function GET(
     );
     const sort = searchParams.get('sort') || 'createdAt';
     const order = searchParams.get('order') === 'asc' ? 'asc' : 'desc';
+    const filterParam = searchParams.get('filter') || '';
+
+    // フィルタのパース
+    const filterResult = parseFilter(filterParam);
+    if (!filterResult.ok) {
+      return apiError(filterResult.error, 'VALIDATION_ERROR', 422);
+    }
 
     const skip = (page - 1) * limit;
 
+    // フィルタ条件をPrismaのwhere句に変換
+    const filterConditions = buildPrismaFilter(filterResult.conditions);
+    const where = {
+      tableId: itemId,
+      ...(filterConditions.length > 0 && { AND: filterConditions }),
+    };
+
     const [records, total] = await Promise.all([
       prisma.record.findMany({
-        where: { tableId: itemId },
+        where,
         orderBy:
           sort === 'createdAt' || sort === 'updatedAt'
             ? { [sort]: order }
@@ -63,7 +79,7 @@ export async function GET(
         skip,
         take: limit,
       }),
-      prisma.record.count({ where: { tableId: itemId } }),
+      prisma.record.count({ where }),
     ]);
 
     return apiSuccessList(records, {

--- a/lib/api-filter.ts
+++ b/lib/api-filter.ts
@@ -118,7 +118,8 @@ export function parseFilter(filterParam: string): FilterParseResult {
  */
 export function buildPrismaFilter(conditions: FilterCondition[]): object[] {
   return conditions.map(({ field, operator, value }) => {
-    const path = ['$', field];
+    // PostgreSQLでのPrisma JSON pathはキー名の配列を使う（'$'プレフィックス不要）
+    const path = [field];
 
     switch (operator) {
       case 'eq':

--- a/lib/api-filter.ts
+++ b/lib/api-filter.ts
@@ -1,0 +1,145 @@
+/**
+ * レコードAPI用フィルタパーサー
+ *
+ * 構文: `?filter=col1:eq:value,col2:gt:100`
+ * 複数条件はカンマ区切りで AND 結合
+ *
+ * 対応演算子:
+ * - eq  : 等しい
+ * - neq : 等しくない
+ * - gt  : より大きい
+ * - gte : 以上
+ * - lt  : より小さい
+ * - lte : 以下
+ * - contains : 部分一致（文字列のみ）
+ */
+
+export const FILTER_OPERATORS = [
+  'eq',
+  'neq',
+  'gt',
+  'gte',
+  'lt',
+  'lte',
+  'contains',
+] as const;
+
+export type FilterOperator = (typeof FILTER_OPERATORS)[number];
+
+export type FilterCondition = {
+  field: string;
+  operator: FilterOperator;
+  value: string | number;
+};
+
+export type FilterParseResult =
+  | { ok: true; conditions: FilterCondition[] }
+  | { ok: false; error: string };
+
+/**
+ * フィルタクエリ文字列をパースして条件配列に変換する
+ *
+ * @param filterParam - クエリパラメータの値（例: "col1:eq:hello,col2:gt:100"）
+ * @returns パース結果（ok=true なら conditions, ok=false なら error）
+ */
+export function parseFilter(filterParam: string): FilterParseResult {
+  if (!filterParam.trim()) {
+    return { ok: true, conditions: [] };
+  }
+
+  const conditions: FilterCondition[] = [];
+  const parts = filterParam.split(',');
+
+  for (const part of parts) {
+    const trimmed = part.trim();
+    if (!trimmed) continue;
+
+    // "field:operator:value" の形式を解析（valueにコロンが含まれる場合を考慮）
+    const colonIdx = trimmed.indexOf(':');
+    if (colonIdx === -1) {
+      return {
+        ok: false,
+        error: `フィルタの形式が不正です: "${trimmed}" - "field:operator:value" 形式で指定してください`,
+      };
+    }
+
+    const field = trimmed.slice(0, colonIdx);
+    const rest = trimmed.slice(colonIdx + 1);
+
+    const secondColonIdx = rest.indexOf(':');
+    if (secondColonIdx === -1) {
+      return {
+        ok: false,
+        error: `フィルタの形式が不正です: "${trimmed}" - "field:operator:value" 形式で指定してください`,
+      };
+    }
+
+    const operator = rest.slice(0, secondColonIdx);
+    const rawValue = rest.slice(secondColonIdx + 1);
+
+    // フィールド名バリデーション（英数字・アンダースコアのみ）
+    if (!/^[a-zA-Z0-9_]+$/.test(field)) {
+      return {
+        ok: false,
+        error: `フィルタのフィールド名が不正です: "${field}"`,
+      };
+    }
+
+    // 演算子バリデーション
+    if (!FILTER_OPERATORS.includes(operator as FilterOperator)) {
+      return {
+        ok: false,
+        error: `未対応の演算子です: "${operator}" - 使用可能: ${FILTER_OPERATORS.join(', ')}`,
+      };
+    }
+
+    // 値の型変換（数値文字列は数値に変換）
+    const value =
+      rawValue === ''
+        ? ''
+        : isNaN(Number(rawValue))
+          ? rawValue
+          : Number(rawValue);
+
+    conditions.push({
+      field,
+      operator: operator as FilterOperator,
+      value,
+    });
+  }
+
+  return { ok: true, conditions };
+}
+
+/**
+ * フィルタ条件をPrismaのJSON path whereクエリに変換する
+ *
+ * Recordの data フィールド（JSON型）に対して条件を適用する
+ */
+export function buildPrismaFilter(conditions: FilterCondition[]): object[] {
+  return conditions.map(({ field, operator, value }) => {
+    const path = ['$', field];
+
+    switch (operator) {
+      case 'eq':
+        return { data: { path, equals: value } };
+      case 'neq':
+        return { NOT: { data: { path, equals: value } } };
+      case 'gt':
+        return { data: { path, gt: value } };
+      case 'gte':
+        return { data: { path, gte: value } };
+      case 'lt':
+        return { data: { path, lt: value } };
+      case 'lte':
+        return { data: { path, lte: value } };
+      case 'contains':
+        return {
+          data: {
+            path,
+            string_contains: String(value),
+          },
+        };
+    }
+  });
+}

--- a/lib/api-filter.ts
+++ b/lib/api-filter.ts
@@ -93,13 +93,13 @@ export function parseFilter(filterParam: string): FilterParseResult {
       };
     }
 
-    // 値の型変換（数値文字列は数値に変換）
+    // 値の型変換: 有限の数値文字列のみ数値に変換（スペース・Infinity・16進数は文字列として扱う）
+    const trimmedValue = rawValue.trim();
+    const numericValue = Number(trimmedValue);
     const value =
-      rawValue === ''
-        ? ''
-        : isNaN(Number(rawValue))
-          ? rawValue
-          : Number(rawValue);
+      trimmedValue !== '' && Number.isFinite(numericValue)
+        ? numericValue
+        : rawValue;
 
     conditions.push({
       field,


### PR DESCRIPTION
## 概要

`GET /api/v1/items/:itemId/records` エンドポイントにフィルタ機能を追加しました。
クエリパラメータ `filter` で `data`（JSON型）フィールドに対する条件検索が可能になります。

## 変更内容

### フィルタ構文

```
?filter=field:operator:value
```

複数条件はカンマ区切りで **AND 結合**になります。

```
?filter=status:eq:active,age:gte:18
```

### 対応演算子

| 演算子 | 説明 |
|--------|------|
| `eq` | 等しい |
| `neq` | 等しくない |
| `gt` | より大きい |
| `gte` | 以上 |
| `lt` | より小さい |
| `lte` | 以下 |
| `contains` | 部分一致（文字列） |

### 実装上のポイント

- フィールド名は英数字・アンダースコアのみ許可（バリデーション付き）
- 数値文字列は自動的に数値型に変換
- Prisma の JSON `path` フィルタ（`data.path`）を使用して `jsonb` カラムを検索
- 不正な構文・未対応演算子は 422 を返す

### 対象ファイル

- `lib/api-filter.ts` — フィルタパーサー（parseFilter / buildPrismaFilter）を新規追加
- `app/api/v1/items/[itemId]/records/route.ts` — GETハンドラにフィルタを組み込み
- `app/api/v1/__tests__/records-api.test.ts` — フィルタのテスト7件を追加

## 関連Issue

Closes #141

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * API レコードフィルタリング機能を追加しました。等号、大小比較、文字列検索などの条件をサポートし、複数条件の組み合わせに対応しています。

* **Tests**
  * フィルタリング機能の包括的なテストを追加しました。正常系および不正な入力に対するエラーハンドリングをカバーしています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->